### PR TITLE
Fix: Add GitHub Action mode for issue-to-PR workflow

### DIFF
--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -1,0 +1,179 @@
+name: Issue to PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: GitHub issue number to address
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: issue-to-pr-${{ inputs.issue_number }}
+  cancel-in-progress: false
+
+jobs:
+  issue-to-pr:
+    runs-on: ubuntu-latest
+    env:
+      ISSUE_NUMBER: ${{ inputs.issue_number }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.7.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        env:
+          CI: true
+
+      - name: Build CLI
+        run: pnpm --filter @git-ai/cli... build
+
+      - name: Prepare issue workspace
+        id: prepare
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node packages/cli/dist/index.js issue prepare "$ISSUE_NUMBER" --mode github-action
+
+      - name: Run Codex remotely
+        uses: openai/codex-action@v1
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          prompt-file: ${{ steps.prepare.outputs.prompt_file }}
+          sandbox: workspace-write
+          safety-strategy: drop-sudo
+
+      - name: Build workspace
+        run: pnpm build
+
+      - name: Configure git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Commit generated changes
+        run: node packages/cli/dist/index.js issue finalize "$ISSUE_NUMBER"
+
+      - name: Push issue branch
+        run: git push -u origin "${{ steps.prepare.outputs.branch_name }}"
+
+      - name: Create or reuse pull request
+        id: pr
+        uses: actions/github-script@v7
+        env:
+          BRANCH_NAME: ${{ steps.prepare.outputs.branch_name }}
+          ISSUE_NUMBER: ${{ steps.prepare.outputs.issue_number }}
+          ISSUE_TITLE: ${{ steps.prepare.outputs.issue_title }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const title = `Fix: ${process.env.ISSUE_TITLE}`;
+            const body = `Closes #${process.env.ISSUE_NUMBER}`;
+            const head = `${context.repo.owner}:${process.env.BRANCH_NAME}`;
+            const { owner, repo } = context.repo;
+
+            const existing = await github.paginate(
+              github.rest.pulls.list,
+              {
+                owner,
+                repo,
+                state: "open",
+                head,
+                base: "main",
+                per_page: 100,
+              }
+            );
+
+            let pullRequest = existing[0];
+
+            if (pullRequest) {
+              pullRequest = (
+                await github.rest.pulls.update({
+                  owner,
+                  repo,
+                  pull_number: pullRequest.number,
+                  title,
+                  body,
+                  base: "main",
+                })
+              ).data;
+            } else {
+              pullRequest = (
+                await github.rest.pulls.create({
+                  owner,
+                  repo,
+                  title,
+                  body,
+                  head: process.env.BRANCH_NAME,
+                  base: "main",
+                })
+              ).data;
+            }
+
+            core.setOutput("pr_number", String(pullRequest.number));
+            core.setOutput("pr_url", pullRequest.html_url);
+
+      - name: Comment on issue with PR link
+        uses: actions/github-script@v7
+        env:
+          ISSUE_NUMBER: ${{ steps.prepare.outputs.issue_number }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          PR_URL: ${{ steps.pr.outputs.pr_url }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const marker = "<!-- git-ai-issue-to-pr -->";
+            const body = `${marker}\nCreated PR #${process.env.PR_NUMBER}: ${process.env.PR_URL}`;
+            const { owner, repo } = context.repo;
+            const issue_number = Number(process.env.ISSUE_NUMBER);
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner,
+                repo,
+                issue_number,
+                per_page: 100,
+              }
+            );
+
+            const existingComment = comments.find((comment) => {
+              const commentBody = comment.body ?? "";
+              return commentBody.includes(marker) && comment.user?.type === "Bot";
+            });
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existingComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }

--- a/README.md
+++ b/README.md
@@ -50,3 +50,23 @@ and authenticated, push the branch and open a pull request automatically.
 
 `.git-ai/` is local working state for issue snapshots and run artifacts. It is
 intentionally gitignored and should not be committed.
+
+## GitHub Actions issue flow
+
+This repository also includes a manual `Issue to PR` workflow under
+`.github/workflows/issue-to-pr.yml`.
+
+Trigger it with `workflow_dispatch`, provide an issue number, and the workflow
+will:
+
+- fetch the GitHub issue details
+- create the issue branch and Codex prompt workspace
+- run Codex remotely in GitHub Actions
+- build the repository with `pnpm build`
+- commit and push the generated changes
+- create or reuse a PR targeting `main`
+- comment on the issue with the PR link
+
+Required secrets:
+
+- `OPENAI_API_KEY`

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -26,7 +26,28 @@ type IssueWorkspace = {
   outputLogPath: string;
 };
 
-const ISSUE_USAGE = 'Usage: git-ai issue <number>';
+type IssueExecutionMode = "local" | "github-action";
+
+type IssueCommandOptions = {
+  action: "run" | "prepare" | "finalize";
+  issueNumber: number;
+  mode: IssueExecutionMode;
+};
+
+type IssueRunContext = {
+  issueNumber: number;
+  issue: IssueDetails;
+  branchName: string;
+  workspace: IssueWorkspace;
+  mode: IssueExecutionMode;
+};
+
+const ISSUE_USAGE = [
+  "Usage:",
+  "  git-ai issue <number>",
+  "  git-ai issue prepare <number> [--mode <local|github-action>]",
+  "  git-ai issue finalize <number>",
+].join("\n");
 
 function getCliArgs(): string[] {
   return process.argv.slice(2).filter((arg) => arg !== "--");
@@ -199,6 +220,70 @@ function parseIssueNumber(rawValue: string | undefined): number {
   }
 
   return issueNumber;
+}
+
+function parseIssueMode(rawArgs: string[]): IssueExecutionMode {
+  if (rawArgs.length === 0) {
+    return "local";
+  }
+
+  let mode: string | undefined;
+
+  for (let index = 0; index < rawArgs.length; index += 1) {
+    const rawArg = rawArgs[index];
+    if (rawArg === "--mode") {
+      mode = rawArgs[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (rawArg.startsWith("--mode=")) {
+      mode = rawArg.slice("--mode=".length);
+      continue;
+    }
+
+    throw new Error(`Unknown issue option "${rawArg}". ${ISSUE_USAGE}`);
+  }
+
+  if (mode !== "local" && mode !== "github-action") {
+    throw new Error(
+      `Invalid issue mode "${mode ?? ""}". Expected "local" or "github-action".`
+    );
+  }
+
+  return mode;
+}
+
+function parseIssueCommandArgs(args: string[]): IssueCommandOptions {
+  const issueArgs = args.slice(1);
+  const subcommand = issueArgs[0];
+
+  if (subcommand === "prepare") {
+    return {
+      action: "prepare",
+      issueNumber: parseIssueNumber(issueArgs[1]),
+      mode: parseIssueMode(issueArgs.slice(2)),
+    };
+  }
+
+  if (subcommand === "finalize") {
+    const optionArgs = issueArgs.slice(2);
+    if (optionArgs.length > 0) {
+      throw new Error(`Unknown issue option "${optionArgs[0]}". ${ISSUE_USAGE}`);
+    }
+
+    return {
+      action: "finalize",
+      issueNumber: parseIssueNumber(issueArgs[1]),
+      mode: "local",
+    };
+  }
+
+  return {
+    action: "run",
+    issueNumber: parseIssueNumber(issueArgs[0]),
+    mode: parseIssueMode(issueArgs.slice(1)),
+  };
 }
 
 function parseGitHubRepoFromRemote(): { owner: string; repo: string } {
@@ -402,15 +487,26 @@ function ensureBranchDoesNotExist(branchName: string): void {
   }
 }
 
-function buildCodexPrompt(workspace: IssueWorkspace): string {
+function buildCodexPrompt(
+  workspace: IssueWorkspace,
+  mode: IssueExecutionMode
+): string {
   const issueFile = toRepoRelativePath(workspace.issueFilePath);
   const runDir = toRepoRelativePath(workspace.runDir);
+  const modeSpecificInstructions =
+    mode === "github-action"
+      ? [
+          "You are running inside a GitHub Actions workflow via Codex.",
+          "Do not wait for interactive user input.",
+        ]
+      : [];
 
   return [
     "You are working in the git-ai repository.",
+    ...modeSpecificInstructions,
     "",
     `Read the issue snapshot at \`${issueFile}\` before making changes.`,
-    `Use \`${runDir}\` for local run artifacts created by this workflow.`,
+    `Use \`${runDir}\` for run artifacts created by this workflow.`,
     "",
     "Instructions to Codex:",
     "- analyze the repository only as needed for this issue",
@@ -426,10 +522,11 @@ function writeIssueWorkspaceFiles(
   issueNumber: number,
   issue: IssueDetails,
   branchName: string,
-  workspace: IssueWorkspace
+  workspace: IssueWorkspace,
+  mode: IssueExecutionMode
 ): void {
   const createdAt = new Date().toISOString();
-  const prompt = buildCodexPrompt(workspace);
+  const prompt = buildCodexPrompt(workspace, mode);
 
   writeFileSync(
     workspace.issueFilePath,
@@ -442,6 +539,7 @@ function writeIssueWorkspaceFiles(
     `${JSON.stringify(
       {
         createdAt,
+        mode,
         issueNumber,
         issueTitle: issue.title,
         issueUrl: issue.url,
@@ -468,6 +566,39 @@ function writeIssueWorkspaceFiles(
     ].join("\n"),
     "utf8"
   );
+}
+
+function writeGitHubOutput(name: string, value: string): void {
+  const outputPath = process.env.GITHUB_OUTPUT?.trim();
+  if (!outputPath) {
+    return;
+  }
+
+  const delimiter = `git_ai_${name}_${Date.now()}`;
+  appendFileSync(
+    outputPath,
+    `${name}<<${delimiter}\n${value}\n${delimiter}\n`,
+    "utf8"
+  );
+}
+
+function emitIssuePrepareOutputs(context: IssueRunContext): void {
+  writeGitHubOutput("issue_number", String(context.issueNumber));
+  writeGitHubOutput("issue_title", context.issue.title);
+  writeGitHubOutput("issue_url", context.issue.url);
+  writeGitHubOutput("branch_name", context.branchName);
+  writeGitHubOutput("issue_file", toRepoRelativePath(context.workspace.issueFilePath));
+  writeGitHubOutput(
+    "prompt_file",
+    toRepoRelativePath(context.workspace.promptFilePath)
+  );
+  writeGitHubOutput(
+    "metadata_file",
+    toRepoRelativePath(context.workspace.metadataFilePath)
+  );
+  writeGitHubOutput("output_log", toRepoRelativePath(context.workspace.outputLogPath));
+  writeGitHubOutput("run_dir", toRepoRelativePath(context.workspace.runDir));
+  writeGitHubOutput("mode", context.mode);
 }
 
 function appendRunLog(
@@ -680,9 +811,10 @@ function createProvider(): OpenAIProvider {
   });
 }
 
-async function runIssueCommand(): Promise<void> {
-  const args = getCliArgs();
-  const issueNumber = parseIssueNumber(args[1]);
+async function prepareIssueRun(
+  issueNumber: number,
+  mode: IssueExecutionMode
+): Promise<IssueRunContext> {
   ensureCleanWorkingTree();
   console.log(`Fetching GitHub issue #${issueNumber}...`);
   const issue = await fetchIssueDetails(issueNumber);
@@ -690,7 +822,7 @@ async function runIssueCommand(): Promise<void> {
   const branchName = createIssueBranchName(issueNumber, issue.title);
   ensureBranchDoesNotExist(branchName);
   const workspace = createIssueWorkspace(issueNumber, issue);
-  writeIssueWorkspaceFiles(issueNumber, issue, branchName, workspace);
+  writeIssueWorkspaceFiles(issueNumber, issue, branchName, workspace, mode);
 
   console.log(`Creating branch ${branchName}...`);
   runInteractiveCommand(
@@ -699,29 +831,86 @@ async function runIssueCommand(): Promise<void> {
     `Failed to create branch "${branchName}".`
   );
 
-  console.log("Opening an interactive Codex session in this terminal...");
-  console.log("Complete the issue work in Codex.");
-  console.log("When Codex exits, git-ai will resume with build and commit steps.");
-  runCodex(workspace);
+  return {
+    issueNumber,
+    issue,
+    branchName,
+    workspace,
+    mode,
+  };
+}
 
-  console.log("Verifying build...");
-  verifyBuild(workspace.outputLogPath);
-
+function finalizeIssueRun(issueNumber: number): void {
   console.log("Committing generated changes...");
   commitIssueChanges(issueNumber);
+}
 
-  if (isGhAuthenticated()) {
-    console.log("Pushing branch and opening a pull request...");
-    pushBranchAndCreatePr(
-      branchName,
-      issueNumber,
-      issue.title,
-      workspace.outputLogPath
+async function runIssueCommand(): Promise<void> {
+  const args = getCliArgs();
+  const issueCommand = parseIssueCommandArgs(args);
+
+  if (issueCommand.action === "prepare") {
+    const context = await prepareIssueRun(
+      issueCommand.issueNumber,
+      issueCommand.mode
+    );
+    emitIssuePrepareOutputs(context);
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          issueNumber: context.issueNumber,
+          issueTitle: context.issue.title,
+          issueUrl: context.issue.url,
+          branchName: context.branchName,
+          issueFile: toRepoRelativePath(context.workspace.issueFilePath),
+          promptFile: toRepoRelativePath(context.workspace.promptFilePath),
+          metadataFile: toRepoRelativePath(context.workspace.metadataFilePath),
+          outputLog: toRepoRelativePath(context.workspace.outputLogPath),
+          runDir: toRepoRelativePath(context.workspace.runDir),
+          mode: context.mode,
+        },
+        null,
+        2
+      )}\n`
     );
     return;
   }
 
-  printManualPrInstructions(branchName, issueNumber);
+  if (issueCommand.action === "finalize") {
+    finalizeIssueRun(issueCommand.issueNumber);
+    return;
+  }
+
+  if (issueCommand.mode !== "local") {
+    throw new Error(
+      'Full issue runs only support local mode. Use `git-ai issue prepare <number> --mode github-action` in workflows.'
+    );
+  }
+
+  const context = await prepareIssueRun(issueCommand.issueNumber, issueCommand.mode);
+
+  console.log("Opening an interactive Codex session in this terminal...");
+  console.log("Complete the issue work in Codex.");
+  console.log("When Codex exits, git-ai will resume with build and commit steps.");
+  runCodex(context.workspace);
+
+  console.log("Verifying build...");
+  verifyBuild(context.workspace.outputLogPath);
+
+  finalizeIssueRun(context.issueNumber);
+
+  if (isGhAuthenticated()) {
+    console.log("Pushing branch and opening a pull request...");
+    pushBranchAndCreatePr(
+      context.branchName,
+      context.issueNumber,
+      context.issue.title,
+      context.workspace.outputLogPath
+    );
+    return;
+  }
+
+  printManualPrInstructions(context.branchName, context.issueNumber);
 }
 
 async function run(): Promise<void> {


### PR DESCRIPTION
## Summary
This pull request introduces a new GitHub Actions workflow that automates the process of converting GitHub issues into pull requests. It allows users to trigger the workflow manually by providing an issue number, which then fetches the issue details, prepares a workspace, runs Codex for code generation, and creates or updates a pull request accordingly.

## Changes
- Added a new workflow file `.github/workflows/issue-to-pr.yml` that defines the steps for the issue-to-PR conversion process.
- Enhanced the CLI to support a new execution mode (`github-action`) for issue handling, allowing the workflow to operate seamlessly within GitHub Actions.
- Updated the README to document the new workflow and its usage.

## Testing
To validate the changes, trigger the `Issue to PR` workflow manually via GitHub Actions, providing a valid issue number. Ensure that the workflow completes successfully and that a pull request is created or updated as expected.

## Risk
No significant risks identified. The new workflow operates independently and should not affect existing functionalities.