### PR TITLE
chore: align diff summary and PR description prompts

### DIFF
--- a/packages/core/src/diff-summary.ts
+++ b/packages/core/src/diff-summary.ts
@@ -5,7 +5,10 @@ import {
   DiffSummaryOutputType,
 } from "@git-ai/contracts";
 import { AIProvider } from "@git-ai/providers";
-import { generateStructuredOutput } from "./structured-generation";
+import {
+  generateStructuredOutput,
+  normalizeNullableFields,
+} from "./structured-generation";
 
 const DIFF_SUMMARY_SYSTEM_PROMPT =
   [
@@ -45,19 +48,6 @@ function buildPrompt(input: DiffSummaryInputType): string {
   ].join("\n");
 }
 
-function normalizeDiffSummaryOutput(value: unknown): unknown {
-  if (!value || typeof value !== "object") {
-    return value;
-  }
-
-  const result = { ...(value as Record<string, unknown>) };
-  if (result.riskAreas === null) {
-    result.riskAreas = undefined;
-  }
-
-  return result;
-}
-
 export async function generateDiffSummary(
   provider: AIProvider,
   input: DiffSummaryInputType
@@ -71,6 +61,6 @@ export async function generateDiffSummary(
     prompt,
     schema: DiffSummaryOutput,
     validationErrorPrefix: "Model output failed diff summary schema validation",
-    normalizeParsedJson: normalizeDiffSummaryOutput,
+    normalizeParsedJson: (value) => normalizeNullableFields(value, ["riskAreas"]),
   });
 }

--- a/packages/core/src/pr-description.ts
+++ b/packages/core/src/pr-description.ts
@@ -5,13 +5,17 @@ import {
   PRDescriptionOutputType,
 } from "@git-ai/contracts";
 import { AIProvider } from "@git-ai/providers";
-import { generateStructuredOutput } from "./structured-generation";
+import {
+  generateStructuredOutput,
+  normalizeNullableFields,
+} from "./structured-generation";
 
 const PR_DESCRIPTION_SYSTEM_PROMPT =
   [
     "You are a senior software engineer writing a GitHub pull request description.",
     "Be concise but informative.",
     "Focus on the intent and meaningful impact of the change, not every tiny diff line.",
+    "Mention testing or risk details only when the diff supports them.",
     "Do not hallucinate or invent missing context.",
     "If uncertain, omit claims rather than guessing.",
     "Return valid JSON only.",
@@ -28,13 +32,16 @@ function buildPrompt(input: PRDescriptionInputType): string {
 
   return [
     "Generate a GitHub pull request title and body from the provided diff.",
+    "Explain the intent of the change at a high level.",
+    'The "title" should be concise and specific to the change.',
     "Use issue context only as supporting context and prefer the diff when they conflict.",
+    "If the diff does not support a claim, omit it.",
     "Return strictly valid JSON in this exact shape:",
     "{",
     '  "title": string,',
     '  "body": string,',
-    '  "testingNotes": string | null,',
-    '  "riskNotes": string | null',
+    '  "testingNotes"?: string,',
+    '  "riskNotes"?: string',
     "}",
     "",
     'The "body" must be markdown using these section headings:',
@@ -50,6 +57,9 @@ function buildPrompt(input: PRDescriptionInputType): string {
     "## Risk",
     "Potential risks, rollout notes, or migration concerns.",
     "",
+    'Omit "testingNotes" when there are no concrete validation steps supported by the diff.',
+    'Omit "riskNotes" when there are no clear risks, rollout notes, or migration concerns supported by the diff.',
+    "",
     "Do not wrap JSON in markdown fences.",
     "",
     ...(contextLines.length > 0
@@ -58,22 +68,6 @@ function buildPrompt(input: PRDescriptionInputType): string {
     "Diff:",
     input.diff,
   ].join("\n");
-}
-
-function normalizeNullableNotes(value: unknown): unknown {
-  if (!value || typeof value !== "object") {
-    return value;
-  }
-
-  const result = { ...(value as Record<string, unknown>) };
-  if (result.testingNotes === null) {
-    result.testingNotes = undefined;
-  }
-  if (result.riskNotes === null) {
-    result.riskNotes = undefined;
-  }
-
-  return result;
 }
 
 export async function generatePRDescription(
@@ -89,7 +83,8 @@ export async function generatePRDescription(
     schema: PRDescriptionOutput,
     validationErrorPrefix:
       "Model output failed PR description schema validation",
-    normalizeParsedJson: normalizeNullableNotes,
+    normalizeParsedJson: (value) =>
+      normalizeNullableFields(value, ["testingNotes", "riskNotes"]),
   });
 
   return modelOutput;

--- a/packages/core/src/structured-generation.ts
+++ b/packages/core/src/structured-generation.ts
@@ -31,6 +31,24 @@ function parseModelJson(raw: string): unknown {
   }
 }
 
+export function normalizeNullableFields(
+  value: unknown,
+  fieldNames: string[]
+): unknown {
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  const result = { ...(value as Record<string, unknown>) };
+  for (const fieldName of fieldNames) {
+    if (result[fieldName] === null) {
+      result[fieldName] = undefined;
+    }
+  }
+
+  return result;
+}
+
 export async function generateStructuredOutput<TSchema extends z.ZodTypeAny>(
   options: GenerateStructuredOutputOptions<TSchema>
 ): Promise<z.output<TSchema>> {


### PR DESCRIPTION
## Summary
This change enhances the prompts used for generating GitHub pull request descriptions and diff summaries by aligning the wording and structure to better reflect the intended use and consistency in handling optional fields.

## Changes
- Updated the PR description prompt to clarify the intent and structure of the output.
- Introduced a shared `normalizeNullableFields` function to handle nullable fields consistently across both PR descriptions and diff summaries.
- Removed redundant normalization logic from both `generateDiffSummary` and `generatePRDescription` functions.

## Testing
- Run `pnpm build` to ensure that the changes compile correctly and do not introduce any errors.

## Risk
- Minimal risk as the changes primarily involve prompt adjustments and normalization logic, which should not affect existing functionality.