### PR TITLE
Fix: Add  command to generate implementation-ready GitHub issues from feature ideas

### DIFF
--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -67,6 +67,33 @@ function createTestBacklogAnalysis() {
   };
 }
 
+function createIssueDraftResult() {
+  return {
+    title: "Merge PR description and review summary into one PR assistant action",
+    summary:
+      "Draft a single implementation path for combining the repository's PR description and review summary generation flows.",
+    motivation:
+      "The current workflow spreads related pull request authoring guidance across separate outputs, which adds friction and inconsistency.",
+    goal:
+      "Provide one shared PR assistant action that produces a cohesive, implementation-ready pull request body update.",
+    proposedBehavior: [
+      "Generate one managed PR assistant output instead of separate PR description and review summary artifacts.",
+      "Update the existing PR body in place rather than replacing unrelated user-authored sections.",
+    ],
+    requirements: [
+      "Reuse the existing PR assistant and body-merging patterns where possible.",
+      "Preserve manual pull request body content outside the managed section.",
+    ],
+    constraints: [
+      "Do not overwrite non-managed PR body content.",
+    ],
+    acceptanceCriteria: [
+      "Running the action updates a single managed PR assistant section.",
+      "Existing non-managed PR body content is preserved.",
+    ],
+  };
+}
+
 function createFetchResponse(
   payload: unknown,
   init: { ok?: boolean; status?: number; statusText?: string } = {}
@@ -94,10 +121,26 @@ function captureStdout(): { output: () => string } {
   };
 }
 
+function listIssueDraftFiles(): string[] {
+  try {
+    return readdirSync(resolve(REPO_ROOT, ".git-ai", "issues"))
+      .filter((entry) => entry.startsWith("issue-draft-") && entry.endsWith(".md"))
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
 async function loadCli(options: {
   analysisResult?: ReturnType<typeof createTestBacklogAnalysis>;
+  issueDraftResult?: ReturnType<typeof createIssueDraftResult>;
+  readlineAnswers?: string[];
   execFileSyncImpl?: (command: string, args: string[]) => string;
-  spawnSyncImpl?: (command: string, args: string[]) => { status: number; error?: Error };
+  spawnSyncImpl?: (
+    command: string,
+    args: string[],
+    rawSecondArg?: unknown
+  ) => { status: number; error?: Error; stdout?: string; stderr?: string };
 } = {}) {
   vi.resetModules();
   process.env.GIT_AI_DISABLE_AUTO_RUN = "1";
@@ -105,6 +148,10 @@ async function loadCli(options: {
   const analyzeTestBacklog = vi.fn();
   if (options.analysisResult) {
     analyzeTestBacklog.mockResolvedValue(options.analysisResult);
+  }
+  const generateIssueDraft = vi.fn();
+  if (options.issueDraftResult) {
+    generateIssueDraft.mockResolvedValue(options.issueDraftResult);
   }
 
   const execFileSync = vi.fn((command: string, args: string[]) => {
@@ -114,31 +161,44 @@ async function loadCli(options: {
 
     throw new Error(`Unexpected execFileSync call: ${command} ${args.join(" ")}`);
   });
-  const spawnSync = vi.fn((command: string, args: string[]) => {
+  const spawnSync = vi.fn((command: string, rawSecondArg?: unknown) => {
+    const args = Array.isArray(rawSecondArg) ? rawSecondArg : [];
     if (options.spawnSyncImpl) {
-      return options.spawnSyncImpl(command, args);
+      return options.spawnSyncImpl(command, args, rawSecondArg);
     }
 
     return { status: 0 };
   });
+  const readlineAnswers = [...(options.readlineAnswers ?? [])];
+  const createInterface = vi.fn(() => ({
+    question: vi.fn(async () => readlineAnswers.shift() ?? ""),
+    close: vi.fn(),
+  }));
 
   vi.doMock("@git-ai/core", () => ({
     analyzeTestBacklog,
     generateCommitMessage: vi.fn(),
     generateDiffSummary: vi.fn(),
+    generateIssueDraft,
   }));
   vi.doMock("node:child_process", () => ({
     execFileSync,
     spawnSync,
+  }));
+  vi.doMock("node:readline/promises", () => ({
+    createInterface,
   }));
 
   const module = await import("./index");
 
   return {
     run: module.run,
+    parseIssueCommandArgs: module.parseIssueCommandArgs,
     analyzeTestBacklog,
+    generateIssueDraft,
     execFileSync,
     spawnSync,
+    createInterface,
   };
 }
 
@@ -148,6 +208,7 @@ afterEach(() => {
   delete process.env.GITHUB_OUTPUT;
   delete process.env.GITHUB_TOKEN;
   delete process.env.GH_TOKEN;
+  delete process.env.OPENAI_API_KEY;
 
   for (const target of cleanupTargets) {
     rmSync(target, { recursive: true, force: true });
@@ -160,6 +221,15 @@ afterEach(() => {
 });
 
 describe("CLI integration", () => {
+  it("parses issue draft as a dedicated issue subcommand", async () => {
+    process.env.GIT_AI_DISABLE_AUTO_RUN = "1";
+    const { parseIssueCommandArgs } = await loadCli();
+
+    expect(parseIssueCommandArgs(["issue", "draft"])).toEqual({
+      action: "draft",
+    });
+  });
+
   it("parses repo-level test-backlog flags for the CLI", async () => {
     process.env.GIT_AI_DISABLE_AUTO_RUN = "1";
     const { parseTestBacklogCommandArgs } = await import("./index");
@@ -318,6 +388,96 @@ describe("CLI integration", () => {
 
     await expect(run()).rejects.toThrow(
       "Creating GitHub issues requires GH_TOKEN or GITHUB_TOKEN to be set."
+    );
+  });
+
+  it("generates a local issue draft and saves it under .git-ai/issues", async () => {
+    const beforeDrafts = listIssueDraftFiles();
+    const issueDraft = createIssueDraftResult();
+    const { run, generateIssueDraft } = await loadCli({
+      issueDraftResult: issueDraft,
+      readlineAnswers: [
+        "Combine PR description and review summary into a single PR assistant action.",
+        "Should update the PR body rather than replacing it.",
+      ],
+      spawnSyncImpl: (command, args) => {
+        if (command === "gh" && args[0] === "--version") {
+          return { status: 1, error: new Error("gh is unavailable") };
+        }
+
+        throw new Error(`Unexpected spawnSync call: ${command} ${args.join(" ")}`);
+      },
+    });
+
+    process.env.OPENAI_API_KEY = "test-key";
+    process.argv = ["node", "git-ai", "issue", "draft"];
+
+    await run();
+
+    expect(generateIssueDraft).toHaveBeenCalledWith(expect.any(Object), {
+      featureIdea: "Combine PR description and review summary into a single PR assistant action.",
+      additionalContext: "Should update the PR body rather than replacing it.",
+    });
+
+    const createdDraft = listIssueDraftFiles().find((entry) => !beforeDrafts.includes(entry));
+    expect(createdDraft).toBeDefined();
+
+    const createdDraftPath = resolve(REPO_ROOT, ".git-ai", "issues", createdDraft as string);
+    cleanupTargets.add(createdDraftPath);
+
+    const content = readFileSync(createdDraftPath, "utf8");
+    expect(content).toContain(`# ${issueDraft.title}`);
+    expect(content).toContain("## Summary");
+    expect(content).toContain("## Proposed behavior");
+    expect(content).toContain("- Do not overwrite non-managed PR body content.");
+  });
+
+  it("creates a GitHub issue from the reviewed draft only after confirmation", async () => {
+    const beforeDrafts = listIssueDraftFiles();
+    const issueDraft = createIssueDraftResult();
+    const { run, execFileSync } = await loadCli({
+      issueDraftResult: issueDraft,
+      readlineAnswers: ["Unify PR assistant outputs.", "", "y"],
+      execFileSyncImpl: (command, args) => {
+        if (command === "gh" && args[0] === "issue" && args[1] === "create") {
+          return "https://github.com/DevwareUK/git-ai/issues/99\n";
+        }
+
+        throw new Error(`Unexpected execFileSync call: ${command} ${args.join(" ")}`);
+      },
+      spawnSyncImpl: (command, args) => {
+        if (command === "gh" && args[0] === "--version") {
+          return { status: 0 };
+        }
+
+        if (command === "gh" && args[0] === "auth" && args[1] === "status") {
+          return { status: 0 };
+        }
+
+        throw new Error(`Unexpected spawnSync call: ${command} ${args.join(" ")}`);
+      },
+    });
+
+    process.env.OPENAI_API_KEY = "test-key";
+    process.argv = ["node", "git-ai", "issue", "draft"];
+
+    await run();
+
+    const createdDraft = listIssueDraftFiles().find((entry) => !beforeDrafts.includes(entry));
+    expect(createdDraft).toBeDefined();
+    cleanupTargets.add(resolve(REPO_ROOT, ".git-ai", "issues", createdDraft as string));
+
+    expect(execFileSync).toHaveBeenCalledWith(
+      "gh",
+      [
+        "issue",
+        "create",
+        "--title",
+        issueDraft.title,
+        "--body",
+        expect.stringContaining("## Summary"),
+      ],
+      expect.any(Object)
     );
   });
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,9 +1,15 @@
 #!/usr/bin/env node
 
 import { execFileSync, spawnSync } from "node:child_process";
-import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { relative, resolve } from "node:path";
-import { analyzeTestBacklog, generateCommitMessage, generateDiffSummary } from "@git-ai/core";
+import { createInterface } from "node:readline/promises";
+import {
+  analyzeTestBacklog,
+  generateCommitMessage,
+  generateDiffSummary,
+  generateIssueDraft,
+} from "@git-ai/core";
 import { OpenAIProvider } from "@git-ai/providers";
 import dotenv from "dotenv";
 
@@ -28,11 +34,17 @@ type IssueWorkspace = {
 
 type IssueExecutionMode = "local" | "github-action";
 
-type IssueCommandOptions = {
-  action: "run" | "prepare" | "finalize";
-  issueNumber: number;
-  mode: IssueExecutionMode;
-};
+type IssueCommandOptions =
+  | {
+      action: "run" | "prepare" | "finalize";
+      issueNumber: number;
+      mode: IssueExecutionMode;
+    }
+  | {
+      action: "draft";
+    };
+
+type GeneratedIssueDraft = Awaited<ReturnType<typeof generateIssueDraft>>;
 
 type TestBacklogOutputFormat = "json" | "markdown";
 
@@ -63,6 +75,7 @@ type IssueRunContext = {
 const ISSUE_USAGE = [
   "Usage:",
   "  git-ai issue <number>",
+  "  git-ai issue draft",
   "  git-ai issue prepare <number> [--mode <local|github-action>]",
   "  git-ai issue finalize <number>",
 ].join("\n");
@@ -279,9 +292,19 @@ function parseIssueMode(rawArgs: string[]): IssueExecutionMode {
   return mode;
 }
 
-function parseIssueCommandArgs(args: string[]): IssueCommandOptions {
+export function parseIssueCommandArgs(args: string[]): IssueCommandOptions {
   const issueArgs = args.slice(1);
   const subcommand = issueArgs[0];
+
+  if (subcommand === "draft") {
+    if (issueArgs.length > 1) {
+      throw new Error(`Unknown issue option "${issueArgs[1]}". ${ISSUE_USAGE}`);
+    }
+
+    return {
+      action: "draft",
+    };
+  }
 
   if (subcommand === "prepare") {
     return {
@@ -577,6 +600,13 @@ function slugifyIssueTitle(title: string): string {
 function createIssueBranchName(issueNumber: number, title: string): string {
   const slug = slugifyIssueTitle(title) || `issue-${issueNumber}`;
   return `feat/issue-${issueNumber}-${slug}`;
+}
+
+function createIssueDraftFilePath(): string {
+  const issueDir = resolve(REPO_ROOT, ".git-ai", "issues");
+  mkdirSync(issueDir, { recursive: true });
+
+  return resolve(issueDir, `issue-draft-${formatRunTimestamp()}.md`);
 }
 
 function toRepoRelativePath(filePath: string): string {
@@ -944,6 +974,123 @@ function formatCommitMessage(title: string, body?: string): string {
   return body ? `${title}\n\n${body}\n` : `${title}\n`;
 }
 
+function formatMarkdownList(items: string[]): string {
+  return items.map((item) => `- ${item}`).join("\n");
+}
+
+function renderIssueDraftMarkdown(draft: GeneratedIssueDraft): string {
+  const lines = [
+    `# ${draft.title}`,
+    "",
+    "## Summary",
+    draft.summary,
+    "",
+    "## Motivation",
+    draft.motivation,
+    "",
+    "## Goal",
+    draft.goal,
+    "",
+    "## Proposed behavior",
+    formatMarkdownList(draft.proposedBehavior),
+    "",
+    "## Requirements",
+    formatMarkdownList(draft.requirements),
+  ];
+
+  if (draft.constraints && draft.constraints.length > 0) {
+    lines.push("", "## Constraints", formatMarkdownList(draft.constraints));
+  }
+
+  lines.push(
+    "",
+    "## Acceptance criteria",
+    formatMarkdownList(draft.acceptanceCriteria),
+    ""
+  );
+
+  return lines.join("\n");
+}
+
+function parseIssueDraftDocument(content: string): { title: string; body: string } {
+  const lines = content.split(/\r?\n/);
+  const titleLineIndex = lines.findIndex((line) => line.trim().length > 0);
+
+  if (titleLineIndex === -1 || !lines[titleLineIndex].startsWith("# ")) {
+    throw new Error(
+      "Issue draft must start with a top-level markdown heading like `# Issue title`."
+    );
+  }
+
+  const title = lines[titleLineIndex].slice(2).trim();
+  const body = lines.slice(titleLineIndex + 1).join("\n").trim();
+
+  if (!title) {
+    throw new Error("Issue draft title cannot be empty.");
+  }
+
+  if (!body) {
+    throw new Error("Issue draft body cannot be empty.");
+  }
+
+  return {
+    title,
+    body,
+  };
+}
+
+async function promptForLine(prompt: string): Promise<string> {
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  try {
+    return await rl.question(prompt);
+  } finally {
+    rl.close();
+  }
+}
+
+function shouldCreateIssue(response: string): boolean {
+  return ["y", "yes"].includes(response.trim().toLowerCase());
+}
+
+function openFileInEditor(filePath: string): void {
+  const editor = process.env.VISUAL?.trim() || process.env.EDITOR?.trim();
+  if (!editor) {
+    console.log(
+      `Draft saved to ${toRepoRelativePath(filePath)}. Review and edit it manually before creating a GitHub issue.`
+    );
+    return;
+  }
+
+  console.log(`Opening draft in ${editor}...`);
+  const result = spawnSync(`${editor} ${JSON.stringify(filePath)}`, {
+    stdio: "inherit",
+    shell: true,
+  });
+
+  if (result.error) {
+    throw new Error(`Failed to open the draft in ${editor}. ${result.error.message}`);
+  }
+
+  if (result.status !== 0) {
+    throw new Error(`Editor command "${editor}" exited with status ${result.status}.`);
+  }
+}
+
+function createGitHubIssueWithGh(title: string, body: string): string {
+  const output = runCommand(
+    "gh",
+    ["issue", "create", "--title", title, "--body", body],
+    `Failed to create GitHub issue "${title}" with gh.`
+  );
+
+  const lines = output.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  return lines[lines.length - 1] ?? output;
+}
+
 function toTitleCase(value: string): string {
   return value.charAt(0).toUpperCase() + value.slice(1);
 }
@@ -1238,6 +1385,39 @@ async function runTestBacklogCommand(): Promise<void> {
   process.stdout.write(`${formatTestBacklogMarkdown(analysis, createdIssues)}\n`);
 }
 
+async function runIssueDraftCommand(): Promise<void> {
+  const featureIdea = (await promptForLine("Feature idea: ")).trim();
+  if (!featureIdea) {
+    throw new Error("Feature idea is required.");
+  }
+
+  const additionalContext = (await promptForLine("Optional context: ")).trim();
+  const provider = createProvider();
+  const draft = await generateIssueDraft(provider, {
+    featureIdea,
+    additionalContext: additionalContext || undefined,
+  });
+
+  const draftFilePath = createIssueDraftFilePath();
+  writeFileSync(draftFilePath, renderIssueDraftMarkdown(draft), "utf8");
+  openFileInEditor(draftFilePath);
+
+  if (!isGhAuthenticated()) {
+    console.log("GitHub issue creation skipped because gh is unavailable or not authenticated.");
+    return;
+  }
+
+  const createNow = await promptForLine("Create GitHub issue with gh now? [y/N]: ");
+  if (!shouldCreateIssue(createNow)) {
+    console.log(`Draft kept at ${toRepoRelativePath(draftFilePath)}.`);
+    return;
+  }
+
+  const reviewedDraft = parseIssueDraftDocument(readFileSync(draftFilePath, "utf8"));
+  const issueUrl = createGitHubIssueWithGh(reviewedDraft.title, reviewedDraft.body);
+  console.log(`Created GitHub issue: ${issueUrl}`);
+}
+
 async function prepareIssueRun(
   issueNumber: number,
   mode: IssueExecutionMode
@@ -1275,6 +1455,11 @@ function finalizeIssueRun(issueNumber: number): void {
 async function runIssueCommand(): Promise<void> {
   const args = getCliArgs();
   const issueCommand = parseIssueCommandArgs(args);
+
+  if (issueCommand.action === "draft") {
+    await runIssueDraftCommand();
+    return;
+  }
 
   if (issueCommand.action === "prepare") {
     const context = await prepareIssueRun(

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./commit-message";
 export * from "./diff-summary";
+export * from "./issue-draft";
 export * from "./pr-assistant";
 export * from "./pr-description";
 export * from "./review-summary";

--- a/packages/contracts/src/issue-draft.ts
+++ b/packages/contracts/src/issue-draft.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+
+export const IssueDraftInput = z.object({
+  featureIdea: z.string().trim().min(1, "featureIdea must be non-empty"),
+  additionalContext: z
+    .string()
+    .trim()
+    .min(1, "additionalContext must be non-empty")
+    .optional(),
+});
+
+export type IssueDraftInputType = z.infer<typeof IssueDraftInput>;
+
+export const IssueDraftModelOutput = z.object({
+  title: z.string().trim().min(1, "title must be non-empty"),
+  summary: z.string().trim().min(1, "summary must be non-empty"),
+  motivation: z.string().trim().min(1, "motivation must be non-empty"),
+  goal: z.string().trim().min(1, "goal must be non-empty"),
+  proposedBehavior: z
+    .array(z.string().trim().min(1, "proposedBehavior items must be non-empty"))
+    .min(1, "proposedBehavior must contain at least one item"),
+  requirements: z
+    .array(z.string().trim().min(1, "requirements items must be non-empty"))
+    .min(1, "requirements must contain at least one item"),
+  constraints: z
+    .array(z.string().trim().min(1, "constraints items must be non-empty"))
+    .nullable(),
+  acceptanceCriteria: z
+    .array(z.string().trim().min(1, "acceptanceCriteria items must be non-empty"))
+    .min(1, "acceptanceCriteria must contain at least one item"),
+});
+
+export type IssueDraftModelOutputType = z.infer<typeof IssueDraftModelOutput>;
+
+export const IssueDraftOutput = z.object({
+  title: z.string().trim().min(1, "title must be non-empty"),
+  summary: z.string().trim().min(1, "summary must be non-empty"),
+  motivation: z.string().trim().min(1, "motivation must be non-empty"),
+  goal: z.string().trim().min(1, "goal must be non-empty"),
+  proposedBehavior: z
+    .array(z.string().trim().min(1, "proposedBehavior items must be non-empty"))
+    .min(1, "proposedBehavior must contain at least one item"),
+  requirements: z
+    .array(z.string().trim().min(1, "requirements items must be non-empty"))
+    .min(1, "requirements must contain at least one item"),
+  constraints: z
+    .array(z.string().trim().min(1, "constraints items must be non-empty"))
+    .optional(),
+  acceptanceCriteria: z
+    .array(z.string().trim().min(1, "acceptanceCriteria items must be non-empty"))
+    .min(1, "acceptanceCriteria must contain at least one item"),
+});
+
+export type IssueDraftOutputType = z.infer<typeof IssueDraftOutput>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./commit-message";
 export * from "./diff-summary";
+export * from "./issue-draft";
 export * from "./pr-assistant";
 export * from "./pr-description";
 export * from "./review-summary";

--- a/packages/core/src/issue-draft.ts
+++ b/packages/core/src/issue-draft.ts
@@ -1,0 +1,74 @@
+import {
+  IssueDraftInput,
+  IssueDraftInputType,
+  IssueDraftModelOutput,
+  IssueDraftOutput,
+  IssueDraftOutputType,
+} from "@git-ai/contracts";
+import { AIProvider } from "@git-ai/providers";
+import {
+  generateStructuredOutput,
+  normalizeNullableFields,
+} from "./structured-generation";
+
+const ISSUE_DRAFT_SYSTEM_PROMPT =
+  [
+    "You are a senior software engineer drafting implementation-ready GitHub issues.",
+    "Turn rough feature ideas into clear, concrete work briefs for another engineer or coding agent.",
+    "Make reasonable inferences from the provided idea and context, but do not invent repository-specific facts that were not supplied.",
+    "Prefer actionable requirements and acceptance criteria over vague aspirations.",
+    "Return valid JSON only.",
+  ].join(" ");
+
+function buildPrompt(input: IssueDraftInputType): string {
+  const sections = [
+    "Generate a structured GitHub issue draft from the feature idea below.",
+    "The result should be detailed enough for a human contributor or coding agent to implement.",
+    "Use concise but specific language.",
+    "Return strictly valid JSON in this exact shape:",
+    "{",
+    '  "title": string,',
+    '  "summary": string,',
+    '  "motivation": string,',
+    '  "goal": string,',
+    '  "proposedBehavior": string[],',
+    '  "requirements": string[],',
+    '  "constraints": string[] | null,',
+    '  "acceptanceCriteria": string[]',
+    "}",
+    "",
+    'Use "constraints" only when the idea or context implies real implementation boundaries; otherwise return null.',
+    "Do not wrap JSON in markdown fences.",
+    "",
+    "Feature idea:",
+    input.featureIdea,
+  ];
+
+  if (input.additionalContext) {
+    sections.push("", "Additional context:", input.additionalContext);
+  }
+
+  return sections.join("\n");
+}
+
+function normalizeIssueDraftOutput(value: unknown): IssueDraftOutputType {
+  return IssueDraftOutput.parse(value);
+}
+
+export async function generateIssueDraft(
+  provider: AIProvider,
+  input: IssueDraftInputType
+): Promise<IssueDraftOutputType> {
+  const parsedInput = IssueDraftInput.parse(input);
+  const prompt = buildPrompt(parsedInput);
+  const modelOutput = await generateStructuredOutput({
+    provider,
+    systemPrompt: ISSUE_DRAFT_SYSTEM_PROMPT,
+    prompt,
+    schema: IssueDraftModelOutput,
+    validationErrorPrefix: "Model output failed issue draft schema validation",
+    normalizeParsedJson: (value) => normalizeNullableFields(value, ["constraints"]),
+  });
+
+  return normalizeIssueDraftOutput(modelOutput);
+}


### PR DESCRIPTION
Closes #40

<!-- git-ai:pr-assistant:start -->
## PR Assistant

### Summary
This pull request introduces a new command to generate implementation-ready GitHub issues from feature ideas, enhancing the CLI's functionality. It aims to streamline the process of drafting issues by consolidating related guidance into a single output, thereby reducing friction and improving consistency in issue creation.

### Key changes
- Added a new command 'issue draft' to the CLI for generating issue drafts based on feature ideas.
- Implemented a function to create structured issue drafts with a defined schema, including title, summary, motivation, goal, proposed behavior, requirements, constraints, and acceptance criteria.
- Introduced file handling for saving generated issue drafts locally and opening them in the user's preferred editor.
- Updated the CLI to handle user prompts for feature ideas and additional context, and to confirm issue creation with GitHub.
- Created validation schemas for issue drafts to ensure the integrity of the generated content.

### Risk areas
- Potential issues with file handling and user input validation could lead to unexpected behavior if the file system is not accessible or if invalid data is provided.

### Reviewer focus
- Ensure the new command integrates well with existing CLI commands and does not introduce regressions.
- Review the validation logic for issue drafts to confirm it correctly enforces the required structure and constraints.
- Check the file handling logic for saving and opening drafts to ensure it behaves as expected across different environments.
<!-- git-ai:pr-assistant:end -->