### PR TITLE
Fix: Add repo-level AI context controls (excludePaths, diff limits) to .git-ai/config.json

### DIFF
--- a/.github/workflows/pr-assistant.yml
+++ b/.github/workflows/pr-assistant.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           {
             echo 'diff<<EOF'
-            git diff --unified=3 "$BASE_SHA...$HEAD_SHA"
+            GIT_AI_DISABLE_AUTO_RUN=1 node -e "const { readReviewDiffForAutomation } = require('./packages/cli/dist/index.js'); process.stdout.write(readReviewDiffForAutomation(process.env.BASE_SHA, process.env.HEAD_SHA));"
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           {
             echo 'diff<<EOF'
-            git diff --unified=3 "$BASE_SHA...$HEAD_SHA"
+            GIT_AI_DISABLE_AUTO_RUN=1 node -e "const { readReviewDiffForAutomation } = require('./packages/cli/dist/index.js'); process.stdout.write(readReviewDiffForAutomation(process.env.BASE_SHA, process.env.HEAD_SHA));"
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/test-suggestions.yml
+++ b/.github/workflows/test-suggestions.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           {
             echo 'diff<<EOF'
-            git diff --unified=3 "$BASE_SHA...$HEAD_SHA"
+            GIT_AI_DISABLE_AUTO_RUN=1 node -e "const { readReviewDiffForAutomation } = require('./packages/cli/dist/index.js'); process.stdout.write(readReviewDiffForAutomation(process.env.BASE_SHA, process.env.HEAD_SHA));"
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ Optional: create `.git-ai/config.json` in the repository root to override reposi
 
 ```json
 {
+  "aiContext": {
+    "excludePaths": [
+      "vendor/**",
+      "dist/**",
+      "build/**",
+      "*.map",
+      "web/themes/**/css/**",
+      "web/themes/**/js/**"
+    ]
+  },
   "baseBranch": "main",
   "buildCommand": ["pnpm", "build"],
   "forge": {
@@ -40,6 +50,7 @@ Optional: create `.git-ai/config.json` in the repository root to override reposi
 
 Supported config fields:
 
+- `aiContext.excludePaths`: repository-relative glob patterns excluded from AI diff and repository context. These exclusions apply to `git-ai commit`, `git-ai diff`, `git-ai review`, the PR automation workflows in this repo, and repo-wide backlog scans. Bare filename globs like `*.map` match by basename anywhere in the repository. Defaults: `["**/node_modules/**", "**/vendor/**", "**/dist/**", "**/build/**", "*.map"]`.
 - `baseBranch`: default pull request base branch for `git-ai issue <number>`. Default: `main`.
 - `buildCommand`: command run after Codex exits during full local `git-ai issue <number>` flows. Default: `["pnpm", "build"]`.
 - `forge.type`: repository forge integration. Use `"github"` for the current GitHub-backed flows or `"none"` to disable issue and PR creation features for non-GitHub repositories.
@@ -111,6 +122,7 @@ Requirements:
 
 - staged changes must exist
 - `OPENAI_API_KEY` must be set
+- `.git-ai/config.json` `aiContext.excludePaths` is applied before the staged diff is sent to AI
 
 #### `git-ai diff`
 
@@ -125,6 +137,7 @@ Requirements:
 - the repository must already have at least one commit
 - there must be changes in `git diff HEAD`
 - `OPENAI_API_KEY` must be set
+- `.git-ai/config.json` `aiContext.excludePaths` is applied before the diff is summarized
 
 #### `git-ai issue`
 
@@ -199,6 +212,7 @@ Important behavior:
 - without `--base`, it reviews the current `git diff HEAD`
 - with `--issue-number`, the CLI fetches the issue title/body from the configured forge and grounds the review in that context
 - JSON output includes line-linked comment suggestions with file paths and right-side line numbers taken from the diff
+- `.git-ai/config.json` `aiContext.excludePaths` is applied before the review diff is generated
 
 #### `git-ai test-backlog`
 
@@ -235,6 +249,7 @@ git-ai test-backlog --labels testing,backlog
 
 When `--create-issues` is enabled, `git-ai` checks for matching open issue titles first so it can reuse existing backlog items instead of creating duplicates.
 If `.git-ai/config.json` sets `forge.type` to `none`, backlog issue creation is disabled for that repository.
+Repository scans also respect `.git-ai/config.json` `aiContext.excludePaths`.
 
 #### `git-ai feature-backlog`
 
@@ -276,6 +291,7 @@ Important behavior:
 - before each issue is created, `git-ai` prompts for the final title, optional extra description, and labels
 - if an open GitHub issue already exists with the chosen title, `git-ai` reuses it instead of creating a duplicate
 - if `.git-ai/config.json` sets `forge.type` to `none`, feature backlog issue creation is disabled for that repository
+- repository scans respect `.git-ai/config.json` `aiContext.excludePaths`
 
 ### GitHub Action local entrypoints
 
@@ -418,6 +434,8 @@ This repository includes three pull-request-triggered workflows:
 - `.github/workflows/pr-review.yml` generates an AI PR review summary, resolves the first linked closing issue when one exists, updates a managed PR comment, and posts filtered inline review comments against added lines in the diff.
 - `.github/workflows/pr-assistant.yml` updates the pull request body with a managed PR assistant section.
 - `.github/workflows/test-suggestions.yml` creates or updates a managed PR comment with suggested automated test coverage.
+
+All three workflows generate their diff input through the built CLI helper, so `.git-ai/config.json` `aiContext.excludePaths` is honored in pull request automation as well.
 
 ## GitHub Actions issue flow
 

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -10,6 +10,8 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { filterRepositoryPaths } from "../../core/src/path-filter";
+import { DEFAULT_REPOSITORY_AI_CONTEXT_EXCLUDE_PATHS } from "../../core/src/repository-config";
 
 const REPO_ROOT = resolve(__dirname, "../../..");
 const ORIGINAL_ARGV = [...process.argv];
@@ -229,10 +231,22 @@ function createFetchResponse(
 
 function parseMockRepositoryConfig(value?: unknown): Record<string, unknown> {
   const config = (value ?? {}) as {
+    aiContext?: { excludePaths?: unknown };
     baseBranch?: unknown;
     buildCommand?: unknown;
     forge?: { type?: unknown };
   };
+
+  if (config.aiContext?.excludePaths !== undefined) {
+    if (
+      !Array.isArray(config.aiContext.excludePaths) ||
+      config.aiContext.excludePaths.some(
+        (pattern) => typeof pattern !== "string" || pattern.trim().length === 0
+      )
+    ) {
+      throw new Error("aiContext.excludePaths must be a string array");
+    }
+  }
 
   if (config.baseBranch !== undefined) {
     if (typeof config.baseBranch !== "string" || config.baseBranch.trim().length === 0) {
@@ -307,6 +321,8 @@ function withRepositoryConfig(
 
 async function loadCli(options: {
   analysisResult?: ReturnType<typeof createTestBacklogAnalysis>;
+  commitMessageResult?: { title: string; body?: string };
+  diffSummaryResult?: { summary: string; filesChanged?: string[]; notableChanges?: string[] };
   featureAnalysisResult?: ReturnType<typeof createFeatureBacklogAnalysis>;
   issueDraftResult?: ReturnType<typeof createIssueDraftResult>;
   issueResolutionPlanResult?: ReturnType<typeof createIssueResolutionPlanResult>;
@@ -337,6 +353,14 @@ async function loadCli(options: {
   const generateIssueResolutionPlan = vi.fn();
   if (options.issueResolutionPlanResult) {
     generateIssueResolutionPlan.mockResolvedValue(options.issueResolutionPlanResult);
+  }
+  const generateCommitMessage = vi.fn();
+  if (options.commitMessageResult) {
+    generateCommitMessage.mockResolvedValue(options.commitMessageResult);
+  }
+  const generateDiffSummary = vi.fn();
+  if (options.diffSummaryResult) {
+    generateDiffSummary.mockResolvedValue(options.diffSummaryResult);
   }
   const generatePRReview = vi.fn();
   if (options.prReviewResult) {
@@ -382,16 +406,26 @@ async function loadCli(options: {
   vi.doMock("@git-ai/core", () => ({
     analyzeFeatureBacklog,
     analyzeTestBacklog,
-    generateCommitMessage: vi.fn(),
-    generateDiffSummary: vi.fn(),
+    filterRepositoryPaths,
+    generateCommitMessage,
+    generateDiffSummary,
     generateIssueDraft,
     generatePRReview,
     generateIssueResolutionPlan,
     resolveRepositoryConfig: vi.fn((config?: {
+      aiContext?: { excludePaths?: string[] };
       baseBranch?: string;
       buildCommand?: string[];
       forge?: { type?: "github" | "none" };
     }) => ({
+      aiContext: {
+        excludePaths: [
+          ...new Set([
+            ...DEFAULT_REPOSITORY_AI_CONTEXT_EXCLUDE_PATHS,
+            ...(config?.aiContext?.excludePaths ?? []),
+          ]),
+        ],
+      },
       baseBranch: config?.baseBranch ?? "main",
       buildCommand: config?.buildCommand ?? ["pnpm", "build"],
       forge: {
@@ -415,11 +449,15 @@ async function loadCli(options: {
   const module = await import("./index");
 
   return {
+    readReviewDiffForAutomation: module.readReviewDiffForAutomation,
     run: module.run,
     parseFeatureBacklogCommandArgs: module.parseFeatureBacklogCommandArgs,
     parseIssueCommandArgs: module.parseIssueCommandArgs,
+    parseReviewCommandArgs: module.parseReviewCommandArgs,
     analyzeFeatureBacklog,
     analyzeTestBacklog,
+    generateCommitMessage,
+    generateDiffSummary,
     generateIssueDraft,
     generatePRReview,
     generateIssueResolutionPlan,
@@ -545,6 +583,132 @@ describe("CLI integration", () => {
     });
   });
 
+  it("filters excluded paths from commit diffs", async () => {
+    await withRepositoryConfig(
+      JSON.stringify(
+        {
+          aiContext: {
+            excludePaths: ["generated/**"],
+          },
+        },
+        null,
+        2
+      ),
+      async () => {
+        const { run, execFileSync, generateCommitMessage } = await loadCli({
+          commitMessageResult: {
+            title: "feat: keep source diff only",
+          },
+          execFileSyncImpl: (command, args) => {
+            if (command === "git" && args[0] === "diff" && args[1] === "--name-only") {
+              return "src/index.ts\ngenerated/app.js\n";
+            }
+
+            if (
+              command === "git" &&
+              args[0] === "diff" &&
+              args[1] === "--cached" &&
+              args[2] === "--" &&
+              args[3] === "src/index.ts"
+            ) {
+              return [
+                "diff --git a/src/index.ts b/src/index.ts",
+                "+++ b/src/index.ts",
+                "@@ -0,0 +1 @@",
+                "+export const value = 1;",
+              ].join("\n");
+            }
+
+            throw new Error(`Unexpected execFileSync call: ${command} ${args.join(" ")}`);
+          },
+        });
+
+        process.env.OPENAI_API_KEY = "test-key";
+        process.argv = ["node", "git-ai", "commit"];
+
+        const stdout = captureStdout();
+        await run();
+
+        expect(execFileSync).toHaveBeenCalledWith(
+          "git",
+          ["-C", REPO_ROOT, "diff", "--name-only", "--cached"],
+          expect.any(Object)
+        );
+        expect(execFileSync).toHaveBeenCalledWith(
+          "git",
+          ["-C", REPO_ROOT, "diff", "--cached", "--", "src/index.ts"],
+          expect.any(Object)
+        );
+        expect(generateCommitMessage).toHaveBeenCalledWith(
+          expect.any(Object),
+          expect.stringContaining("src/index.ts")
+        );
+        expect(generateCommitMessage).toHaveBeenCalledWith(
+          expect.any(Object),
+          expect.not.stringContaining("generated/app.js")
+        );
+        expect(stdout.output()).toContain("feat: keep source diff only");
+      }
+    );
+  });
+
+  it("reads review diffs for automation with repo exclusions applied", async () => {
+    await withRepositoryConfig(
+      JSON.stringify(
+        {
+          aiContext: {
+            excludePaths: ["generated/**"],
+          },
+        },
+        null,
+        2
+      ),
+      async () => {
+        const { readReviewDiffForAutomation, execFileSync } = await loadCli({
+          execFileSyncImpl: (command, args) => {
+            if (
+              command === "git" &&
+              args[0] === "diff" &&
+              args[1] === "--name-only" &&
+              args[2] === "--unified=3" &&
+              args[3] === "origin/main...HEAD"
+            ) {
+              return "src/index.ts\ngenerated/app.js\n";
+            }
+
+            if (
+              command === "git" &&
+              args[0] === "diff" &&
+              args[1] === "--unified=3" &&
+              args[2] === "origin/main...HEAD" &&
+              args[3] === "--" &&
+              args[4] === "src/index.ts"
+            ) {
+              return [
+                "diff --git a/src/index.ts b/src/index.ts",
+                "+++ b/src/index.ts",
+                "@@ -0,0 +1 @@",
+                "+export const value = 1;",
+              ].join("\n");
+            }
+
+            throw new Error(`Unexpected execFileSync call: ${command} ${args.join(" ")}`);
+          },
+        });
+
+        const diff = readReviewDiffForAutomation("origin/main", "HEAD");
+
+        expect(diff).toContain("src/index.ts");
+        expect(diff).not.toContain("generated/app.js");
+        expect(execFileSync).toHaveBeenCalledWith(
+          "git",
+          ["-C", REPO_ROOT, "diff", "--name-only", "--unified=3", "origin/main...HEAD"],
+          expect.any(Object)
+        );
+      }
+    );
+  });
+
   it("runs test-backlog in JSON mode and reuses duplicate GitHub issues", async () => {
     const analysis = createTestBacklogAnalysis();
     const fetchMock = vi
@@ -605,6 +769,13 @@ describe("CLI integration", () => {
     await run();
 
     expect(analyzeTestBacklog).toHaveBeenCalledWith({
+      excludePaths: [
+        "**/node_modules/**",
+        "**/vendor/**",
+        "**/dist/**",
+        "**/build/**",
+        "*.map",
+      ],
       repoRoot: REPO_ROOT,
       maxFindings: 3,
     });
@@ -652,6 +823,13 @@ describe("CLI integration", () => {
     await run();
 
     expect(analyzeTestBacklog).toHaveBeenCalledWith({
+      excludePaths: [
+        "**/node_modules/**",
+        "**/vendor/**",
+        "**/dist/**",
+        "**/build/**",
+        "*.map",
+      ],
       repoRoot: REPO_ROOT,
       maxFindings: 2,
     });
@@ -721,6 +899,45 @@ describe("CLI integration", () => {
     expect(stdout.output()).toContain("# AI PR Review");
     expect(stdout.output()).toContain("## Linked issue");
     expect(stdout.output()).toContain("packages/cli/src/index.ts:412");
+  });
+
+  it("passes configured excludePaths into test-backlog analysis", async () => {
+    await withRepositoryConfig(
+      JSON.stringify(
+        {
+          aiContext: {
+            excludePaths: ["web/themes/**/css/**"],
+          },
+        },
+        null,
+        2
+      ),
+      async () => {
+        const analysis = createTestBacklogAnalysis();
+        const { run, analyzeTestBacklog } = await loadCli({
+          analysisResult: analysis,
+        });
+
+        process.argv = ["node", "git-ai", "test-backlog", "--top", "1"];
+
+        const stdout = captureStdout();
+        await run();
+
+        expect(analyzeTestBacklog).toHaveBeenCalledWith({
+          excludePaths: [
+            "**/node_modules/**",
+            "**/vendor/**",
+            "**/dist/**",
+            "**/build/**",
+            "*.map",
+            "web/themes/**/css/**",
+          ],
+          repoRoot: REPO_ROOT,
+          maxFindings: 1,
+        });
+        expect(stdout.output()).toContain("# AI Test Backlog");
+      }
+    );
   });
 
   it("fails test-backlog issue creation clearly when no GitHub token is configured", async () => {
@@ -801,6 +1018,13 @@ describe("CLI integration", () => {
     await run();
 
     expect(analyzeFeatureBacklog).toHaveBeenCalledWith({
+      excludePaths: [
+        "**/node_modules/**",
+        "**/vendor/**",
+        "**/dist/**",
+        "**/build/**",
+        "*.map",
+      ],
       repoRoot: REPO_ROOT,
       maxSuggestions: 5,
     });
@@ -842,6 +1066,13 @@ describe("CLI integration", () => {
     await run();
 
     expect(analyzeFeatureBacklog).toHaveBeenCalledWith({
+      excludePaths: [
+        "**/node_modules/**",
+        "**/vendor/**",
+        "**/dist/**",
+        "**/build/**",
+        "*.map",
+      ],
       repoRoot: REPO_ROOT,
       maxSuggestions: 2,
     });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,6 +7,7 @@ import { createInterface } from "node:readline/promises";
 import {
   analyzeFeatureBacklog,
   analyzeTestBacklog,
+  filterRepositoryPaths,
   generateCommitMessage,
   generateDiffSummary,
   generateIssueDraft,
@@ -163,30 +164,19 @@ function getRepositoryForge(repoRoot = getDefaultRepoRoot()): RepositoryForge {
   return createRepositoryForge(repoRoot, getRepositoryConfig(repoRoot));
 }
 
-function readGitDiff(
+function executeGitDiff(
+  repoRoot: string,
   args: string[],
-  emptyDiffMessage: string,
   commandDescription: string,
   missingRevisionMessage?: string
 ): string {
-  const repoRoot = getDefaultRepoRoot();
   try {
-    const diff = execFileSync("git", ["-C", repoRoot, ...args], {
+    return execFileSync("git", ["-C", repoRoot, ...args], {
       encoding: "utf8",
       maxBuffer: 10 * 1024 * 1024,
       stdio: ["ignore", "pipe", "pipe"],
     });
-
-    if (!diff.trim()) {
-      throw new Error(emptyDiffMessage);
-    }
-
-    return diff;
   } catch (error: unknown) {
-    if (error instanceof Error && error.message === emptyDiffMessage) {
-      throw error;
-    }
-
     const stderr =
       typeof error === "object" &&
       error !== null &&
@@ -213,34 +203,114 @@ function readGitDiff(
   }
 }
 
+function buildNameOnlyDiffArgs(args: string[]): string[] {
+  return args[0] === "diff" ? [args[0], "--name-only", ...args.slice(1)] : args;
+}
+
+type ReadGitDiffOptions = {
+  allowEmpty?: boolean;
+  excludePaths?: string[];
+  repoRoot?: string;
+};
+
+function readGitDiff(
+  args: string[],
+  emptyDiffMessage: string,
+  commandDescription: string,
+  missingRevisionMessage?: string,
+  options: ReadGitDiffOptions = {}
+): string {
+  const repoRoot = options.repoRoot ?? getDefaultRepoRoot();
+  const excludePaths = options.excludePaths ?? [];
+
+  let effectiveArgs = args;
+  if (excludePaths.length > 0) {
+    const changedPaths = executeGitDiff(
+      repoRoot,
+      buildNameOnlyDiffArgs(args),
+      commandDescription,
+      missingRevisionMessage
+    )
+      .split(/\r?\n/)
+      .map((filePath) => filePath.trim())
+      .filter(Boolean);
+    const includedPaths = filterRepositoryPaths(changedPaths, excludePaths);
+
+    if (includedPaths.length === 0) {
+      if (options.allowEmpty) {
+        return "";
+      }
+
+      throw new Error(emptyDiffMessage);
+    }
+
+    effectiveArgs = [...args, "--", ...includedPaths];
+  }
+
+  const diff = executeGitDiff(
+    repoRoot,
+    effectiveArgs,
+    commandDescription,
+    missingRevisionMessage
+  );
+
+  if (!diff.trim()) {
+    if (options.allowEmpty) {
+      return "";
+    }
+
+    throw new Error(emptyDiffMessage);
+  }
+
+  return diff;
+}
+
 function readStagedDiff(): string {
+  const repoRoot = getDefaultRepoRoot();
   return readGitDiff(
     ["diff", "--cached"],
     "No staged changes found. Stage changes before generating a commit message.",
-    "staged"
+    "staged",
+    undefined,
+    {
+      excludePaths: getRepositoryConfig(repoRoot).aiContext.excludePaths,
+      repoRoot,
+    }
   );
 }
 
 function readHeadDiff(): string {
+  const repoRoot = getDefaultRepoRoot();
   return readGitDiff(
     ["diff", "HEAD"],
     "No changes found in git diff HEAD. Make a change before generating a diff summary.",
     "HEAD",
-    "git diff HEAD requires at least one commit. Create an initial commit before generating a diff summary."
+    "git diff HEAD requires at least one commit. Create an initial commit before generating a diff summary.",
+    {
+      excludePaths: getRepositoryConfig(repoRoot).aiContext.excludePaths,
+      repoRoot,
+    }
   );
 }
 
-function readReviewDiff(base?: string, head?: string): string {
+export function readReviewDiff(base?: string, head?: string): string {
   if (head && !base) {
     throw new Error(`--head requires --base. ${REVIEW_USAGE}`);
   }
+
+  const repoRoot = getDefaultRepoRoot();
+  const excludePaths = getRepositoryConfig(repoRoot).aiContext.excludePaths;
 
   if (!base) {
     return readGitDiff(
       ["diff", "--unified=3", "HEAD"],
       "No changes found in git diff HEAD. Make a change before generating a PR review.",
       "HEAD",
-      "git diff HEAD requires at least one commit. Create an initial commit before generating a PR review."
+      "git diff HEAD requires at least one commit. Create an initial commit before generating a PR review.",
+      {
+        excludePaths,
+        repoRoot,
+      }
     );
   }
 
@@ -249,8 +319,35 @@ function readReviewDiff(base?: string, head?: string): string {
     ["diff", "--unified=3", range],
     `No changes found in git diff ${range}. Make a change before generating a PR review.`,
     range,
-    `git diff ${range} requires the referenced revisions to exist before generating a PR review.`
+    `git diff ${range} requires the referenced revisions to exist before generating a PR review.`,
+    {
+      excludePaths,
+      repoRoot,
+    }
   );
+}
+
+export function readReviewDiffForAutomation(base?: string, head?: string): string {
+  if (head && !base) {
+    throw new Error(`--head requires --base. ${REVIEW_USAGE}`);
+  }
+
+  const repoRoot = getDefaultRepoRoot();
+  const excludePaths = getRepositoryConfig(repoRoot).aiContext.excludePaths;
+  const range = base ? (head ? `${base}...${head}` : `${base}...HEAD`) : "HEAD";
+  const args = base ? ["diff", "--unified=3", range] : ["diff", "--unified=3", "HEAD"];
+  const emptyDiffMessage = base
+    ? `No changes found in git diff ${range}. Make a change before generating a PR review.`
+    : "No changes found in git diff HEAD. Make a change before generating a PR review.";
+  const missingRevisionMessage = base
+    ? `git diff ${range} requires the referenced revisions to exist before generating a PR review.`
+    : "git diff HEAD requires at least one commit. Create an initial commit before generating a PR review.";
+
+  return readGitDiff(args, emptyDiffMessage, range, missingRevisionMessage, {
+    allowEmpty: true,
+    excludePaths,
+    repoRoot,
+  });
 }
 
 function runCommand(
@@ -1705,7 +1802,9 @@ async function maybeCreateFeatureBacklogIssues(
 
 async function runTestBacklogCommand(): Promise<void> {
   const options = parseTestBacklogCommandArgs(getCliArgs());
+  const repositoryConfig = getRepositoryConfig(options.repoRoot);
   const analysis = await analyzeTestBacklog({
+    excludePaths: repositoryConfig.aiContext.excludePaths,
     repoRoot: options.repoRoot,
     maxFindings: options.top,
   });
@@ -1725,7 +1824,9 @@ async function runTestBacklogCommand(): Promise<void> {
 
 async function runFeatureBacklogCommand(): Promise<void> {
   const options = parseFeatureBacklogCommandArgs(getCliArgs());
+  const repositoryConfig = getRepositoryConfig(options.repoRoot);
   const analysis = await analyzeFeatureBacklog({
+    excludePaths: repositoryConfig.aiContext.excludePaths,
     repoRoot: options.repoRoot,
     maxSuggestions: options.top,
   });

--- a/packages/contracts/src/feature-backlog.ts
+++ b/packages/contracts/src/feature-backlog.ts
@@ -11,6 +11,7 @@ export const FeatureBacklogCategory = z.enum([
 ]);
 
 export const FeatureBacklogInput = z.object({
+  excludePaths: z.array(z.string().trim().min(1)).optional(),
   repoRoot: z.string().trim().min(1, "repoRoot must be non-empty"),
   maxSuggestions: z.number().int().min(1).max(20).optional(),
 });

--- a/packages/contracts/src/repository-config.ts
+++ b/packages/contracts/src/repository-config.ts
@@ -8,11 +8,20 @@ export const RepositoryForgeConfig = z.object({
 
 export type RepositoryForgeConfigType = z.infer<typeof RepositoryForgeConfig>;
 
+export const RepositoryAiContextConfig = z.object({
+  excludePaths: z
+    .array(z.string().trim().min(1, "excludePaths entries must be non-empty"))
+    .optional(),
+});
+
+export type RepositoryAiContextConfigType = z.infer<typeof RepositoryAiContextConfig>;
+
 export const RepositoryConfigCommand = z
   .array(z.string().trim().min(1, "command segments must be non-empty"))
   .min(1, "command must contain at least one segment");
 
 export const RepositoryConfig = z.object({
+  aiContext: RepositoryAiContextConfig.optional(),
   baseBranch: z.string().trim().min(1, "baseBranch must be non-empty").optional(),
   buildCommand: RepositoryConfigCommand.optional(),
   forge: RepositoryForgeConfig.optional(),
@@ -21,6 +30,9 @@ export const RepositoryConfig = z.object({
 export type RepositoryConfigType = z.infer<typeof RepositoryConfig>;
 
 export const ResolvedRepositoryConfig = z.object({
+  aiContext: z.object({
+    excludePaths: z.array(z.string().trim().min(1)),
+  }),
   baseBranch: z.string().trim().min(1),
   buildCommand: RepositoryConfigCommand,
   forge: z.object({

--- a/packages/contracts/src/test-backlog.ts
+++ b/packages/contracts/src/test-backlog.ts
@@ -11,6 +11,7 @@ export const SuggestedTestType = z.enum([
 ]);
 
 export const TestBacklogInput = z.object({
+  excludePaths: z.array(z.string().trim().min(1)).optional(),
   repoRoot: z.string().trim().min(1, "repoRoot must be non-empty"),
   maxFindings: z.number().int().min(1).max(20).optional(),
 });

--- a/packages/core/src/feature-backlog.test.ts
+++ b/packages/core/src/feature-backlog.test.ts
@@ -85,4 +85,37 @@ describe("analyzeFeatureBacklog", () => {
       "multi-provider",
     ]);
   });
+
+  it("ignores excluded example paths from repository signals", async () => {
+    const repoRoot = mkdtempSync(resolve(tmpdir(), "git-ai-feature-backlog-exclude-"));
+
+    writeFile(
+      repoRoot,
+      "package.json",
+      JSON.stringify(
+        {
+          name: "fixture-repo",
+          private: true,
+          bin: {
+            "fixture-cli": "dist/index.js",
+          },
+        },
+        null,
+        2
+      )
+    );
+    writeFile(repoRoot, "README.md", "# Fixture Repo\n");
+    writeFile(repoRoot, "examples/basic/README.md", "# Example\n");
+
+    const result = await analyzeFeatureBacklog({
+      excludePaths: ["examples/**"],
+      repoRoot,
+      maxSuggestions: 10,
+    });
+
+    expect(result.repositorySignals.hasExamples).toBe(false);
+    expect(result.suggestions.map((suggestion) => suggestion.id)).toContain(
+      "starter-templates"
+    );
+  });
 });

--- a/packages/core/src/feature-backlog.ts
+++ b/packages/core/src/feature-backlog.ts
@@ -8,6 +8,8 @@ import {
   type FeatureBacklogSuggestionType,
   type RepositoryFeatureSignalsType,
 } from "@git-ai/contracts";
+import { createRepositoryPathMatcher } from "./path-filter";
+import { resolveRepositoryConfig } from "./repository-config";
 
 type PackageJson = {
   path: string;
@@ -84,26 +86,36 @@ function isSourceFile(filePath: string): boolean {
   );
 }
 
-function walkFiles(rootDir: string, currentDir = rootDir): string[] {
+function walkFiles(
+  rootDir: string,
+  matchesExcludedPath: (filePath: string) => boolean,
+  currentDir = rootDir
+): string[] {
   const entries = readdirSync(currentDir, { withFileTypes: true });
   const files: string[] = [];
 
   for (const entry of entries) {
-    if (entry.isDirectory() && SKIP_DIRECTORIES.has(entry.name)) {
-      continue;
-    }
-
     const absolutePath = resolve(currentDir, entry.name);
+    const relativePath = normalizePath(relative(rootDir, absolutePath));
+
     if (entry.isDirectory()) {
-      files.push(...walkFiles(rootDir, absolutePath));
+      if (
+        SKIP_DIRECTORIES.has(entry.name) ||
+        matchesExcludedPath(relativePath) ||
+        matchesExcludedPath(`${relativePath}/`)
+      ) {
+        continue;
+      }
+
+      files.push(...walkFiles(rootDir, matchesExcludedPath, absolutePath));
       continue;
     }
 
-    if (!entry.isFile()) {
+    if (!entry.isFile() || matchesExcludedPath(relativePath)) {
       continue;
     }
 
-    files.push(normalizePath(relative(rootDir, absolutePath)));
+    files.push(relativePath);
   }
 
   return files.sort((left, right) => left.localeCompare(right));
@@ -152,8 +164,8 @@ function collectPackageJsons(repoRoot: string, allFiles: string[]): PackageJson[
     .filter((value): value is PackageJson => Boolean(value));
 }
 
-function collectSnapshot(repoRoot: string): RepositorySnapshot {
-  const allFiles = walkFiles(repoRoot);
+function collectSnapshot(repoRoot: string, excludePaths: string[]): RepositorySnapshot {
+  const allFiles = walkFiles(repoRoot, createRepositoryPathMatcher(excludePaths));
   const workflowPaths = allFiles.filter((filePath) =>
     /^\.github\/workflows\/.+\.(yml|yaml)$/.test(filePath)
   );
@@ -508,7 +520,12 @@ export async function analyzeFeatureBacklog(
 ): Promise<FeatureBacklogOutputType> {
   const parsed = FeatureBacklogInput.parse(input);
   const repoRoot = resolve(parsed.repoRoot);
-  const snapshot = collectSnapshot(repoRoot);
+  const excludePaths = resolveRepositoryConfig({
+    aiContext: {
+      excludePaths: parsed.excludePaths,
+    },
+  }).aiContext.excludePaths;
+  const snapshot = collectSnapshot(repoRoot, excludePaths);
   const signals = collectSignals(snapshot);
   const suggestions = buildSuggestions(snapshot, signals)
     .sort((left, right) => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export * from "./diff-summary";
 export * from "./feature-backlog";
 export * from "./issue-draft";
 export * from "./issue-resolution-plan";
+export * from "./path-filter";
 export * from "./pr-assistant";
 export * from "./pr-description";
 export * from "./pr-review";

--- a/packages/core/src/path-filter.test.ts
+++ b/packages/core/src/path-filter.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  createRepositoryPathMatcher,
+  filterRepositoryPaths,
+  normalizeRepositoryPath,
+} from "./path-filter";
+
+describe("path filter helpers", () => {
+  it("normalizes repository paths to forward-slash relative paths", () => {
+    expect(normalizeRepositoryPath("./packages\\cli\\src\\index.ts")).toBe(
+      "packages/cli/src/index.ts"
+    );
+  });
+
+  it("matches basename globs anywhere in the repository", () => {
+    const matchesExcludedPath = createRepositoryPathMatcher(["*.map"]);
+
+    expect(matchesExcludedPath("dist/app.js.map")).toBe(true);
+    expect(matchesExcludedPath("packages/cli/src/index.ts")).toBe(false);
+  });
+
+  it("matches nested directory globs and filters excluded paths", () => {
+    expect(
+      filterRepositoryPaths(
+        [
+          "packages/cli/src/index.ts",
+          "packages/cli/dist/index.js",
+          "web/themes/site/css/app.css",
+        ],
+        ["**/dist/**", "web/themes/**/css/**"]
+      )
+    ).toEqual(["packages/cli/src/index.ts"]);
+  });
+});

--- a/packages/core/src/path-filter.ts
+++ b/packages/core/src/path-filter.ts
@@ -1,0 +1,98 @@
+function escapeRegexCharacter(character: string): string {
+  return /[\\^$+?.()|[\]{}]/.test(character) ? `\\${character}` : character;
+}
+
+export function normalizeRepositoryPath(filePath: string): string {
+  const normalized = filePath
+    .trim()
+    .replace(/\\/g, "/")
+    .replace(/\/+/g, "/")
+    .replace(/^\.\//, "")
+    .replace(/^\/+/, "");
+
+  return normalized === "." ? "" : normalized;
+}
+
+function compileGlobPattern(pattern: string): RegExp {
+  const normalizedPattern = normalizeRepositoryPath(pattern);
+  let expression = "^";
+
+  for (let index = 0; index < normalizedPattern.length; index += 1) {
+    const character = normalizedPattern[index];
+
+    if (character === "*") {
+      const nextCharacter = normalizedPattern[index + 1];
+      if (nextCharacter === "*") {
+        const followingCharacter = normalizedPattern[index + 2];
+        if (followingCharacter === "/") {
+          expression += "(?:.*\\/)?";
+          index += 2;
+          continue;
+        }
+
+        expression += ".*";
+        index += 1;
+        continue;
+      }
+
+      expression += "[^/]*";
+      continue;
+    }
+
+    if (character === "?") {
+      expression += "[^/]";
+      continue;
+    }
+
+    expression += escapeRegexCharacter(character);
+  }
+
+  expression += "$";
+  return new RegExp(expression);
+}
+
+type CompiledPathPattern = {
+  regex: RegExp;
+  matchBasenameOnly: boolean;
+};
+
+export function createRepositoryPathMatcher(patterns: readonly string[]): (filePath: string) => boolean {
+  const compiledPatterns: CompiledPathPattern[] = patterns
+    .map((pattern) => normalizeRepositoryPath(pattern))
+    .filter(Boolean)
+    .map((pattern) => ({
+      regex: compileGlobPattern(pattern),
+      matchBasenameOnly: !pattern.includes("/"),
+    }));
+
+  if (compiledPatterns.length === 0) {
+    return () => false;
+  }
+
+  return (filePath: string): boolean => {
+    const normalizedPath = normalizeRepositoryPath(filePath);
+    const basename =
+      normalizedPath.length === 0
+        ? normalizedPath
+        : normalizedPath.slice(normalizedPath.lastIndexOf("/") + 1);
+
+    return compiledPatterns.some(({ regex, matchBasenameOnly }) =>
+      regex.test(matchBasenameOnly ? basename : normalizedPath)
+    );
+  };
+}
+
+export function isRepositoryPathExcluded(
+  filePath: string,
+  excludePaths: readonly string[]
+): boolean {
+  return createRepositoryPathMatcher(excludePaths)(filePath);
+}
+
+export function filterRepositoryPaths(
+  filePaths: readonly string[],
+  excludePaths: readonly string[]
+): string[] {
+  const matchesExcludedPath = createRepositoryPathMatcher(excludePaths);
+  return filePaths.filter((filePath) => !matchesExcludedPath(filePath));
+}

--- a/packages/core/src/repository-config.test.ts
+++ b/packages/core/src/repository-config.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_REPOSITORY_AI_CONTEXT_EXCLUDE_PATHS,
+  resolveRepositoryConfig,
+} from "./repository-config";
+
+describe("resolveRepositoryConfig", () => {
+  it("adds default AI context exclusions and merges repository patterns", () => {
+    const resolved = resolveRepositoryConfig({
+      aiContext: {
+        excludePaths: ["web/themes/**/css/**", "*.map"],
+      },
+      baseBranch: "develop",
+    });
+
+    expect(resolved.baseBranch).toBe("develop");
+    expect(resolved.aiContext.excludePaths).toEqual([
+      ...DEFAULT_REPOSITORY_AI_CONTEXT_EXCLUDE_PATHS,
+      "web/themes/**/css/**",
+    ]);
+  });
+});

--- a/packages/core/src/repository-config.ts
+++ b/packages/core/src/repository-config.ts
@@ -8,6 +8,17 @@ import {
 export const DEFAULT_REPOSITORY_BASE_BRANCH = "main";
 export const DEFAULT_REPOSITORY_BUILD_COMMAND = ["pnpm", "build"] as const;
 export const DEFAULT_REPOSITORY_FORGE_TYPE = "github" as const;
+export const DEFAULT_REPOSITORY_AI_CONTEXT_EXCLUDE_PATHS = [
+  "**/node_modules/**",
+  "**/vendor/**",
+  "**/dist/**",
+  "**/build/**",
+  "*.map",
+] as const;
+
+function uniquePaths(paths: readonly string[]): string[] {
+  return [...new Set(paths.map((path) => path.trim()).filter(Boolean))];
+}
 
 export function resolveRepositoryConfig(
   config?: RepositoryConfigType
@@ -15,6 +26,12 @@ export function resolveRepositoryConfig(
   const parsedConfig = RepositoryConfig.parse(config ?? {});
 
   return ResolvedRepositoryConfig.parse({
+    aiContext: {
+      excludePaths: uniquePaths([
+        ...DEFAULT_REPOSITORY_AI_CONTEXT_EXCLUDE_PATHS,
+        ...(parsedConfig.aiContext?.excludePaths ?? []),
+      ]),
+    },
     baseBranch: parsedConfig.baseBranch ?? DEFAULT_REPOSITORY_BASE_BRANCH,
     buildCommand: parsedConfig.buildCommand ?? [...DEFAULT_REPOSITORY_BUILD_COMMAND],
     forge: {

--- a/packages/core/src/test-backlog.test.ts
+++ b/packages/core/src/test-backlog.test.ts
@@ -75,4 +75,43 @@ describe("analyzeTestBacklog", () => {
       "initial-test-harness"
     );
   });
+
+  it("ignores excluded test paths from the repository scan", async () => {
+    const repoRoot = mkdtempSync(resolve(tmpdir(), "git-ai-test-backlog-exclude-"));
+
+    writeFile(
+      repoRoot,
+      "package.json",
+      JSON.stringify(
+        {
+          name: "fixture-repo",
+          private: true,
+        },
+        null,
+        2
+      )
+    );
+    writeFile(
+      repoRoot,
+      "packages/core/src/example.ts",
+      'export function example(): string { return "ok"; }\n'
+    );
+    writeFile(
+      repoRoot,
+      "generated/tests/example.test.ts",
+      'import { describe, it } from "vitest";\n' +
+        'describe("generated", () => {\n' +
+        '  it("is ignored", () => {});\n' +
+        "});\n"
+    );
+
+    const result = await analyzeTestBacklog({
+      excludePaths: ["generated/**"],
+      repoRoot,
+      maxFindings: 10,
+    });
+
+    expect(result.currentTestingSetup.hasTests).toBe(false);
+    expect(result.currentTestingSetup.testFileCount).toBe(0);
+  });
 });

--- a/packages/core/src/test-backlog.ts
+++ b/packages/core/src/test-backlog.ts
@@ -10,6 +10,8 @@ import {
   type TestBacklogInputType,
   type TestBacklogOutputType,
 } from "@git-ai/contracts";
+import { createRepositoryPathMatcher } from "./path-filter";
+import { resolveRepositoryConfig } from "./repository-config";
 
 type PackageJson = {
   path: string;
@@ -136,26 +138,36 @@ function isSourceFile(filePath: string): boolean {
   );
 }
 
-function walkFiles(rootDir: string, currentDir = rootDir): string[] {
+function walkFiles(
+  rootDir: string,
+  matchesExcludedPath: (filePath: string) => boolean,
+  currentDir = rootDir
+): string[] {
   const entries = readdirSync(currentDir, { withFileTypes: true });
   const files: string[] = [];
 
   for (const entry of entries) {
-    if (entry.isDirectory() && SKIP_DIRECTORIES.has(entry.name)) {
-      continue;
-    }
-
     const absolutePath = resolve(currentDir, entry.name);
+    const relativePath = normalizePath(relative(rootDir, absolutePath));
+
     if (entry.isDirectory()) {
-      files.push(...walkFiles(rootDir, absolutePath));
+      if (
+        SKIP_DIRECTORIES.has(entry.name) ||
+        matchesExcludedPath(relativePath) ||
+        matchesExcludedPath(`${relativePath}/`)
+      ) {
+        continue;
+      }
+
+      files.push(...walkFiles(rootDir, matchesExcludedPath, absolutePath));
       continue;
     }
 
-    if (!entry.isFile()) {
+    if (!entry.isFile() || matchesExcludedPath(relativePath)) {
       continue;
     }
 
-    files.push(normalizePath(relative(rootDir, absolutePath)));
+    files.push(relativePath);
   }
 
   return files.sort((left, right) => left.localeCompare(right));
@@ -399,8 +411,8 @@ function collectCiIntegration(
   };
 }
 
-function collectSnapshot(repoRoot: string): RepositorySnapshot {
-  const allFiles = walkFiles(repoRoot);
+function collectSnapshot(repoRoot: string, excludePaths: string[]): RepositorySnapshot {
+  const allFiles = walkFiles(repoRoot, createRepositoryPathMatcher(excludePaths));
   const packageJsons = collectPackageJsons(repoRoot, allFiles);
   const workflowPaths = allFiles.filter((filePath) =>
     /^\.github\/workflows\/.+\.(yml|yaml)$/.test(filePath)
@@ -926,7 +938,12 @@ export async function analyzeTestBacklog(
 ): Promise<TestBacklogOutputType> {
   const parsed = TestBacklogInput.parse(input);
   const repoRoot = resolve(parsed.repoRoot);
-  const snapshot = collectSnapshot(repoRoot);
+  const excludePaths = resolveRepositoryConfig({
+    aiContext: {
+      excludePaths: parsed.excludePaths,
+    },
+  }).aiContext.excludePaths;
+  const snapshot = collectSnapshot(repoRoot, excludePaths);
   const localSetup = collectTestingSetup(snapshot);
   const ciIntegration = collectCiIntegration(snapshot, localSetup);
   const setup: CurrentTestingSetupType = {


### PR DESCRIPTION
Closes #52

<!-- git-ai:pr-assistant:start -->
## PR Assistant

### Summary
This pull request introduces repository-level AI context controls by adding an `excludePaths` configuration to `.git-ai/config.json`. This allows users to specify file patterns that should be excluded from AI-related operations, enhancing the relevance of AI suggestions and analyses by ignoring irrelevant files. Additionally, the workflows for pull request automation have been updated to respect these exclusions.

### Key changes
- Added `aiContext.excludePaths` to `.git-ai/config.json`, allowing users to specify file patterns to exclude from AI operations.
- Updated the PR automation workflows to utilize the new `readReviewDiffForAutomation` function, which respects the `excludePaths` configuration.
- Refactored the CLI to filter out excluded paths during diff operations, ensuring that AI analyses do not consider irrelevant files.
- Implemented validation for the `excludePaths` configuration to ensure it is an array of non-empty strings.

### Risk areas
- Changes to the diff reading functions could potentially lead to incorrect diff outputs if the path filtering logic does not work as intended.

### Reviewer focus
- Verify that the `excludePaths` configuration is correctly implemented and validated in `.git-ai/config.json`.
- Check that the updated workflows correctly respect the `excludePaths` during PR automation.
- Ensure that the filtering logic in the CLI and related functions behaves as expected and does not inadvertently exclude necessary files.
<!-- git-ai:pr-assistant:end -->