### PR TITLE
Fix: Extract CLI command handlers and PR fix-comments workflow out of index.ts

### DIFF
--- a/packages/cli/src/commands/pr.ts
+++ b/packages/cli/src/commands/pr.ts
@@ -1,0 +1,31 @@
+export type PrCommandOptions = {
+  action: "fix-comments";
+  prNumber: number;
+};
+
+export const PR_USAGE = [
+  "Usage:",
+  "  git-ai pr fix-comments <pr-number>",
+].join("\n");
+
+export function parsePrCommandArgs(
+  args: string[],
+  parseIssueNumber: (rawValue: string | undefined) => number
+): PrCommandOptions {
+  const prArgs = args.slice(1);
+  const subcommand = prArgs[0];
+
+  if (subcommand !== "fix-comments") {
+    throw new Error(`Unknown pr subcommand "${subcommand ?? ""}". ${PR_USAGE}`);
+  }
+
+  const optionArgs = prArgs.slice(2);
+  if (optionArgs.length > 0) {
+    throw new Error(`Unknown pr option "${optionArgs[0]}". ${PR_USAGE}`);
+  }
+
+  return {
+    action: "fix-comments",
+    prNumber: parseIssueNumber(prArgs[1]),
+  };
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,7 +2,7 @@
 
 import { execFileSync, spawnSync } from "node:child_process";
 import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { relative, resolve } from "node:path";
+import { resolve } from "node:path";
 import { createInterface } from "node:readline/promises";
 import {
   analyzeFeatureBacklog,
@@ -21,15 +21,19 @@ import {
   loadResolvedRepositoryConfig,
 } from "./config";
 import {
+  parsePrCommandArgs as parsePrCommandArgsImpl,
+  type PrCommandOptions,
+} from "./commands/pr";
+import {
   createRepositoryForge,
   type CreatedIssueRecord,
   type IssueDetails,
   type IssuePlanComment,
-  type PullRequestDetails,
-  type PullRequestReviewComment,
   type RepositoryForge,
 } from "./forge";
 import { resolveRuntimeRepoRoot } from "./repo-root";
+import { formatRunTimestamp, toRepoRelativePath } from "./run-artifacts";
+import { runPrFixCommentsCommand } from "./workflows/pr-fix-comments/run";
 
 type IssueWorkspace = {
   issueDir: string;
@@ -38,41 +42,6 @@ type IssueWorkspace = {
   promptFilePath: string;
   metadataFilePath: string;
   outputLogPath: string;
-};
-
-type PullRequestFixWorkspace = {
-  runDir: string;
-  snapshotFilePath: string;
-  promptFilePath: string;
-  metadataFilePath: string;
-  outputLogPath: string;
-};
-
-type PullRequestReviewThread = {
-  threadId: number;
-  path: string;
-  startLine?: number;
-  endLine?: number;
-  anchorLine?: number;
-  rootComment: PullRequestReviewComment;
-  comments: PullRequestReviewComment[];
-  actionableComments: PullRequestReviewComment[];
-  summary: string;
-};
-
-type PullRequestReviewTask = {
-  taskId: string;
-  kind: "group" | "thread";
-  path: string;
-  startLine?: number;
-  endLine?: number;
-  summary: string;
-  comments: PullRequestReviewComment[];
-  threads: PullRequestReviewThread[];
-};
-
-type PullRequestLinkedIssueContext = IssueDetails & {
-  number: number;
 };
 
 type IssueExecutionMode = "local" | "github-action";
@@ -86,11 +55,6 @@ type IssueCommandOptions =
   | {
       action: "draft";
     };
-
-type PrCommandOptions = {
-  action: "fix-comments";
-  prNumber: number;
-};
 
 type GeneratedIssueDraft = Awaited<ReturnType<typeof generateIssueDraft>>;
 type GeneratedIssueResolutionPlan = Awaited<
@@ -164,11 +128,6 @@ const REVIEW_USAGE = [
   "Usage:",
   "  git-ai review [--base <git-ref>] [--head <git-ref>] [--format <markdown|json>]",
   "                [--issue-number <number>]",
-].join("\n");
-
-const PR_USAGE = [
-  "Usage:",
-  "  git-ai pr fix-comments <pr-number>",
 ].join("\n");
 
 function getCliArgs(): string[] {
@@ -570,22 +529,7 @@ export function parseIssueCommandArgs(args: string[]): IssueCommandOptions {
 }
 
 export function parsePrCommandArgs(args: string[]): PrCommandOptions {
-  const prArgs = args.slice(1);
-  const subcommand = prArgs[0];
-
-  if (subcommand !== "fix-comments") {
-    throw new Error(`Unknown pr subcommand "${subcommand ?? ""}". ${PR_USAGE}`);
-  }
-
-  const optionArgs = prArgs.slice(2);
-  if (optionArgs.length > 0) {
-    throw new Error(`Unknown pr option "${optionArgs[0]}". ${PR_USAGE}`);
-  }
-
-  return {
-    action: "fix-comments",
-    prNumber: parseIssueNumber(prArgs[1]),
-  };
+  return parsePrCommandArgsImpl(args, parseIssueNumber);
 }
 
 function parsePositiveInteger(value: string | undefined, flagName: string): number {
@@ -1007,27 +951,6 @@ function createIssueDraftFilePath(repoRoot: string): string {
   return resolve(issueDir, `issue-draft-${formatRunTimestamp()}.md`);
 }
 
-function toRepoRelativePath(repoRoot: string, filePath: string): string {
-  return (relative(repoRoot, filePath) || ".").split("\\").join("/");
-}
-
-function formatRunTimestamp(date = new Date()): string {
-  const pad = (value: number, length = 2): string =>
-    String(value).padStart(length, "0");
-
-  return [
-    `${date.getUTCFullYear()}`,
-    pad(date.getUTCMonth() + 1),
-    pad(date.getUTCDate()),
-    "T",
-    pad(date.getUTCHours()),
-    pad(date.getUTCMinutes()),
-    pad(date.getUTCSeconds()),
-    pad(date.getUTCMilliseconds(), 3),
-    "Z",
-  ].join("");
-}
-
 function createIssueWorkspace(
   repoRoot: string,
   issueNumber: number,
@@ -1049,28 +972,6 @@ function createIssueWorkspace(
     issueDir,
     issueFilePath: resolve(issueDir, "issue.md"),
     runDir,
-    promptFilePath: resolve(runDir, "prompt.md"),
-    metadataFilePath: resolve(runDir, "metadata.json"),
-    outputLogPath: resolve(runDir, "output.log"),
-  };
-}
-
-function createPullRequestFixWorkspace(
-  repoRoot: string,
-  prNumber: number
-): PullRequestFixWorkspace {
-  const runDir = resolve(
-    repoRoot,
-    ".git-ai",
-    "runs",
-    `${formatRunTimestamp()}-pr-${prNumber}-fix-comments`
-  );
-
-  mkdirSync(runDir, { recursive: true });
-
-  return {
-    runDir,
-    snapshotFilePath: resolve(runDir, "pr-review-comments.md"),
     promptFilePath: resolve(runDir, "prompt.md"),
     metadataFilePath: resolve(runDir, "metadata.json"),
     outputLogPath: resolve(runDir, "output.log"),
@@ -1104,487 +1005,6 @@ function formatIssueSnapshot(
       "",
       stripIssuePlanCommentMarker(planComment.body)
     );
-  }
-
-  lines.push("");
-  return lines.join("\n");
-}
-
-function getReviewCommentDisplayLine(comment: PullRequestReviewComment): number | undefined {
-  return (
-    comment.line ??
-    comment.originalLine ??
-    comment.startLine ??
-    comment.originalStartLine
-  );
-}
-
-function getReviewCommentLineRange(
-  comment: PullRequestReviewComment
-): { startLine?: number; endLine?: number } {
-  const endLine =
-    comment.line ?? comment.originalLine ?? getReviewCommentDisplayLine(comment);
-  const startLine = comment.startLine ?? comment.originalStartLine ?? endLine;
-
-  return {
-    startLine,
-    endLine,
-  };
-}
-
-function formatReviewCommentLineRange(startLine?: number, endLine?: number): string {
-  if (startLine === undefined && endLine === undefined) {
-    return "Unknown";
-  }
-
-  if (startLine === undefined) {
-    return String(endLine);
-  }
-
-  if (endLine === undefined || startLine === endLine) {
-    return String(startLine);
-  }
-
-  return `${startLine}-${endLine}`;
-}
-
-function isTriviallyNonActionableReviewCommentBody(body: string): boolean {
-  const normalizedBody = body.trim().toLowerCase();
-  if (!normalizedBody) {
-    return true;
-  }
-
-  return [
-    /^\+1$/,
-    /^lgtm[.!]?$/,
-    /^looks good(?: to me)?[.!]?$/,
-    /^nice work[.!]?$/,
-    /^great work[.!]?$/,
-    /^thanks[.!]?$/,
-    /^thank you[.!]?$/,
-    /^resolved[.!]?$/,
-    /^done[.!]?$/,
-    /^approved[.!]?$/,
-  ].some((pattern) => pattern.test(normalizedBody));
-}
-
-function hasReviewCommentTaskContext(comment: PullRequestReviewComment): boolean {
-  return Boolean(comment.path.trim()) && getReviewCommentDisplayLine(comment) !== undefined;
-}
-
-function isActionablePullRequestReviewComment(comment: PullRequestReviewComment): boolean {
-  if (!hasReviewCommentTaskContext(comment)) {
-    return false;
-  }
-
-  return !isTriviallyNonActionableReviewCommentBody(comment.body);
-}
-
-function shouldRetainPullRequestReviewCommentInThread(
-  comment: PullRequestReviewComment
-): boolean {
-  if (!hasReviewCommentTaskContext(comment)) {
-    return false;
-  }
-
-  return !isTriviallyNonActionableReviewCommentBody(comment.body);
-}
-
-function summarizeReviewCommentBody(body: string): string {
-  const normalized = body.replace(/\s+/g, " ").trim();
-  if (normalized.length <= 140) {
-    return normalized;
-  }
-
-  return `${normalized.slice(0, 137)}...`;
-}
-
-function resolvePullRequestReviewThreadId(
-  comment: PullRequestReviewComment,
-  commentsById: Map<number, PullRequestReviewComment>
-): number {
-  let current = comment;
-  const visited = new Set<number>();
-
-  while (current.inReplyToId !== undefined && !visited.has(current.inReplyToId)) {
-    const parent = commentsById.get(current.inReplyToId);
-    if (!parent) {
-      break;
-    }
-
-    visited.add(current.id);
-    current = parent;
-  }
-
-  return current.id;
-}
-
-function formatPullRequestReviewThreadSummary(thread: PullRequestReviewThread): string {
-  const summaries = [...new Set(thread.actionableComments.map((comment) => summarizeReviewCommentBody(comment.body)))];
-  if (summaries.length === 0) {
-    return summarizeReviewCommentBody(thread.rootComment.body);
-  }
-
-  if (summaries.length === 1) {
-    return summaries[0];
-  }
-
-  const visibleSummaries = summaries.slice(0, 2);
-  const suffix =
-    summaries.length > visibleSummaries.length
-      ? ` (+${summaries.length - visibleSummaries.length} more)`
-      : "";
-  return `${visibleSummaries.join(" / ")}${suffix}`;
-}
-
-function buildPullRequestReviewThreads(
-  comments: PullRequestReviewComment[]
-): PullRequestReviewThread[] {
-  const retainedComments = comments.filter(shouldRetainPullRequestReviewCommentInThread);
-  const commentsById = new Map(comments.map((comment) => [comment.id, comment]));
-  const commentsByThreadId = new Map<number, PullRequestReviewComment[]>();
-
-  for (const comment of retainedComments) {
-    const threadId = resolvePullRequestReviewThreadId(comment, commentsById);
-    const existing = commentsByThreadId.get(threadId);
-    if (existing) {
-      existing.push(comment);
-    } else {
-      commentsByThreadId.set(threadId, [comment]);
-    }
-  }
-
-  const threads: PullRequestReviewThread[] = [];
-
-  for (const [threadId, threadComments] of commentsByThreadId.entries()) {
-    const sortedComments = [...threadComments].sort((left, right) => {
-      const createdAtComparison =
-        Date.parse(left.createdAt) - Date.parse(right.createdAt);
-      if (createdAtComparison !== 0) {
-        return createdAtComparison;
-      }
-
-      return left.id - right.id;
-    });
-    const actionableComments = sortedComments.filter(isActionablePullRequestReviewComment);
-    if (actionableComments.length === 0) {
-      continue;
-    }
-
-    const rootComment =
-      sortedComments.find((comment) => comment.id === threadId) ?? sortedComments[0];
-    const ranges = sortedComments.map(getReviewCommentLineRange);
-    const lineNumbers = ranges.flatMap(({ startLine, endLine }) =>
-      [startLine, endLine].filter((line): line is number => line !== undefined)
-    );
-    const anchorLine = getReviewCommentDisplayLine(rootComment);
-    const baseThread = {
-      threadId,
-      path: rootComment.path,
-      startLine: lineNumbers.length > 0 ? Math.min(...lineNumbers) : anchorLine,
-      endLine: lineNumbers.length > 0 ? Math.max(...lineNumbers) : anchorLine,
-      anchorLine,
-      rootComment,
-      comments: sortedComments,
-      actionableComments,
-    };
-
-    threads.push({
-      ...baseThread,
-      summary: formatPullRequestReviewThreadSummary({ ...baseThread, summary: "" }),
-    });
-  }
-
-  return threads.sort((left, right) => {
-    const pathComparison = left.path.localeCompare(right.path);
-    if (pathComparison !== 0) {
-      return pathComparison;
-    }
-
-    const lineComparison =
-      (left.startLine ?? Number.MAX_SAFE_INTEGER) -
-      (right.startLine ?? Number.MAX_SAFE_INTEGER);
-    if (lineComparison !== 0) {
-      return lineComparison;
-    }
-
-    return left.threadId - right.threadId;
-  });
-}
-
-function shouldGroupPullRequestReviewThreads(
-  currentGroup: PullRequestReviewThread[],
-  nextThread: PullRequestReviewThread
-): boolean {
-  const previousThread = currentGroup[currentGroup.length - 1];
-  if (previousThread.path !== nextThread.path) {
-    return false;
-  }
-
-  const previousEndLine = previousThread.endLine ?? previousThread.startLine;
-  const nextStartLine = nextThread.startLine ?? nextThread.endLine;
-  if (previousEndLine !== undefined && nextStartLine !== undefined) {
-    return nextStartLine <= previousEndLine + 12;
-  }
-
-  const previousDiffHunks = new Set(
-    previousThread.comments
-      .map((comment) => comment.diffHunk?.trim())
-      .filter((diffHunk): diffHunk is string => Boolean(diffHunk))
-  );
-  return nextThread.comments.some(
-    (comment) => comment.diffHunk?.trim() && previousDiffHunks.has(comment.diffHunk.trim())
-  );
-}
-
-function formatPullRequestReviewTaskSummary(threads: PullRequestReviewThread[]): string {
-  const summaries = [...new Set(threads.map((thread) => thread.summary))];
-  if (summaries.length === 1) {
-    return summaries[0];
-  }
-
-  const visibleSummaries = summaries.slice(0, 2);
-  const suffix =
-    summaries.length > visibleSummaries.length
-      ? ` (+${summaries.length - visibleSummaries.length} more)`
-      : "";
-  return `${visibleSummaries.join(" / ")}${suffix}`;
-}
-
-function createPullRequestReviewTask(
-  kind: "group" | "thread",
-  taskId: string,
-  threads: PullRequestReviewThread[]
-): PullRequestReviewTask {
-  const lineNumbers = threads.flatMap((thread) =>
-    [thread.startLine, thread.endLine].filter((line): line is number => line !== undefined)
-  );
-  const commentsById = new Map<number, PullRequestReviewComment>();
-  for (const thread of threads) {
-    for (const comment of thread.comments) {
-      commentsById.set(comment.id, comment);
-    }
-  }
-
-  return {
-    taskId,
-    kind,
-    path: threads[0]?.path ?? "",
-    startLine: lineNumbers.length > 0 ? Math.min(...lineNumbers) : undefined,
-    endLine: lineNumbers.length > 0 ? Math.max(...lineNumbers) : undefined,
-    summary: formatPullRequestReviewTaskSummary(threads),
-    comments: [...commentsById.values()].sort((left, right) => left.id - right.id),
-    threads,
-  };
-}
-
-function buildPullRequestReviewTasks(
-  comments: PullRequestReviewComment[]
-): { groupTasks: PullRequestReviewTask[]; threadTasks: PullRequestReviewTask[] } {
-  const threads = buildPullRequestReviewThreads(comments);
-  const threadTasks = threads.map((thread) =>
-    createPullRequestReviewTask("thread", `thread-${thread.threadId}`, [thread])
-  );
-  const groupTasks: PullRequestReviewTask[] = [];
-
-  let currentGroup: PullRequestReviewThread[] = [];
-  for (const thread of threads) {
-    if (currentGroup.length === 0 || shouldGroupPullRequestReviewThreads(currentGroup, thread)) {
-      currentGroup.push(thread);
-      continue;
-    }
-
-    if (currentGroup.length > 1) {
-      groupTasks.push(
-        createPullRequestReviewTask("group", `group-${groupTasks.length + 1}`, currentGroup)
-      );
-    }
-    currentGroup = [thread];
-  }
-
-  if (currentGroup.length > 1) {
-    groupTasks.push(
-      createPullRequestReviewTask("group", `group-${groupTasks.length + 1}`, currentGroup)
-    );
-  }
-
-  return {
-    groupTasks,
-    threadTasks,
-  };
-}
-
-function formatLocalFileExcerpt(
-  repoRoot: string,
-  filePath: string,
-  startLine?: number,
-  endLine?: number
-): string | undefined {
-  const excerptStartLine = startLine ?? endLine;
-  const excerptEndLine = endLine ?? startLine;
-  if (excerptStartLine === undefined || excerptEndLine === undefined) {
-    return undefined;
-  }
-
-  try {
-    const fileContents = readFileSync(resolve(repoRoot, filePath), "utf8");
-    if (fileContents.includes("\u0000")) {
-      return undefined;
-    }
-
-    const lines = fileContents.split(/\r?\n/);
-    const firstLine = Math.max(1, excerptStartLine - 4);
-    const lastLine = Math.min(lines.length, excerptEndLine + 4);
-    const lineNumberWidth = String(lastLine).length;
-
-    return lines
-      .slice(firstLine - 1, lastLine)
-      .map(
-        (line, index) =>
-          `${String(firstLine + index).padStart(lineNumberWidth, " ")} | ${line}`
-      )
-      .join("\n");
-  } catch {
-    return undefined;
-  }
-}
-
-function formatPullRequestReviewTaskLocation(task: PullRequestReviewTask): string {
-  const lineRange = formatReviewCommentLineRange(task.startLine, task.endLine);
-  return lineRange === "Unknown" ? task.path : `${task.path}:${lineRange}`;
-}
-
-async function fetchLinkedIssuesForPullRequest(
-  forge: RepositoryForge,
-  pullRequest: PullRequestDetails
-): Promise<PullRequestLinkedIssueContext[]> {
-  const linkedIssueNumbers = new Set<number>();
-  for (const match of pullRequest.body.matchAll(
-    /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/gi
-  )) {
-    const parsed = Number.parseInt(match[1] ?? "", 10);
-    if (Number.isSafeInteger(parsed) && parsed > 0) {
-      linkedIssueNumbers.add(parsed);
-    }
-  }
-
-  const linkedIssues: PullRequestLinkedIssueContext[] = [];
-  for (const issueNumber of [...linkedIssueNumbers].sort((left, right) => left - right)) {
-    try {
-      const issue = await forge.fetchIssueDetails(issueNumber);
-      linkedIssues.push({
-        number: issueNumber,
-        ...issue,
-      });
-    } catch {
-      continue;
-    }
-  }
-
-  return linkedIssues;
-}
-
-function formatPullRequestReviewCommentsSnapshot(
-  repoRoot: string,
-  pullRequest: PullRequestDetails,
-  tasks: PullRequestReviewTask[],
-  linkedIssues: PullRequestLinkedIssueContext[]
-): string {
-  const pullRequestBody = pullRequest.body.trim() || "(No pull request body provided.)";
-  const lines = [
-    "# Pull Request Review Fix Snapshot",
-    "",
-    "## Pull Request",
-    "",
-    `- PR number: ${pullRequest.number}`,
-    `- Title: ${pullRequest.title}`,
-    `- URL: ${pullRequest.url}`,
-    `- Base branch: ${pullRequest.baseRefName}`,
-    `- Head branch: ${pullRequest.headRefName}`,
-    "",
-    "## Body",
-    "",
-    pullRequestBody,
-  ];
-
-  if (linkedIssues.length > 0) {
-    lines.push("", "## Linked issues");
-
-    for (const issue of linkedIssues) {
-      lines.push(
-        "",
-        `### Issue #${issue.number}: ${issue.title}`,
-        "",
-        `- URL: ${issue.url}`,
-        "",
-        issue.body.trim() || "(No issue body provided.)"
-      );
-    }
-  }
-
-  lines.push("", "## Selected review tasks");
-
-  for (const [index, task] of tasks.entries()) {
-    lines.push(
-      "",
-      `### Task ${index + 1}`,
-      "",
-      `- Selection type: ${task.kind === "group" ? "Grouped review task" : "Review thread"}`,
-      `- File: ${task.path}`,
-      `- Lines: ${formatReviewCommentLineRange(task.startLine, task.endLine)}`,
-      `- Threads: ${task.threads.length}`,
-      `- Comments: ${task.comments.length}`,
-      `- Summary: ${task.summary}`,
-      "",
-      "#### Success looks like",
-      "",
-      "- Address each actionable review point captured in this task.",
-      "- Preserve any clarifications from follow-up review replies.",
-      "- Leave the affected code in a state that passes the configured verification command."
-    );
-
-    for (const [threadIndex, thread] of task.threads.entries()) {
-      lines.push(
-        "",
-        `#### Thread ${threadIndex + 1}`,
-        "",
-        `- Root comment ID: ${thread.rootComment.id}`,
-        `- Reviewer: ${thread.rootComment.author}`,
-        `- URL: ${thread.rootComment.url}`,
-        `- Lines: ${formatReviewCommentLineRange(thread.startLine, thread.endLine)}`,
-        `- Summary: ${thread.summary}`,
-        "",
-        "##### Thread conversation"
-      );
-
-      for (const comment of thread.comments) {
-        lines.push(
-          "",
-          `${comment.author} (${comment.updatedAt})`,
-          "",
-          comment.body.trim()
-        );
-      }
-
-      const diffHunks = [...new Set(
-        thread.comments
-          .map((comment) => comment.diffHunk?.trim())
-          .filter((diffHunk): diffHunk is string => Boolean(diffHunk))
-      )];
-      if (diffHunks.length > 0) {
-        lines.push("", "##### Diff hunk", "", "```diff", diffHunks[0], "```");
-      }
-
-      const localExcerpt = formatLocalFileExcerpt(
-        repoRoot,
-        thread.path,
-        thread.startLine,
-        thread.endLine
-      );
-      if (localExcerpt) {
-        lines.push("", "##### Local file excerpt", "", "```text", localExcerpt, "```");
-      }
-    }
   }
 
   lines.push("");
@@ -1629,31 +1049,6 @@ function buildCodexPrompt(
     "- keep code changes focused on the issue snapshot",
     "- follow existing architecture patterns",
     "- if the issue snapshot includes a resolution plan, treat it as the latest plan of record",
-    `- run \`${formatCommandForDisplay(buildCommand)}\` before finishing if code changes are made`,
-    "- do not modify `.git-ai/` unless needed for local workflow artifacts",
-    "- do not commit `.git-ai/` files",
-  ].join("\n");
-}
-
-function buildPullRequestFixCodexPrompt(
-  repoRoot: string,
-  workspace: PullRequestFixWorkspace,
-  buildCommand: string[]
-): string {
-  const snapshotFile = toRepoRelativePath(repoRoot, workspace.snapshotFilePath);
-  const runDir = toRepoRelativePath(repoRoot, workspace.runDir);
-
-  return [
-    "You are working in the current repository.",
-    "",
-    `Read the pull request review fix snapshot at \`${snapshotFile}\` before making changes.`,
-    `Use \`${runDir}\` for run artifacts created by this workflow.`,
-    "",
-    "Instructions to Codex:",
-    "- analyze the repository only as needed for the selected review tasks",
-    "- keep code changes focused on addressing the selected review tasks",
-    "- follow existing architecture patterns",
-    "- verify each selected review thread or grouped task is fully addressed before finishing",
     `- run \`${formatCommandForDisplay(buildCommand)}\` before finishing if code changes are made`,
     "- do not modify `.git-ai/` unless needed for local workflow artifacts",
     "- do not commit `.git-ai/` files",
@@ -1707,79 +1102,6 @@ function writeIssueWorkspaceFiles(
       "",
       `Created: ${createdAt}`,
       `Issue snapshot: ${toRepoRelativePath(repoRoot, workspace.issueFilePath)}`,
-      `Prompt file: ${toRepoRelativePath(repoRoot, workspace.promptFilePath)}`,
-      "",
-    ].join("\n"),
-    "utf8"
-  );
-}
-
-function writePullRequestFixWorkspaceFiles(
-  repoRoot: string,
-  pullRequest: PullRequestDetails,
-  tasks: PullRequestReviewTask[],
-  workspace: PullRequestFixWorkspace,
-  buildCommand: string[],
-  linkedIssues: PullRequestLinkedIssueContext[]
-): void {
-  const createdAt = new Date().toISOString();
-  const prompt = buildPullRequestFixCodexPrompt(repoRoot, workspace, buildCommand);
-  const selectedComments = tasks.flatMap((task) => task.comments);
-
-  writeFileSync(
-    workspace.snapshotFilePath,
-    formatPullRequestReviewCommentsSnapshot(repoRoot, pullRequest, tasks, linkedIssues),
-    "utf8"
-  );
-  writeFileSync(workspace.promptFilePath, `${prompt}\n`, "utf8");
-  writeFileSync(
-    workspace.metadataFilePath,
-    `${JSON.stringify(
-      {
-        createdAt,
-        prNumber: pullRequest.number,
-        prTitle: pullRequest.title,
-        prUrl: pullRequest.url,
-        baseRefName: pullRequest.baseRefName,
-        headRefName: pullRequest.headRefName,
-        snapshotFile: toRepoRelativePath(repoRoot, workspace.snapshotFilePath),
-        promptFile: toRepoRelativePath(repoRoot, workspace.promptFilePath),
-        outputLog: toRepoRelativePath(repoRoot, workspace.outputLogPath),
-        runDir: toRepoRelativePath(repoRoot, workspace.runDir),
-        linkedIssues: linkedIssues.map((issue) => ({
-          number: issue.number,
-          title: issue.title,
-          url: issue.url,
-        })),
-        selectedTasks: tasks.map((task) => ({
-          id: task.taskId,
-          kind: task.kind,
-          path: task.path,
-          startLine: task.startLine,
-          endLine: task.endLine,
-          summary: task.summary,
-          threadIds: task.threads.map((thread) => thread.threadId),
-          commentIds: task.comments.map((comment) => comment.id),
-        })),
-        selectedComments: selectedComments.map((comment) => ({
-          id: comment.id,
-          path: comment.path,
-          line: getReviewCommentDisplayLine(comment),
-          url: comment.url,
-        })),
-      },
-      null,
-      2
-    )}\n`,
-    "utf8"
-  );
-  writeFileSync(
-    workspace.outputLogPath,
-    [
-      "# git-ai pr fix-comments run log",
-      "",
-      `Created: ${createdAt}`,
-      `Snapshot file: ${toRepoRelativePath(repoRoot, workspace.snapshotFilePath)}`,
       `Prompt file: ${toRepoRelativePath(repoRoot, workspace.promptFilePath)}`,
       "",
     ].join("\n"),
@@ -2201,200 +1523,23 @@ async function runReviewCommand(): Promise<void> {
   process.stdout.write(`${formatPRReviewMarkdown(result, issue, options.issueNumber)}\n`);
 }
 
-function printPullRequestReviewTasks(
-  pullRequest: PullRequestDetails,
-  groupTasks: PullRequestReviewTask[],
-  threadTasks: PullRequestReviewTask[]
-): void {
-  console.log(`Actionable review tasks for PR #${pullRequest.number}: ${pullRequest.title}`);
-  const paths = [...new Set(threadTasks.map((task) => task.path))];
-
-  for (const path of paths) {
-    const fileGroupTasks = groupTasks.filter((task) => task.path === path);
-    const fileThreadTasks = threadTasks.filter((task) => task.path === path);
-
-    console.log("");
-    console.log(path);
-
-    for (const groupTask of fileGroupTasks) {
-      const groupNumber =
-        groupTasks.findIndex((task) => task.taskId === groupTask.taskId) + 1;
-      console.log(
-        `  g${groupNumber}. ${formatPullRequestReviewTaskLocation(groupTask)} (${groupTask.threads.length} threads, ${groupTask.comments.length} comments)`
-      );
-      console.log(`      ${groupTask.summary}`);
-    }
-
-    for (const threadTask of fileThreadTasks) {
-      const threadNumber =
-        threadTasks.findIndex((task) => task.taskId === threadTask.taskId) + 1;
-      const thread = threadTask.threads[0];
-      const commentLabel = thread.comments.length === 1 ? "comment" : "comments";
-
-      console.log(
-        `  ${threadNumber}. ${formatPullRequestReviewTaskLocation(threadTask)} by ${thread.rootComment.author} (${thread.comments.length} ${commentLabel})`
-      );
-      console.log(`      ${threadTask.summary}`);
-      if (thread.comments.length > 1) {
-        const replyAuthors = [...new Set(thread.comments.slice(1).map((comment) => comment.author))];
-        if (replyAuthors.length > 0) {
-          console.log(`      Thread context from: ${replyAuthors.join(", ")}`);
-        }
-      }
-    }
-  }
-}
-
-function shouldCommitGeneratedChanges(response: string): boolean {
-  const normalized = response.trim().toLowerCase();
-  if (!normalized) {
-    return true;
-  }
-
-  return ["y", "yes"].includes(normalized);
-}
-
-async function selectPullRequestReviewComments(
-  pullRequest: PullRequestDetails,
-  comments: PullRequestReviewComment[]
-): Promise<PullRequestReviewTask[]> {
-  const { groupTasks, threadTasks } = buildPullRequestReviewTasks(comments);
-  printPullRequestReviewTasks(pullRequest, groupTasks, threadTasks);
-
-  const selectionPrompt =
-    groupTasks.length > 0
-      ? "Select tasks to address [all|none|g1,2,...] (`all` selects every individual thread): "
-      : "Select tasks to address [all|none|1,2,...]: ";
-  const selection = await promptForLine(selectionPrompt);
-  const selectedEntries = parsePullRequestReviewSelection(
-    selection,
-    threadTasks.length,
-    groupTasks.length
-  );
-  const selectedGroupIndexes = new Set(
-    selectedEntries
-      .filter((entry) => entry.kind === "group")
-      .map((entry) => entry.index)
-  );
-  const coveredThreadIds = new Set(
-    [...selectedGroupIndexes].flatMap((groupIndex) =>
-      groupTasks[groupIndex]?.threads.map((thread) => thread.threadId) ?? []
-    )
-  );
-  const selectedTasks: PullRequestReviewTask[] = [];
-  const addedTaskIds = new Set<string>();
-
-  for (const entry of selectedEntries) {
-    if (entry.kind === "group") {
-      const task = groupTasks[entry.index];
-      if (!task || addedTaskIds.has(task.taskId)) {
-        continue;
-      }
-
-      selectedTasks.push(task);
-      addedTaskIds.add(task.taskId);
-      continue;
-    }
-
-    const task = threadTasks[entry.index];
-    if (!task || addedTaskIds.has(task.taskId)) {
-      continue;
-    }
-
-    const thread = task.threads[0];
-    if (coveredThreadIds.has(thread.threadId)) {
-      continue;
-    }
-
-    selectedTasks.push(task);
-    addedTaskIds.add(task.taskId);
-  }
-
-  return selectedTasks;
-}
-
 async function runPrCommand(): Promise<void> {
   const repoRoot = getDefaultRepoRoot();
   const prCommand = parsePrCommandArgs(getCliArgs());
-  const forge = getRepositoryForge(repoRoot);
   const repositoryConfig = getRepositoryConfig(repoRoot);
 
-  if (forge.type === "none") {
-    throw new Error(
-      "Repository forge support is disabled by .git-ai/config.json. Configure `forge.type` to enable pull request workflows."
-    );
-  }
-
-  ensureCleanWorkingTree(repoRoot);
-
-  console.log(`Fetching pull request #${prCommand.prNumber}...`);
-  const pullRequest = await forge.fetchPullRequestDetails(prCommand.prNumber);
-  const linkedIssues = await fetchLinkedIssuesForPullRequest(forge, pullRequest);
-  const comments = (await forge.fetchPullRequestReviewComments(prCommand.prNumber))
-    .filter(shouldRetainPullRequestReviewCommentInThread)
-    .sort((left, right) => {
-      const pathComparison = left.path.localeCompare(right.path);
-      if (pathComparison !== 0) {
-        return pathComparison;
-      }
-
-      const lineComparison =
-        (getReviewCommentDisplayLine(left) ?? Number.MAX_SAFE_INTEGER) -
-        (getReviewCommentDisplayLine(right) ?? Number.MAX_SAFE_INTEGER);
-      if (lineComparison !== 0) {
-        return lineComparison;
-      }
-
-      return left.id - right.id;
-    });
-
-  if (buildPullRequestReviewThreads(comments).length === 0) {
-    throw new Error(
-      `No actionable pull request review comments were found for PR #${prCommand.prNumber}.`
-    );
-  }
-
-  const selectedTasks = await selectPullRequestReviewComments(pullRequest, comments);
-  if (selectedTasks.length === 0) {
-    console.log("No review tasks selected. Exiting without changes.");
-    return;
-  }
-
-  const workspace = createPullRequestFixWorkspace(repoRoot, pullRequest.number);
-  writePullRequestFixWorkspaceFiles(
+  await runPrFixCommentsCommand({
+    prNumber: prCommand.prNumber,
     repoRoot,
-    pullRequest,
-    selectedTasks,
-    workspace,
-    repositoryConfig.buildCommand,
-    linkedIssues
-  );
-
-  console.log("Opening an interactive Codex session in this terminal...");
-  console.log("Complete the selected review task fixes in Codex.");
-  console.log("When Codex exits, git-ai will resume with build and commit steps.");
-  runCodex(repoRoot, workspace);
-
-  console.log("Verifying build...");
-  verifyBuild(repoRoot, repositoryConfig.buildCommand, workspace.outputLogPath);
-
-  if (!hasChanges(repoRoot)) {
-    throw new Error("Codex completed without producing any file changes to commit.");
-  }
-
-  const commitNow = shouldCommitGeneratedChanges(
-    await promptForLine("Commit fixes now? [Y/n]: ")
-  );
-  if (!commitNow) {
-    console.log("Leaving the generated changes uncommitted.");
-    return;
-  }
-
-  console.log("Committing generated changes...");
-  commitGeneratedChanges(
-    repoRoot,
-    `fix: address PR review comments for #${pullRequest.number}`
-  );
+    buildCommand: repositoryConfig.buildCommand,
+    forge: getRepositoryForge(repoRoot),
+    ensureCleanWorkingTree,
+    promptForLine,
+    runCodex,
+    verifyBuild,
+    hasChanges,
+    commitGeneratedChanges,
+  });
 }
 
 function formatTestBacklogMarkdown(
@@ -2592,77 +1737,6 @@ function parseNumberedSelection(
   }
 
   return [...selected].sort((left, right) => left - right);
-}
-
-function parsePullRequestReviewSelection(
-  response: string,
-  threadCount: number,
-  groupCount: number
-): Array<{ kind: "group" | "thread"; index: number }> {
-  const normalized = response.trim().toLowerCase();
-  if (!normalized || normalized === "none" || normalized === "n") {
-    return [];
-  }
-
-  if (normalized === "all") {
-    return Array.from({ length: threadCount }, (_, index) => ({
-      kind: "thread" as const,
-      index,
-    }));
-  }
-
-  const selectedEntries: Array<{ kind: "group" | "thread"; index: number }> = [];
-  const seenEntries = new Set<string>();
-
-  for (const part of normalized.split(",")) {
-    const trimmed = part.trim();
-    if (!trimmed) {
-      continue;
-    }
-
-    if (/^g\d+$/.test(trimmed)) {
-      if (groupCount === 0) {
-        throw new Error(
-          'Invalid selection. No grouped review tasks are available for this pull request.'
-        );
-      }
-
-      const parsed = Number.parseInt(trimmed.slice(1), 10);
-      if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > groupCount) {
-        throw new Error(
-          `Invalid selection "${trimmed}". Choose group values between g1 and g${groupCount}.`
-        );
-      }
-
-      const key = `group:${parsed - 1}`;
-      if (!seenEntries.has(key)) {
-        selectedEntries.push({ kind: "group", index: parsed - 1 });
-        seenEntries.add(key);
-      }
-      continue;
-    }
-
-    if (!/^\d+$/.test(trimmed)) {
-      throw new Error(
-        'Invalid selection. Use comma-separated thread numbers, optional group values like "g1", "all", or "none".'
-      );
-    }
-
-    const parsed = Number.parseInt(trimmed, 10);
-    if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > threadCount) {
-      throw new Error(
-        `Invalid selection "${trimmed}". Choose thread values between 1 and ${threadCount}.`
-      );
-    }
-
-    const key = `thread:${parsed - 1}`;
-    if (!seenEntries.has(key)) {
-      selectedEntries.push({ kind: "thread", index: parsed - 1 });
-      seenEntries.add(key);
-    }
-  }
-
-  return selectedEntries;
 }
 
 function appendAdditionalDescription(body: string, additionalDescription: string): string {

--- a/packages/cli/src/run-artifacts.ts
+++ b/packages/cli/src/run-artifacts.ts
@@ -1,0 +1,22 @@
+import { relative } from "node:path";
+
+export function toRepoRelativePath(repoRoot: string, filePath: string): string {
+  return (relative(repoRoot, filePath) || ".").split("\\").join("/");
+}
+
+export function formatRunTimestamp(date = new Date()): string {
+  const pad = (value: number, length = 2): string =>
+    String(value).padStart(length, "0");
+
+  return [
+    `${date.getUTCFullYear()}`,
+    pad(date.getUTCMonth() + 1),
+    pad(date.getUTCDate()),
+    "T",
+    pad(date.getUTCHours()),
+    pad(date.getUTCMinutes()),
+    pad(date.getUTCSeconds()),
+    pad(date.getUTCMilliseconds(), 3),
+    "Z",
+  ].join("");
+}

--- a/packages/cli/src/workflows/pr-fix-comments/run.ts
+++ b/packages/cli/src/workflows/pr-fix-comments/run.ts
@@ -1,0 +1,250 @@
+import type {
+  PullRequestDetails,
+  PullRequestReviewComment,
+  RepositoryForge,
+} from "../../forge";
+import {
+  buildPullRequestReviewTasks,
+  buildPullRequestReviewThreads,
+  formatPullRequestReviewTaskLocation,
+  getReviewCommentDisplayLine,
+  parsePullRequestReviewSelection,
+  shouldRetainPullRequestReviewCommentInThread,
+} from "./selection";
+import { fetchLinkedIssuesForPullRequest } from "./snapshot";
+import {
+  createPullRequestFixWorkspace,
+  writePullRequestFixWorkspaceFiles,
+} from "./workspace";
+import type { PullRequestFixWorkspace, PullRequestReviewTask } from "./types";
+
+type RunPrFixCommentsCommandOptions = {
+  prNumber: number;
+  repoRoot: string;
+  buildCommand: string[];
+  forge: RepositoryForge;
+  ensureCleanWorkingTree(repoRoot: string): void;
+  promptForLine(prompt: string): Promise<string>;
+  runCodex(
+    repoRoot: string,
+    workspace: Pick<PullRequestFixWorkspace, "promptFilePath" | "outputLogPath">
+  ): void;
+  verifyBuild(repoRoot: string, buildCommand: string[], outputLogPath: string): void;
+  hasChanges(repoRoot: string): boolean;
+  commitGeneratedChanges(repoRoot: string, commitMessage: string): void;
+};
+
+function sortPullRequestReviewComments(
+  left: PullRequestReviewComment,
+  right: PullRequestReviewComment
+): number {
+  const pathComparison = left.path.localeCompare(right.path);
+  if (pathComparison !== 0) {
+    return pathComparison;
+  }
+
+  const lineComparison =
+    (getReviewCommentDisplayLine(left) ?? Number.MAX_SAFE_INTEGER) -
+    (getReviewCommentDisplayLine(right) ?? Number.MAX_SAFE_INTEGER);
+  if (lineComparison !== 0) {
+    return lineComparison;
+  }
+
+  return left.id - right.id;
+}
+
+function printPullRequestReviewTasks(
+  pullRequest: PullRequestDetails,
+  groupTasks: PullRequestReviewTask[],
+  threadTasks: PullRequestReviewTask[]
+): void {
+  console.log(`Actionable review tasks for PR #${pullRequest.number}: ${pullRequest.title}`);
+  const paths = [...new Set(threadTasks.map((task) => task.path))];
+
+  for (const path of paths) {
+    const fileGroupTasks = groupTasks.filter((task) => task.path === path);
+    const fileThreadTasks = threadTasks.filter((task) => task.path === path);
+
+    console.log("");
+    console.log(path);
+
+    for (const groupTask of fileGroupTasks) {
+      const groupNumber =
+        groupTasks.findIndex((task) => task.taskId === groupTask.taskId) + 1;
+      console.log(
+        `  g${groupNumber}. ${formatPullRequestReviewTaskLocation(groupTask)} (${groupTask.threads.length} threads, ${groupTask.comments.length} comments)`
+      );
+      console.log(`      ${groupTask.summary}`);
+    }
+
+    for (const threadTask of fileThreadTasks) {
+      const threadNumber =
+        threadTasks.findIndex((task) => task.taskId === threadTask.taskId) + 1;
+      const thread = threadTask.threads[0];
+      const commentLabel = thread.comments.length === 1 ? "comment" : "comments";
+
+      console.log(
+        `  ${threadNumber}. ${formatPullRequestReviewTaskLocation(threadTask)} by ${thread.rootComment.author} (${thread.comments.length} ${commentLabel})`
+      );
+      console.log(`      ${threadTask.summary}`);
+      if (thread.comments.length > 1) {
+        const replyAuthors = [
+          ...new Set(thread.comments.slice(1).map((comment) => comment.author)),
+        ];
+        if (replyAuthors.length > 0) {
+          console.log(`      Thread context from: ${replyAuthors.join(", ")}`);
+        }
+      }
+    }
+  }
+}
+
+function shouldCommitGeneratedChanges(response: string): boolean {
+  const normalized = response.trim().toLowerCase();
+  if (!normalized) {
+    return true;
+  }
+
+  return ["y", "yes"].includes(normalized);
+}
+
+async function selectPullRequestReviewComments(
+  pullRequest: PullRequestDetails,
+  comments: PullRequestReviewComment[],
+  promptForLine: (prompt: string) => Promise<string>
+): Promise<PullRequestReviewTask[]> {
+  const { groupTasks, threadTasks } = buildPullRequestReviewTasks(comments);
+  printPullRequestReviewTasks(pullRequest, groupTasks, threadTasks);
+
+  const selectionPrompt =
+    groupTasks.length > 0
+      ? "Select tasks to address [all|none|g1,2,...] (`all` selects every individual thread): "
+      : "Select tasks to address [all|none|1,2,...]: ";
+  const selection = await promptForLine(selectionPrompt);
+  const selectedEntries = parsePullRequestReviewSelection(
+    selection,
+    threadTasks.length,
+    groupTasks.length
+  );
+  const selectedGroupIndexes = new Set(
+    selectedEntries
+      .filter((entry) => entry.kind === "group")
+      .map((entry) => entry.index)
+  );
+  const coveredThreadIds = new Set(
+    [...selectedGroupIndexes].flatMap(
+      (groupIndex) =>
+        groupTasks[groupIndex]?.threads.map((thread) => thread.threadId) ?? []
+    )
+  );
+  const selectedTasks: PullRequestReviewTask[] = [];
+  const addedTaskIds = new Set<string>();
+
+  for (const entry of selectedEntries) {
+    if (entry.kind === "group") {
+      const task = groupTasks[entry.index];
+      if (!task || addedTaskIds.has(task.taskId)) {
+        continue;
+      }
+
+      selectedTasks.push(task);
+      addedTaskIds.add(task.taskId);
+      continue;
+    }
+
+    const task = threadTasks[entry.index];
+    if (!task || addedTaskIds.has(task.taskId)) {
+      continue;
+    }
+
+    const thread = task.threads[0];
+    if (coveredThreadIds.has(thread.threadId)) {
+      continue;
+    }
+
+    selectedTasks.push(task);
+    addedTaskIds.add(task.taskId);
+  }
+
+  return selectedTasks;
+}
+
+export async function runPrFixCommentsCommand(
+  options: RunPrFixCommentsCommandOptions
+): Promise<void> {
+  if (options.forge.type === "none") {
+    throw new Error(
+      "Repository forge support is disabled by .git-ai/config.json. Configure `forge.type` to enable pull request workflows."
+    );
+  }
+
+  options.ensureCleanWorkingTree(options.repoRoot);
+
+  console.log(`Fetching pull request #${options.prNumber}...`);
+  const pullRequest = await options.forge.fetchPullRequestDetails(options.prNumber);
+  const linkedIssues = await fetchLinkedIssuesForPullRequest(options.forge, pullRequest);
+  const comments = (
+    await options.forge.fetchPullRequestReviewComments(options.prNumber)
+  )
+    .filter(shouldRetainPullRequestReviewCommentInThread)
+    .sort(sortPullRequestReviewComments);
+
+  if (buildPullRequestReviewThreads(comments).length === 0) {
+    throw new Error(
+      `No actionable pull request review comments were found for PR #${options.prNumber}.`
+    );
+  }
+
+  const selectedTasks = await selectPullRequestReviewComments(
+    pullRequest,
+    comments,
+    options.promptForLine
+  );
+  if (selectedTasks.length === 0) {
+    console.log("No review tasks selected. Exiting without changes.");
+    return;
+  }
+
+  const workspace = createPullRequestFixWorkspace(
+    options.repoRoot,
+    pullRequest.number
+  );
+  writePullRequestFixWorkspaceFiles(
+    options.repoRoot,
+    pullRequest,
+    selectedTasks,
+    workspace,
+    options.buildCommand,
+    linkedIssues
+  );
+
+  console.log("Opening an interactive Codex session in this terminal...");
+  console.log("Complete the selected review task fixes in Codex.");
+  console.log("When Codex exits, git-ai will resume with build and commit steps.");
+  options.runCodex(options.repoRoot, workspace);
+
+  console.log("Verifying build...");
+  options.verifyBuild(
+    options.repoRoot,
+    options.buildCommand,
+    workspace.outputLogPath
+  );
+
+  if (!options.hasChanges(options.repoRoot)) {
+    throw new Error("Codex completed without producing any file changes to commit.");
+  }
+
+  const commitNow = shouldCommitGeneratedChanges(
+    await options.promptForLine("Commit fixes now? [Y/n]: ")
+  );
+  if (!commitNow) {
+    console.log("Leaving the generated changes uncommitted.");
+    return;
+  }
+
+  console.log("Committing generated changes...");
+  options.commitGeneratedChanges(
+    options.repoRoot,
+    `fix: address PR review comments for #${pullRequest.number}`
+  );
+}

--- a/packages/cli/src/workflows/pr-fix-comments/selection.ts
+++ b/packages/cli/src/workflows/pr-fix-comments/selection.ts
@@ -1,0 +1,417 @@
+import type { PullRequestReviewComment } from "../../forge";
+import type { PullRequestReviewTask, PullRequestReviewThread } from "./types";
+
+export function getReviewCommentDisplayLine(
+  comment: PullRequestReviewComment
+): number | undefined {
+  return (
+    comment.line ??
+    comment.originalLine ??
+    comment.startLine ??
+    comment.originalStartLine
+  );
+}
+
+function getReviewCommentLineRange(
+  comment: PullRequestReviewComment
+): { startLine?: number; endLine?: number } {
+  const endLine =
+    comment.line ?? comment.originalLine ?? getReviewCommentDisplayLine(comment);
+  const startLine = comment.startLine ?? comment.originalStartLine ?? endLine;
+
+  return {
+    startLine,
+    endLine,
+  };
+}
+
+export function formatReviewCommentLineRange(
+  startLine?: number,
+  endLine?: number
+): string {
+  if (startLine === undefined && endLine === undefined) {
+    return "Unknown";
+  }
+
+  if (startLine === undefined) {
+    return String(endLine);
+  }
+
+  if (endLine === undefined || startLine === endLine) {
+    return String(startLine);
+  }
+
+  return `${startLine}-${endLine}`;
+}
+
+function isTriviallyNonActionableReviewCommentBody(body: string): boolean {
+  const normalizedBody = body.trim().toLowerCase();
+  if (!normalizedBody) {
+    return true;
+  }
+
+  return [
+    /^\+1$/,
+    /^lgtm[.!]?$/,
+    /^looks good(?: to me)?[.!]?$/,
+    /^nice work[.!]?$/,
+    /^great work[.!]?$/,
+    /^thanks[.!]?$/,
+    /^thank you[.!]?$/,
+    /^resolved[.!]?$/,
+    /^done[.!]?$/,
+    /^approved[.!]?$/,
+  ].some((pattern) => pattern.test(normalizedBody));
+}
+
+function hasReviewCommentTaskContext(comment: PullRequestReviewComment): boolean {
+  return Boolean(comment.path.trim()) && getReviewCommentDisplayLine(comment) !== undefined;
+}
+
+function isActionablePullRequestReviewComment(
+  comment: PullRequestReviewComment
+): boolean {
+  if (!hasReviewCommentTaskContext(comment)) {
+    return false;
+  }
+
+  return !isTriviallyNonActionableReviewCommentBody(comment.body);
+}
+
+export function shouldRetainPullRequestReviewCommentInThread(
+  comment: PullRequestReviewComment
+): boolean {
+  if (!hasReviewCommentTaskContext(comment)) {
+    return false;
+  }
+
+  return !isTriviallyNonActionableReviewCommentBody(comment.body);
+}
+
+function summarizeReviewCommentBody(body: string): string {
+  const normalized = body.replace(/\s+/g, " ").trim();
+  if (normalized.length <= 140) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, 137)}...`;
+}
+
+function resolvePullRequestReviewThreadId(
+  comment: PullRequestReviewComment,
+  commentsById: Map<number, PullRequestReviewComment>
+): number {
+  let current = comment;
+  const visited = new Set<number>();
+
+  while (current.inReplyToId !== undefined && !visited.has(current.inReplyToId)) {
+    const parent = commentsById.get(current.inReplyToId);
+    if (!parent) {
+      break;
+    }
+
+    visited.add(current.id);
+    current = parent;
+  }
+
+  return current.id;
+}
+
+function formatPullRequestReviewThreadSummary(
+  thread: PullRequestReviewThread
+): string {
+  const summaries = [
+    ...new Set(
+      thread.actionableComments.map((comment) =>
+        summarizeReviewCommentBody(comment.body)
+      )
+    ),
+  ];
+  if (summaries.length === 0) {
+    return summarizeReviewCommentBody(thread.rootComment.body);
+  }
+
+  if (summaries.length === 1) {
+    return summaries[0];
+  }
+
+  const visibleSummaries = summaries.slice(0, 2);
+  const suffix =
+    summaries.length > visibleSummaries.length
+      ? ` (+${summaries.length - visibleSummaries.length} more)`
+      : "";
+  return `${visibleSummaries.join(" / ")}${suffix}`;
+}
+
+export function buildPullRequestReviewThreads(
+  comments: PullRequestReviewComment[]
+): PullRequestReviewThread[] {
+  const retainedComments = comments.filter(shouldRetainPullRequestReviewCommentInThread);
+  const commentsById = new Map(comments.map((comment) => [comment.id, comment]));
+  const commentsByThreadId = new Map<number, PullRequestReviewComment[]>();
+
+  for (const comment of retainedComments) {
+    const threadId = resolvePullRequestReviewThreadId(comment, commentsById);
+    const existing = commentsByThreadId.get(threadId);
+    if (existing) {
+      existing.push(comment);
+    } else {
+      commentsByThreadId.set(threadId, [comment]);
+    }
+  }
+
+  const threads: PullRequestReviewThread[] = [];
+
+  for (const [threadId, threadComments] of commentsByThreadId.entries()) {
+    const sortedComments = [...threadComments].sort((left, right) => {
+      const createdAtComparison =
+        Date.parse(left.createdAt) - Date.parse(right.createdAt);
+      if (createdAtComparison !== 0) {
+        return createdAtComparison;
+      }
+
+      return left.id - right.id;
+    });
+    const actionableComments = sortedComments.filter(
+      isActionablePullRequestReviewComment
+    );
+    if (actionableComments.length === 0) {
+      continue;
+    }
+
+    const rootComment =
+      sortedComments.find((comment) => comment.id === threadId) ?? sortedComments[0];
+    const ranges = sortedComments.map(getReviewCommentLineRange);
+    const lineNumbers = ranges.flatMap(({ startLine, endLine }) =>
+      [startLine, endLine].filter((line): line is number => line !== undefined)
+    );
+    const anchorLine = getReviewCommentDisplayLine(rootComment);
+    const baseThread = {
+      threadId,
+      path: rootComment.path,
+      startLine: lineNumbers.length > 0 ? Math.min(...lineNumbers) : anchorLine,
+      endLine: lineNumbers.length > 0 ? Math.max(...lineNumbers) : anchorLine,
+      anchorLine,
+      rootComment,
+      comments: sortedComments,
+      actionableComments,
+    };
+
+    threads.push({
+      ...baseThread,
+      summary: formatPullRequestReviewThreadSummary({ ...baseThread, summary: "" }),
+    });
+  }
+
+  return threads.sort((left, right) => {
+    const pathComparison = left.path.localeCompare(right.path);
+    if (pathComparison !== 0) {
+      return pathComparison;
+    }
+
+    const lineComparison =
+      (left.startLine ?? Number.MAX_SAFE_INTEGER) -
+      (right.startLine ?? Number.MAX_SAFE_INTEGER);
+    if (lineComparison !== 0) {
+      return lineComparison;
+    }
+
+    return left.threadId - right.threadId;
+  });
+}
+
+function shouldGroupPullRequestReviewThreads(
+  currentGroup: PullRequestReviewThread[],
+  nextThread: PullRequestReviewThread
+): boolean {
+  const previousThread = currentGroup[currentGroup.length - 1];
+  if (previousThread.path !== nextThread.path) {
+    return false;
+  }
+
+  const previousEndLine = previousThread.endLine ?? previousThread.startLine;
+  const nextStartLine = nextThread.startLine ?? nextThread.endLine;
+  if (previousEndLine !== undefined && nextStartLine !== undefined) {
+    return nextStartLine <= previousEndLine + 12;
+  }
+
+  const previousDiffHunks = new Set(
+    previousThread.comments
+      .map((comment) => comment.diffHunk?.trim())
+      .filter((diffHunk): diffHunk is string => Boolean(diffHunk))
+  );
+  return nextThread.comments.some(
+    (comment) =>
+      comment.diffHunk?.trim() && previousDiffHunks.has(comment.diffHunk.trim())
+  );
+}
+
+function formatPullRequestReviewTaskSummary(
+  threads: PullRequestReviewThread[]
+): string {
+  const summaries = [...new Set(threads.map((thread) => thread.summary))];
+  if (summaries.length === 1) {
+    return summaries[0];
+  }
+
+  const visibleSummaries = summaries.slice(0, 2);
+  const suffix =
+    summaries.length > visibleSummaries.length
+      ? ` (+${summaries.length - visibleSummaries.length} more)`
+      : "";
+  return `${visibleSummaries.join(" / ")}${suffix}`;
+}
+
+function createPullRequestReviewTask(
+  kind: "group" | "thread",
+  taskId: string,
+  threads: PullRequestReviewThread[]
+): PullRequestReviewTask {
+  const lineNumbers = threads.flatMap((thread) =>
+    [thread.startLine, thread.endLine].filter(
+      (line): line is number => line !== undefined
+    )
+  );
+  const commentsById = new Map<number, PullRequestReviewComment>();
+  for (const thread of threads) {
+    for (const comment of thread.comments) {
+      commentsById.set(comment.id, comment);
+    }
+  }
+
+  return {
+    taskId,
+    kind,
+    path: threads[0]?.path ?? "",
+    startLine: lineNumbers.length > 0 ? Math.min(...lineNumbers) : undefined,
+    endLine: lineNumbers.length > 0 ? Math.max(...lineNumbers) : undefined,
+    summary: formatPullRequestReviewTaskSummary(threads),
+    comments: [...commentsById.values()].sort((left, right) => left.id - right.id),
+    threads,
+  };
+}
+
+export function buildPullRequestReviewTasks(
+  comments: PullRequestReviewComment[]
+): { groupTasks: PullRequestReviewTask[]; threadTasks: PullRequestReviewTask[] } {
+  const threads = buildPullRequestReviewThreads(comments);
+  const threadTasks = threads.map((thread) =>
+    createPullRequestReviewTask("thread", `thread-${thread.threadId}`, [thread])
+  );
+  const groupTasks: PullRequestReviewTask[] = [];
+
+  let currentGroup: PullRequestReviewThread[] = [];
+  for (const thread of threads) {
+    if (
+      currentGroup.length === 0 ||
+      shouldGroupPullRequestReviewThreads(currentGroup, thread)
+    ) {
+      currentGroup.push(thread);
+      continue;
+    }
+
+    if (currentGroup.length > 1) {
+      groupTasks.push(
+        createPullRequestReviewTask(
+          "group",
+          `group-${groupTasks.length + 1}`,
+          currentGroup
+        )
+      );
+    }
+    currentGroup = [thread];
+  }
+
+  if (currentGroup.length > 1) {
+    groupTasks.push(
+      createPullRequestReviewTask(
+        "group",
+        `group-${groupTasks.length + 1}`,
+        currentGroup
+      )
+    );
+  }
+
+  return {
+    groupTasks,
+    threadTasks,
+  };
+}
+
+export function formatPullRequestReviewTaskLocation(
+  task: PullRequestReviewTask
+): string {
+  const lineRange = formatReviewCommentLineRange(task.startLine, task.endLine);
+  return lineRange === "Unknown" ? task.path : `${task.path}:${lineRange}`;
+}
+
+export function parsePullRequestReviewSelection(
+  response: string,
+  threadCount: number,
+  groupCount: number
+): Array<{ kind: "group" | "thread"; index: number }> {
+  const normalized = response.trim().toLowerCase();
+  if (!normalized || normalized === "none" || normalized === "n") {
+    return [];
+  }
+
+  if (normalized === "all") {
+    return Array.from({ length: threadCount }, (_, index) => ({
+      kind: "thread" as const,
+      index,
+    }));
+  }
+
+  const selectedEntries: Array<{ kind: "group" | "thread"; index: number }> = [];
+  const seenEntries = new Set<string>();
+
+  for (const part of normalized.split(",")) {
+    const trimmed = part.trim();
+    if (!trimmed) {
+      continue;
+    }
+
+    if (/^g\d+$/.test(trimmed)) {
+      if (groupCount === 0) {
+        throw new Error(
+          'Invalid selection. No grouped review tasks are available for this pull request.'
+        );
+      }
+
+      const parsed = Number.parseInt(trimmed.slice(1), 10);
+      if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > groupCount) {
+        throw new Error(
+          `Invalid selection "${trimmed}". Choose group values between g1 and g${groupCount}.`
+        );
+      }
+
+      const key = `group:${parsed - 1}`;
+      if (!seenEntries.has(key)) {
+        selectedEntries.push({ kind: "group", index: parsed - 1 });
+        seenEntries.add(key);
+      }
+      continue;
+    }
+
+    if (!/^\d+$/.test(trimmed)) {
+      throw new Error(
+        'Invalid selection. Use comma-separated thread numbers, optional group values like "g1", "all", or "none".'
+      );
+    }
+
+    const parsed = Number.parseInt(trimmed, 10);
+    if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > threadCount) {
+      throw new Error(
+        `Invalid selection "${trimmed}". Choose thread values between 1 and ${threadCount}.`
+      );
+    }
+
+    const key = `thread:${parsed - 1}`;
+    if (!seenEntries.has(key)) {
+      selectedEntries.push({ kind: "thread", index: parsed - 1 });
+      seenEntries.add(key);
+    }
+  }
+
+  return selectedEntries;
+}

--- a/packages/cli/src/workflows/pr-fix-comments/snapshot.ts
+++ b/packages/cli/src/workflows/pr-fix-comments/snapshot.ts
@@ -1,0 +1,189 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type {
+  PullRequestDetails,
+  RepositoryForge,
+} from "../../forge";
+import {
+  formatReviewCommentLineRange,
+} from "./selection";
+import type {
+  PullRequestLinkedIssueContext,
+  PullRequestReviewTask,
+} from "./types";
+
+function formatLocalFileExcerpt(
+  repoRoot: string,
+  filePath: string,
+  startLine?: number,
+  endLine?: number
+): string | undefined {
+  const excerptStartLine = startLine ?? endLine;
+  const excerptEndLine = endLine ?? startLine;
+  if (excerptStartLine === undefined || excerptEndLine === undefined) {
+    return undefined;
+  }
+
+  try {
+    const fileContents = readFileSync(resolve(repoRoot, filePath), "utf8");
+    if (fileContents.includes("\u0000")) {
+      return undefined;
+    }
+
+    const lines = fileContents.split(/\r?\n/);
+    const firstLine = Math.max(1, excerptStartLine - 4);
+    const lastLine = Math.min(lines.length, excerptEndLine + 4);
+    const lineNumberWidth = String(lastLine).length;
+
+    return lines
+      .slice(firstLine - 1, lastLine)
+      .map(
+        (line, index) =>
+          `${String(firstLine + index).padStart(lineNumberWidth, " ")} | ${line}`
+      )
+      .join("\n");
+  } catch {
+    return undefined;
+  }
+}
+
+export async function fetchLinkedIssuesForPullRequest(
+  forge: RepositoryForge,
+  pullRequest: PullRequestDetails
+): Promise<PullRequestLinkedIssueContext[]> {
+  const linkedIssueNumbers = new Set<number>();
+  for (const match of pullRequest.body.matchAll(
+    /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/gi
+  )) {
+    const parsed = Number.parseInt(match[1] ?? "", 10);
+    if (Number.isSafeInteger(parsed) && parsed > 0) {
+      linkedIssueNumbers.add(parsed);
+    }
+  }
+
+  const linkedIssues: PullRequestLinkedIssueContext[] = [];
+  for (const issueNumber of [...linkedIssueNumbers].sort((left, right) => left - right)) {
+    try {
+      const issue = await forge.fetchIssueDetails(issueNumber);
+      linkedIssues.push({
+        number: issueNumber,
+        ...issue,
+      });
+    } catch {
+      continue;
+    }
+  }
+
+  return linkedIssues;
+}
+
+export function formatPullRequestReviewCommentsSnapshot(
+  repoRoot: string,
+  pullRequest: PullRequestDetails,
+  tasks: PullRequestReviewTask[],
+  linkedIssues: PullRequestLinkedIssueContext[]
+): string {
+  const pullRequestBody = pullRequest.body.trim() || "(No pull request body provided.)";
+  const lines = [
+    "# Pull Request Review Fix Snapshot",
+    "",
+    "## Pull Request",
+    "",
+    `- PR number: ${pullRequest.number}`,
+    `- Title: ${pullRequest.title}`,
+    `- URL: ${pullRequest.url}`,
+    `- Base branch: ${pullRequest.baseRefName}`,
+    `- Head branch: ${pullRequest.headRefName}`,
+    "",
+    "## Body",
+    "",
+    pullRequestBody,
+  ];
+
+  if (linkedIssues.length > 0) {
+    lines.push("", "## Linked issues");
+
+    for (const issue of linkedIssues) {
+      lines.push(
+        "",
+        `### Issue #${issue.number}: ${issue.title}`,
+        "",
+        `- URL: ${issue.url}`,
+        "",
+        issue.body.trim() || "(No issue body provided.)"
+      );
+    }
+  }
+
+  lines.push("", "## Selected review tasks");
+
+  for (const [index, task] of tasks.entries()) {
+    lines.push(
+      "",
+      `### Task ${index + 1}`,
+      "",
+      `- Selection type: ${
+        task.kind === "group" ? "Grouped review task" : "Review thread"
+      }`,
+      `- File: ${task.path}`,
+      `- Lines: ${formatReviewCommentLineRange(task.startLine, task.endLine)}`,
+      `- Threads: ${task.threads.length}`,
+      `- Comments: ${task.comments.length}`,
+      `- Summary: ${task.summary}`,
+      "",
+      "#### Success looks like",
+      "",
+      "- Address each actionable review point captured in this task.",
+      "- Preserve any clarifications from follow-up review replies.",
+      "- Leave the affected code in a state that passes the configured verification command."
+    );
+
+    for (const [threadIndex, thread] of task.threads.entries()) {
+      lines.push(
+        "",
+        `#### Thread ${threadIndex + 1}`,
+        "",
+        `- Root comment ID: ${thread.rootComment.id}`,
+        `- Reviewer: ${thread.rootComment.author}`,
+        `- URL: ${thread.rootComment.url}`,
+        `- Lines: ${formatReviewCommentLineRange(thread.startLine, thread.endLine)}`,
+        `- Summary: ${thread.summary}`,
+        "",
+        "##### Thread conversation"
+      );
+
+      for (const comment of thread.comments) {
+        lines.push(
+          "",
+          `${comment.author} (${comment.updatedAt})`,
+          "",
+          comment.body.trim()
+        );
+      }
+
+      const diffHunks = [
+        ...new Set(
+          thread.comments
+            .map((comment) => comment.diffHunk?.trim())
+            .filter((diffHunk): diffHunk is string => Boolean(diffHunk))
+        ),
+      ];
+      if (diffHunks.length > 0) {
+        lines.push("", "##### Diff hunk", "", "```diff", diffHunks[0], "```");
+      }
+
+      const localExcerpt = formatLocalFileExcerpt(
+        repoRoot,
+        thread.path,
+        thread.startLine,
+        thread.endLine
+      );
+      if (localExcerpt) {
+        lines.push("", "##### Local file excerpt", "", "```text", localExcerpt, "```");
+      }
+    }
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}

--- a/packages/cli/src/workflows/pr-fix-comments/types.ts
+++ b/packages/cli/src/workflows/pr-fix-comments/types.ts
@@ -1,0 +1,36 @@
+import type { IssueDetails, PullRequestReviewComment } from "../../forge";
+
+export type PullRequestFixWorkspace = {
+  runDir: string;
+  snapshotFilePath: string;
+  promptFilePath: string;
+  metadataFilePath: string;
+  outputLogPath: string;
+};
+
+export type PullRequestReviewThread = {
+  threadId: number;
+  path: string;
+  startLine?: number;
+  endLine?: number;
+  anchorLine?: number;
+  rootComment: PullRequestReviewComment;
+  comments: PullRequestReviewComment[];
+  actionableComments: PullRequestReviewComment[];
+  summary: string;
+};
+
+export type PullRequestReviewTask = {
+  taskId: string;
+  kind: "group" | "thread";
+  path: string;
+  startLine?: number;
+  endLine?: number;
+  summary: string;
+  comments: PullRequestReviewComment[];
+  threads: PullRequestReviewThread[];
+};
+
+export type PullRequestLinkedIssueContext = IssueDetails & {
+  number: number;
+};

--- a/packages/cli/src/workflows/pr-fix-comments/workspace.ts
+++ b/packages/cli/src/workflows/pr-fix-comments/workspace.ts
@@ -1,0 +1,132 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { formatCommandForDisplay } from "../../config";
+import type { PullRequestDetails } from "../../forge";
+import { formatRunTimestamp, toRepoRelativePath } from "../../run-artifacts";
+import { getReviewCommentDisplayLine } from "./selection";
+import { formatPullRequestReviewCommentsSnapshot } from "./snapshot";
+import type {
+  PullRequestFixWorkspace,
+  PullRequestLinkedIssueContext,
+  PullRequestReviewTask,
+} from "./types";
+
+export function createPullRequestFixWorkspace(
+  repoRoot: string,
+  prNumber: number
+): PullRequestFixWorkspace {
+  const runDir = resolve(
+    repoRoot,
+    ".git-ai",
+    "runs",
+    `${formatRunTimestamp()}-pr-${prNumber}-fix-comments`
+  );
+
+  mkdirSync(runDir, { recursive: true });
+
+  return {
+    runDir,
+    snapshotFilePath: resolve(runDir, "pr-review-comments.md"),
+    promptFilePath: resolve(runDir, "prompt.md"),
+    metadataFilePath: resolve(runDir, "metadata.json"),
+    outputLogPath: resolve(runDir, "output.log"),
+  };
+}
+
+function buildPullRequestFixCodexPrompt(
+  repoRoot: string,
+  workspace: PullRequestFixWorkspace,
+  buildCommand: string[]
+): string {
+  const snapshotFile = toRepoRelativePath(repoRoot, workspace.snapshotFilePath);
+  const runDir = toRepoRelativePath(repoRoot, workspace.runDir);
+
+  return [
+    "You are working in the current repository.",
+    "",
+    `Read the pull request review fix snapshot at \`${snapshotFile}\` before making changes.`,
+    `Use \`${runDir}\` for run artifacts created by this workflow.`,
+    "",
+    "Instructions to Codex:",
+    "- analyze the repository only as needed for the selected review tasks",
+    "- keep code changes focused on addressing the selected review tasks",
+    "- follow existing architecture patterns",
+    "- verify each selected review thread or grouped task is fully addressed before finishing",
+    `- run \`${formatCommandForDisplay(buildCommand)}\` before finishing if code changes are made`,
+    "- do not modify `.git-ai/` unless needed for local workflow artifacts",
+    "- do not commit `.git-ai/` files",
+  ].join("\n");
+}
+
+export function writePullRequestFixWorkspaceFiles(
+  repoRoot: string,
+  pullRequest: PullRequestDetails,
+  tasks: PullRequestReviewTask[],
+  workspace: PullRequestFixWorkspace,
+  buildCommand: string[],
+  linkedIssues: PullRequestLinkedIssueContext[]
+): void {
+  const createdAt = new Date().toISOString();
+  const prompt = buildPullRequestFixCodexPrompt(repoRoot, workspace, buildCommand);
+  const selectedComments = tasks.flatMap((task) => task.comments);
+
+  writeFileSync(
+    workspace.snapshotFilePath,
+    formatPullRequestReviewCommentsSnapshot(repoRoot, pullRequest, tasks, linkedIssues),
+    "utf8"
+  );
+  writeFileSync(workspace.promptFilePath, `${prompt}\n`, "utf8");
+  writeFileSync(
+    workspace.metadataFilePath,
+    `${JSON.stringify(
+      {
+        createdAt,
+        prNumber: pullRequest.number,
+        prTitle: pullRequest.title,
+        prUrl: pullRequest.url,
+        baseRefName: pullRequest.baseRefName,
+        headRefName: pullRequest.headRefName,
+        snapshotFile: toRepoRelativePath(repoRoot, workspace.snapshotFilePath),
+        promptFile: toRepoRelativePath(repoRoot, workspace.promptFilePath),
+        outputLog: toRepoRelativePath(repoRoot, workspace.outputLogPath),
+        runDir: toRepoRelativePath(repoRoot, workspace.runDir),
+        linkedIssues: linkedIssues.map((issue) => ({
+          number: issue.number,
+          title: issue.title,
+          url: issue.url,
+        })),
+        selectedTasks: tasks.map((task) => ({
+          id: task.taskId,
+          kind: task.kind,
+          path: task.path,
+          startLine: task.startLine,
+          endLine: task.endLine,
+          summary: task.summary,
+          threadIds: task.threads.map((thread) => thread.threadId),
+          commentIds: task.comments.map((comment) => comment.id),
+        })),
+        selectedComments: selectedComments.map((comment) => ({
+          id: comment.id,
+          path: comment.path,
+          line: getReviewCommentDisplayLine(comment),
+          url: comment.url,
+        })),
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+  writeFileSync(
+    workspace.outputLogPath,
+    [
+      "# git-ai pr fix-comments run log",
+      "",
+      `Created: ${createdAt}`,
+      `Snapshot file: ${toRepoRelativePath(repoRoot, workspace.snapshotFilePath)}`,
+      `Prompt file: ${toRepoRelativePath(repoRoot, workspace.promptFilePath)}`,
+      "",
+    ].join("\n"),
+    "utf8"
+  );
+}


### PR DESCRIPTION
Closes #68

<!-- git-ai:pr-assistant:start -->
## PR Assistant

### Summary
This pull request refactors the CLI command handling for fixing pull request comments by extracting the relevant logic into dedicated modules. It introduces a new command structure for handling PR comments and organizes the codebase for better maintainability and clarity. This change aims to enhance the workflow for addressing PR review comments, making it easier to manage and execute related tasks.

### Key changes
- Introduced a new command handler for 'fix-comments' in a separate file (pr.ts) to streamline command parsing and execution.
- Refactored the main CLI index file to utilize the new command handler, improving separation of concerns.
- Created a new workflow for fixing PR comments, encapsulating related logic into dedicated modules for better organization.
- Removed deprecated types and functions related to pull request handling, simplifying the codebase.

### Risk areas
- The refactoring may introduce regressions in the CLI command execution if the new command handler does not correctly parse arguments or execute workflows as intended.

### Reviewer focus
- Ensure that the new command handler correctly processes the 'fix-comments' command and integrates seamlessly with the existing CLI structure.
- Verify that the refactored workflow for fixing PR comments functions as expected and that all related tasks are correctly handled.
- Check for any potential issues arising from the removal of deprecated types and functions, ensuring that existing functionality is preserved.
<!-- git-ai:pr-assistant:end -->