### PR TITLE
Fix: Add test coverage for docs-aware PR review (diff classification and findings output)

### DIFF
--- a/packages/contracts/src/pr-review.test.ts
+++ b/packages/contracts/src/pr-review.test.ts
@@ -49,4 +49,57 @@ describe("PRReviewOutput", () => {
       })
     ).toThrow();
   });
+
+  it("rejects malformed higher-level findings", () => {
+    expect(() =>
+      PRReviewOutput.parse({
+        summary: "The review found a broader onboarding issue.",
+        comments: [],
+        findings: [
+          {
+            title: "  ",
+            severity: "medium",
+            category: "usability",
+            body: "This finding is malformed because the title is empty.",
+            relatedPaths: [],
+          },
+        ],
+      })
+    ).toThrow();
+  });
+
+  it("rejects more than three higher-level findings", () => {
+    expect(() =>
+      PRReviewOutput.parse({
+        summary: "Too many higher-level findings were returned.",
+        comments: [],
+        findings: [
+          {
+            title: "Finding 1",
+            severity: "low",
+            category: "documentation",
+            body: "First finding.",
+          },
+          {
+            title: "Finding 2",
+            severity: "low",
+            category: "documentation",
+            body: "Second finding.",
+          },
+          {
+            title: "Finding 3",
+            severity: "low",
+            category: "documentation",
+            body: "Third finding.",
+          },
+          {
+            title: "Finding 4",
+            severity: "low",
+            category: "documentation",
+            body: "Fourth finding.",
+          },
+        ],
+      })
+    ).toThrow();
+  });
 });

--- a/packages/core/src/pr-review.test.ts
+++ b/packages/core/src/pr-review.test.ts
@@ -82,6 +82,52 @@ describe("generatePRReview", () => {
     expect(request?.prompt).toContain('"findings": [');
   });
 
+  it("keeps docs-heavy diffs predictable when no higher-level findings are needed", async () => {
+    const provider = createProvider({
+      summary: "The documentation changes look correct and no broader onboarding issues stand out.",
+      comments: [],
+      findings: [],
+    });
+
+    const review = await generatePRReview(provider, {
+      diff: [
+        "diff --git a/docs/setup.md b/docs/setup.md",
+        "--- a/docs/setup.md",
+        "+++ b/docs/setup.md",
+        "@@ -1,2 +1,18 @@",
+        "-Old setup",
+        "+# Setup",
+        "+",
+        "+pnpm install",
+        "+pnpm build",
+        "+pnpm test",
+        "+",
+        "+Run the CLI after build.",
+        "+Verify the output before opening a PR.",
+        "+Repeat for CI if needed.",
+        "+Keep the branch up to date.",
+        "+Review the generated summary.",
+        "diff --git a/examples/config.example.json b/examples/config.example.json",
+        "--- a/examples/config.example.json",
+        "+++ b/examples/config.example.json",
+        "@@ -0,0 +1,10 @@",
+        '+{"apiKey":"demo"}',
+        '+{"apiKey":"demo"}',
+        '+{"apiKey":"demo"}',
+        '+{"apiKey":"demo"}',
+        '+{"apiKey":"demo"}',
+      ].join("\n"),
+    });
+
+    expect(review.findings).toEqual([]);
+
+    const request = provider.generateText.mock.calls[0]?.[0];
+    expect(request?.prompt).toContain("Review classification: docs-heavy.");
+    expect(request?.prompt).toContain(
+      'Prefer the "findings" array for invalid or confusing commands'
+    );
+  });
+
   it("keeps standard diffs on the conservative rubric and defaults findings to empty", async () => {
     const provider = createProvider({
       summary: "The change is small and no broader concerns stand out.",
@@ -113,6 +159,76 @@ describe("generatePRReview", () => {
     expect(request?.prompt).toContain("Review classification: standard.");
     expect(request?.prompt).toContain(
       'The "findings" array should usually stay empty for code-heavy diffs'
+    );
+    expect(request?.prompt).not.toContain("This diff is documentation-heavy");
+  });
+
+  it("treats mixed diffs as standard when docs do not dominate the change", async () => {
+    const provider = createProvider({
+      summary: "The code changes look sound and do not justify broader findings.",
+      comments: [],
+      findings: [],
+    });
+
+    await generatePRReview(provider, {
+      diff: [
+        "diff --git a/README.md b/README.md",
+        "--- a/README.md",
+        "+++ b/README.md",
+        "@@ -1,2 +1,6 @@",
+        "-Old note",
+        "+Updated usage note",
+        "+Added one more sentence",
+        "diff --git a/packages/core/src/pr-review.ts b/packages/core/src/pr-review.ts",
+        "--- a/packages/core/src/pr-review.ts",
+        "+++ b/packages/core/src/pr-review.ts",
+        "@@ -10,4 +10,8 @@",
+        "-const oldValue = before();",
+        "+const newValue = after();",
+        "+if (newValue) {",
+        "+  return newValue;",
+        "+}",
+        "diff --git a/packages/core/src/repository-config.ts b/packages/core/src/repository-config.ts",
+        "--- a/packages/core/src/repository-config.ts",
+        "+++ b/packages/core/src/repository-config.ts",
+        "@@ -1,4 +1,8 @@",
+        "-export const config = oldConfig;",
+        "+export const config = nextConfig;",
+        "+export function readConfig() {",
+        "+  return config;",
+        "+}",
+      ].join("\n"),
+    });
+
+    const request = provider.generateText.mock.calls[0]?.[0];
+    expect(request?.prompt).toContain("Review classification: standard.");
+    expect(request?.prompt).toContain("Classification signal: Changed files: 3; doc-like files: 1.");
+    expect(request?.prompt).toContain(
+      'The "findings" array should usually stay empty for code-heavy diffs'
+    );
+  });
+
+  it("treats header-only diffs as low-signal standard reviews", async () => {
+    const provider = createProvider({
+      summary: "The diff does not contain enough changed lines to support review findings.",
+      comments: [],
+      findings: [],
+    });
+
+    const review = await generatePRReview(provider, {
+      diff: [
+        "diff --git a/README.md b/README.md",
+        "--- a/README.md",
+        "+++ b/README.md",
+      ].join("\n"),
+    });
+
+    expect(review.findings).toEqual([]);
+
+    const request = provider.generateText.mock.calls[0]?.[0];
+    expect(request?.prompt).toContain("Review classification: standard.");
+    expect(request?.prompt).toContain(
+      "Classification signal: No added or removed lines were detected in the diff."
     );
     expect(request?.prompt).not.toContain("This diff is documentation-heavy");
   });

--- a/packages/core/src/pr-review.ts
+++ b/packages/core/src/pr-review.ts
@@ -105,6 +105,16 @@ function classifyReviewDiff(diff: string): ReviewClassification {
     (sum, file) => sum + file.changedLines,
     0
   );
+  if (totalChangedLines === 0) {
+    return {
+      mode: "standard",
+      signals: [
+        `Changed files: ${fileStats.length}; doc-like files: ${docFiles.length}.`,
+        "No added or removed lines were detected in the diff.",
+      ],
+    };
+  }
+
   const docChangedLines = docFiles.reduce(
     (sum, file) => sum + file.changedLines,
     0


### PR DESCRIPTION
Closes #62

<!-- git-ai:pr-assistant:start -->
## PR Assistant

### Summary
This pull request enhances the test coverage for the PR review process, specifically focusing on the handling of higher-level findings and the classification of documentation-heavy diffs. It introduces new test cases to ensure that malformed findings are correctly rejected and that the system behaves predictably when no findings are necessary.

### Key changes
- Added tests to validate rejection of malformed higher-level findings in PRReviewOutput.
- Implemented a check to reject cases where more than three higher-level findings are provided.
- Enhanced the generatePRReview function to classify diffs as standard when no higher-level findings are needed and to handle documentation-heavy diffs appropriately.

### Risk areas
No additional diff-grounded risk areas identified.

### Reviewer focus
- Verify that the new tests for malformed findings and the limit on higher-level findings are comprehensive and correctly implemented.
- Check that the classification logic for documentation-heavy and standard diffs behaves as expected under various scenarios.
<!-- git-ai:pr-assistant:end -->