### PR TITLE
fix: configure pnpm for frozen lockfile in CI

### DIFF
--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -23,12 +23,17 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 10.7.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: pnpm
+
+      - name: Configure pnpm
+        run: pnpm config set inject-workspace-packages true
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
This pull request updates the GitHub Actions workflow to configure pnpm for a frozen lockfile during continuous integration.

## Changes
- Updated pnpm version to 10.7.0.
- Added a step to configure pnpm to inject workspace packages.

## Testing
Reviewers can validate the change by checking the CI workflow runs to ensure that pnpm installs dependencies correctly with the frozen lockfile setting.

## Risk
There is a potential risk of compatibility issues with the new pnpm version. It is advisable to monitor the CI runs for any unexpected behavior after this change.