### PR TITLE
Fix: Codex run does not terminate cleanly before PR workflow execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Use `draft` to turn a feature idea into a structured issue. Use `plan` to genera
 git-ai issue 54
 ```
 
-This full local workflow fetches the configured issue, creates the working branch, writes `.git-ai/` run artifacts, opens Codex, runs the configured build command, commits the result, and opens a pull request when the configured forge supports it.
+This full local workflow fetches the configured issue, creates the working branch, writes `.git-ai/` run artifacts, runs Codex non-interactively, stores Codex's final summary in the run directory, runs the configured build command, commits the result, and opens a pull request when the configured forge supports it.
 
 If you need separate setup and completion steps:
 
@@ -137,7 +137,7 @@ git-ai issue prepare 54 --mode github-action
 git-ai pr fix-comments 88
 ```
 
-Use this when the PR branch is already checked out locally and you want `git-ai` to fetch the PR review comments, let you choose which actionable comments to address, open Codex with a focused prompt, run the configured build command, and optionally commit the result.
+Use this when the PR branch is already checked out locally and you want `git-ai` to fetch the PR review comments, let you choose which actionable comments to address, run Codex non-interactively with a focused prompt, run the configured build command, and optionally commit the result.
 
 Nearby comments on the same file are grouped into optional review tasks, non-trivial reply comments are kept as thread context, and the generated `.git-ai/runs/.../pr-review-comments.md` snapshot includes linked issue context plus local file excerpts when available.
 
@@ -147,7 +147,7 @@ Nearby comments on the same file are grouped into optional review tasks, non-tri
 git-ai pr fix-tests 88
 ```
 
-Use this when the PR branch is already checked out locally and you want `git-ai` to fetch the managed AI Test Suggestions comment, let you choose which structured test suggestions to implement, open Codex with a focused test-oriented prompt, run the configured build command, and optionally commit the result.
+Use this when the PR branch is already checked out locally and you want `git-ai` to fetch the managed AI Test Suggestions comment, let you choose which structured test suggestions to implement, run Codex non-interactively with a focused test-oriented prompt, run the configured build command, and optionally commit the result.
 
 The command parses the managed `<!-- git-ai-test-suggestions -->` PR comment conservatively, keeps the selected suggestion areas plus likely file locations in `.git-ai/runs/.../pr-test-suggestions.md`, and fails clearly if the managed comment is missing or malformed.
 
@@ -214,7 +214,7 @@ Think of `.git-ai/` as the working memory for issue, planning, and backlog flows
 Typical contents:
 
 - `.git-ai/issues/`: issue snapshots and generated drafts
-- `.git-ai/runs/`: run prompts, metadata, and logs for automated issue work and PR comment-fix runs
+- `.git-ai/runs/`: run prompts, final Codex summaries, metadata, and logs for automated issue work and PR comment-fix runs
 
 ## CLI command reference
 
@@ -273,10 +273,10 @@ Available subcommands:
 
 | Command | What it does |
 | --- | --- |
-| `git-ai issue <number>` | Full local issue-to-PR flow for the current Git repository. Fetches the configured forge issue, creates a branch, writes `.git-ai/` workspace files, opens an interactive Codex session, runs the configured build command, commits the result, and opens a PR if the configured forge supports it. |
+| `git-ai issue <number>` | Full local issue-to-PR flow for the current Git repository. Fetches the configured forge issue, creates a branch, writes `.git-ai/` workspace files, runs Codex non-interactively, saves Codex's final summary under `.git-ai/runs/.../codex-final-message.md`, runs the configured build command, commits the result, and opens a PR if the configured forge supports it. |
 | `git-ai issue draft` | Interactive issue drafting flow. Prompts for a feature idea, generates a Markdown issue draft with AI, optionally opens it in `$VISUAL` or `$EDITOR`, and can create the issue through the configured forge when GitHub support is enabled. |
 | `git-ai issue plan <number>` | Generates an issue resolution plan for the configured forge issue and posts it as a managed comment. If an editable plan comment already exists, the command reuses it instead of overwriting collaborator edits. |
-| `git-ai issue prepare <number>` | Prepares the issue branch and `.git-ai/` workspace artifacts, then prints machine-readable JSON describing the run. |
+| `git-ai issue prepare <number>` | Prepares the issue branch and `.git-ai/` workspace artifacts, then prints machine-readable JSON describing the run, including the planned `codex-final-message.md` artifact path. |
 | `git-ai issue prepare <number> --mode github-action` | Same preparation flow, but writes prompt instructions tailored for non-interactive GitHub Actions runs. |
 | `git-ai issue finalize <number>` | Commits generated changes with `feat: address issue #<number>`. |
 
@@ -285,7 +285,7 @@ Important behavior:
 - `git-ai issue` requires a clean working tree before it starts
 - `git-ai issue plan <number>` requires `OPENAI_API_KEY` the first time it generates a plan comment
 - local full issue runs require the `codex` CLI on `PATH`
-- full local issue runs execute the configured `buildCommand`, defaulting to `pnpm build`
+- full local issue runs execute the configured `buildCommand` after Codex exits cleanly, defaulting to `pnpm build`
 - PR creation uses the configured `baseBranch`, defaulting to `main`
 - GitHub-backed PR creation requires `gh` to be installed and authenticated
 - GitHub-backed issue plan comments require `GH_TOKEN` or `GITHUB_TOKEN`, or an authenticated `gh` session, when they are created
@@ -308,8 +308,8 @@ Available subcommands:
 
 | Command | What it does |
 | --- | --- |
-| `git-ai pr fix-comments <pr-number>` | Fetches pull request metadata and review comments from the configured forge, filters out obviously non-actionable comments, groups nearby threads into selectable review tasks, preserves non-trivial replies as thread context, writes richer `.git-ai/` run artifacts, opens an interactive Codex session, runs the configured build command, and optionally commits the resulting fixes. |
-| `git-ai pr fix-tests <pr-number>` | Fetches pull request metadata and PR issue comments from the configured forge, finds the managed AI Test Suggestions comment, parses structured suggestion areas into selectable tasks, writes focused `.git-ai/` run artifacts, opens an interactive Codex session, runs the configured build command, and optionally commits the resulting test changes. |
+| `git-ai pr fix-comments <pr-number>` | Fetches pull request metadata and review comments from the configured forge, filters out obviously non-actionable comments, groups nearby threads into selectable review tasks, preserves non-trivial replies as thread context, writes richer `.git-ai/` run artifacts, runs Codex non-interactively, saves Codex's final summary under `.git-ai/runs/.../codex-final-message.md`, runs the configured build command, and optionally commits the resulting fixes. |
+| `git-ai pr fix-tests <pr-number>` | Fetches pull request metadata and PR issue comments from the configured forge, finds the managed AI Test Suggestions comment, parses structured suggestion areas into selectable tasks, writes focused `.git-ai/` run artifacts, runs Codex non-interactively, saves Codex's final summary under `.git-ai/runs/.../codex-final-message.md`, runs the configured build command, and optionally commits the resulting test changes. |
 
 Important behavior:
 
@@ -318,7 +318,7 @@ Important behavior:
 - local PR comment-fix runs require the `codex` CLI on `PATH`
 - local PR test-fix runs require the `codex` CLI on `PATH`
 - PR comment-fix and test-fix runs execute the configured `buildCommand`, defaulting to `pnpm build`
-- the command expects the relevant PR branch to already be checked out locally before Codex starts editing
+- the command expects the relevant PR branch to already be checked out locally before the Codex phase starts editing
 - the interactive selector accepts numbered thread choices and, when available, grouped task choices like `g1`; `all` still selects every individual thread
 - `git-ai pr fix-tests <pr-number>` accepts `all`, `none`, or a comma-separated suggestion list like `1,2`
 - when `forge.type` is `github`, PR fetching uses `gh pr view` when available, otherwise the GitHub API

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -2366,6 +2366,7 @@ describe("CLI integration", () => {
       promptFile: string;
       metadataFile: string;
       outputLog: string;
+      finalMessageFile: string;
       runDir: string;
       mode: string;
     };
@@ -2373,6 +2374,7 @@ describe("CLI integration", () => {
     const promptFilePath = resolve(REPO_ROOT, output.promptFile);
     const metadataFilePath = resolve(REPO_ROOT, output.metadataFile);
     const outputLogPath = resolve(REPO_ROOT, output.outputLog);
+    const finalMessageFilePath = resolve(REPO_ROOT, output.finalMessageFile);
     const runDirPath = resolve(REPO_ROOT, output.runDir);
 
     cleanupTargets.add(dirname(issueFilePath));
@@ -2391,9 +2393,19 @@ describe("CLI integration", () => {
       "if the issue snapshot includes a resolution plan, treat it as the latest plan of record"
     );
     expect(readFileSync(promptFilePath, "utf8")).toContain(
+      "do not run build, test, commit, push, or pull request commands"
+    );
+    expect(readFileSync(promptFilePath, "utf8")).toContain(
+      "finish with a concise final summary and then exit cleanly"
+    );
+    expect(readFileSync(promptFilePath, "utf8")).toContain(
       `Read the issue snapshot at \`${output.issueFile}\` before making changes.`
     );
     expect(readFileSync(outputLogPath, "utf8")).toContain("# git-ai issue run log");
+    expect(readFileSync(outputLogPath, "utf8")).toContain(
+      `Final message file: ${output.finalMessageFile}`
+    );
+    expect(readFileSync(finalMessageFilePath, "utf8")).toBe("");
     expect(JSON.parse(readFileSync(metadataFilePath, "utf8"))).toMatchObject({
       issueNumber,
       issueTitle,
@@ -2401,11 +2413,13 @@ describe("CLI integration", () => {
       issueFile: output.issueFile,
       promptFile: output.promptFile,
       outputLog: output.outputLog,
+      finalMessageFile: output.finalMessageFile,
       issuePlanCommentUrl:
         `https://github.com/DevwareUK/git-ai/issues/${issueNumber}#issuecomment-613`,
       mode: "github-action",
     });
     expect(readFileSync(githubOutputPath, "utf8")).toContain("branch_name<<");
+    expect(readFileSync(githubOutputPath, "utf8")).toContain("final_message_file<<");
     expect(readFileSync(githubOutputPath, "utf8")).toContain(output.branchName);
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
@@ -2513,6 +2527,19 @@ describe("CLI integration", () => {
 
       process.argv = ["node", "git-ai", "issue", String(issueNumber)];
       await run();
+
+      const codexCall = spawnSync.mock.calls.find(([command, args]) => {
+        return command === "codex" && Array.isArray(args) && args[0] === "exec";
+      });
+      expect(codexCall).toBeDefined();
+      expect(codexCall?.[1]).toEqual(
+        expect.arrayContaining([
+          "exec",
+          "--sandbox",
+          "workspace-write",
+          "--output-last-message",
+        ])
+      );
 
       expect(spawnSync).toHaveBeenCalledWith(
         "npm",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,7 +17,6 @@ import {
 import { OpenAIProvider } from "@git-ai/providers";
 import dotenv from "dotenv";
 import {
-  formatCommandForDisplay,
   loadResolvedRepositoryConfig,
 } from "./config";
 import {
@@ -46,6 +45,7 @@ type IssueWorkspace = {
   promptFilePath: string;
   metadataFilePath: string;
   outputLogPath: string;
+  finalMessageFilePath: string;
 };
 
 type IssueExecutionMode = "local" | "github-action";
@@ -979,6 +979,7 @@ function createIssueWorkspace(
     promptFilePath: resolve(runDir, "prompt.md"),
     metadataFilePath: resolve(runDir, "metadata.json"),
     outputLogPath: resolve(runDir, "output.log"),
+    finalMessageFilePath: resolve(runDir, "codex-final-message.md"),
   };
 }
 
@@ -1028,8 +1029,7 @@ function ensureBranchDoesNotExist(repoRoot: string, branchName: string): void {
 function buildCodexPrompt(
   repoRoot: string,
   workspace: IssueWorkspace,
-  mode: IssueExecutionMode,
-  buildCommand: string[]
+  mode: IssueExecutionMode
 ): string {
   const issueFile = toRepoRelativePath(repoRoot, workspace.issueFilePath);
   const runDir = toRepoRelativePath(repoRoot, workspace.runDir);
@@ -1053,7 +1053,8 @@ function buildCodexPrompt(
     "- keep code changes focused on the issue snapshot",
     "- follow existing architecture patterns",
     "- if the issue snapshot includes a resolution plan, treat it as the latest plan of record",
-    `- run \`${formatCommandForDisplay(buildCommand)}\` before finishing if code changes are made`,
+    "- do not run build, test, commit, push, or pull request commands; git-ai will handle execution after you exit",
+    "- finish with a concise final summary and then exit cleanly",
     "- do not modify `.git-ai/` unless needed for local workflow artifacts",
     "- do not commit `.git-ai/` files",
   ].join("\n");
@@ -1066,11 +1067,10 @@ function writeIssueWorkspaceFiles(
   planComment: IssuePlanComment | undefined,
   branchName: string,
   workspace: IssueWorkspace,
-  mode: IssueExecutionMode,
-  buildCommand: string[]
+  mode: IssueExecutionMode
 ): void {
   const createdAt = new Date().toISOString();
-  const prompt = buildCodexPrompt(repoRoot, workspace, mode, buildCommand);
+  const prompt = buildCodexPrompt(repoRoot, workspace, mode);
 
   writeFileSync(
     workspace.issueFilePath,
@@ -1093,12 +1093,14 @@ function writeIssueWorkspaceFiles(
         issueFile: toRepoRelativePath(repoRoot, workspace.issueFilePath),
         promptFile: toRepoRelativePath(repoRoot, workspace.promptFilePath),
         outputLog: toRepoRelativePath(repoRoot, workspace.outputLogPath),
+        finalMessageFile: toRepoRelativePath(repoRoot, workspace.finalMessageFilePath),
       },
       null,
       2
     )}\n`,
     "utf8"
   );
+  writeFileSync(workspace.finalMessageFilePath, "", "utf8");
   writeFileSync(
     workspace.outputLogPath,
     [
@@ -1107,6 +1109,7 @@ function writeIssueWorkspaceFiles(
       `Created: ${createdAt}`,
       `Issue snapshot: ${toRepoRelativePath(repoRoot, workspace.issueFilePath)}`,
       `Prompt file: ${toRepoRelativePath(repoRoot, workspace.promptFilePath)}`,
+      `Final message file: ${toRepoRelativePath(repoRoot, workspace.finalMessageFilePath)}`,
       "",
     ].join("\n"),
     "utf8"
@@ -1142,6 +1145,10 @@ function emitIssuePrepareOutputs(repoRoot: string, context: IssueRunContext): vo
     toRepoRelativePath(repoRoot, context.workspace.metadataFilePath)
   );
   writeGitHubOutput("output_log", toRepoRelativePath(repoRoot, context.workspace.outputLogPath));
+  writeGitHubOutput(
+    "final_message_file",
+    toRepoRelativePath(repoRoot, context.workspace.finalMessageFilePath)
+  );
   writeGitHubOutput("run_dir", toRepoRelativePath(repoRoot, context.workspace.runDir));
   writeGitHubOutput("mode", context.mode);
 }
@@ -1201,32 +1208,38 @@ function runTrackedCommand(
 
 function runCodex(
   repoRoot: string,
-  workspace: { promptFilePath: string; outputLogPath: string }
+  workspace: {
+    promptFilePath: string;
+    outputLogPath: string;
+    finalMessageFilePath: string;
+  }
 ): void {
   if (!canRunCommand("codex")) {
     throw new Error(
-      "The `codex` CLI is not available on PATH. Install it before running interactive git-ai Codex workflows."
+      "The `codex` CLI is not available on PATH. Install it before running git-ai Codex workflows."
     );
   }
 
   const args = [
+    "exec",
     "--sandbox",
     "workspace-write",
-    "--ask-for-approval",
-    "on-request",
     "--cd",
     repoRoot,
+    "--output-last-message",
+    workspace.finalMessageFilePath,
     `Read and follow the instructions in ${toRepoRelativePath(
       repoRoot,
       workspace.promptFilePath
     )}.`,
   ];
 
+  writeFileSync(workspace.finalMessageFilePath, "", "utf8");
   appendRunLog(
     workspace.outputLogPath,
     "codex",
     args,
-    "[interactive Codex session opened in current terminal]",
+    "[non-interactive Codex execution started]",
     ""
   );
 
@@ -1237,13 +1250,20 @@ function runCodex(
 
   if (result.error) {
     throw new Error(
-      `Failed to start the interactive Codex session. ${result.error.message}`
+      `Failed to start the Codex run. ${result.error.message}`
     );
   }
 
   if (result.status !== 0) {
-    throw new Error(
-      "The interactive Codex session did not complete successfully."
+    throw new Error("The Codex run did not complete successfully.");
+  }
+
+  const finalMessage = readFileSync(workspace.finalMessageFilePath, "utf8").trim();
+  if (finalMessage) {
+    appendFileSync(
+      workspace.outputLogPath,
+      ["## Codex final message", "", finalMessage, ""].join("\n"),
+      "utf8"
     );
   }
 }
@@ -1990,8 +2010,7 @@ async function prepareIssueRun(
     planComment,
     branchName,
     workspace,
-    mode,
-    repositoryConfig.buildCommand
+    mode
   );
 
   console.log(`Creating branch ${branchName}...`);
@@ -2049,6 +2068,10 @@ async function runIssueCommand(): Promise<void> {
           promptFile: toRepoRelativePath(repoRoot, context.workspace.promptFilePath),
           metadataFile: toRepoRelativePath(repoRoot, context.workspace.metadataFilePath),
           outputLog: toRepoRelativePath(repoRoot, context.workspace.outputLogPath),
+          finalMessageFile: toRepoRelativePath(
+            repoRoot,
+            context.workspace.finalMessageFilePath
+          ),
           runDir: toRepoRelativePath(repoRoot, context.workspace.runDir),
           mode: context.mode,
         },
@@ -2074,10 +2097,15 @@ async function runIssueCommand(): Promise<void> {
   const repositoryConfig = getRepositoryConfig(repoRoot);
   const forge = getRepositoryForge(repoRoot);
 
-  console.log("Opening an interactive Codex session in this terminal...");
-  console.log("Complete the issue work in Codex.");
-  console.log("When Codex exits, git-ai will resume with build and commit steps.");
+  console.log("Running Codex non-interactively for this issue...");
+  console.log("Codex will print a final summary, exit cleanly, and then git-ai will resume.");
   runCodex(repoRoot, context.workspace);
+  console.log(
+    `Codex phase completed. Final summary saved to ${toRepoRelativePath(
+      repoRoot,
+      context.workspace.finalMessageFilePath
+    )}.`
+  );
 
   console.log("Verifying build...");
   verifyBuild(repoRoot, repositoryConfig.buildCommand, context.workspace.outputLogPath);

--- a/packages/cli/src/workflows/pr-fix-comments/run.ts
+++ b/packages/cli/src/workflows/pr-fix-comments/run.ts
@@ -27,7 +27,10 @@ type RunPrFixCommentsCommandOptions = {
   promptForLine(prompt: string): Promise<string>;
   runCodex(
     repoRoot: string,
-    workspace: Pick<PullRequestFixWorkspace, "promptFilePath" | "outputLogPath">
+    workspace: Pick<
+      PullRequestFixWorkspace,
+      "promptFilePath" | "outputLogPath" | "finalMessageFilePath"
+    >
   ): void;
   verifyBuild(repoRoot: string, buildCommand: string[], outputLogPath: string): void;
   hasChanges(repoRoot: string): boolean;
@@ -218,10 +221,9 @@ export async function runPrFixCommentsCommand(
     linkedIssues
   );
 
-  console.log("Opening an interactive Codex session in this terminal...");
-  console.log("Complete the selected review task fixes in Codex.");
-  console.log("When Codex exits, git-ai will resume with build and commit steps.");
+  console.log("Running Codex non-interactively for the selected review tasks...");
   options.runCodex(options.repoRoot, workspace);
+  console.log("Codex phase completed. Resuming build and commit steps.");
 
   console.log("Verifying build...");
   options.verifyBuild(

--- a/packages/cli/src/workflows/pr-fix-comments/types.ts
+++ b/packages/cli/src/workflows/pr-fix-comments/types.ts
@@ -6,6 +6,7 @@ export type PullRequestFixWorkspace = {
   promptFilePath: string;
   metadataFilePath: string;
   outputLogPath: string;
+  finalMessageFilePath: string;
 };
 
 export type PullRequestReviewThread = {

--- a/packages/cli/src/workflows/pr-fix-comments/workspace.ts
+++ b/packages/cli/src/workflows/pr-fix-comments/workspace.ts
@@ -1,6 +1,5 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { formatCommandForDisplay } from "../../config";
 import type { PullRequestDetails } from "../../forge";
 import { formatRunTimestamp, toRepoRelativePath } from "../../run-artifacts";
 import { getReviewCommentDisplayLine } from "./selection";
@@ -30,13 +29,13 @@ export function createPullRequestFixWorkspace(
     promptFilePath: resolve(runDir, "prompt.md"),
     metadataFilePath: resolve(runDir, "metadata.json"),
     outputLogPath: resolve(runDir, "output.log"),
+    finalMessageFilePath: resolve(runDir, "codex-final-message.md"),
   };
 }
 
 function buildPullRequestFixCodexPrompt(
   repoRoot: string,
-  workspace: PullRequestFixWorkspace,
-  buildCommand: string[]
+  workspace: PullRequestFixWorkspace
 ): string {
   const snapshotFile = toRepoRelativePath(repoRoot, workspace.snapshotFilePath);
   const runDir = toRepoRelativePath(repoRoot, workspace.runDir);
@@ -52,7 +51,8 @@ function buildPullRequestFixCodexPrompt(
     "- keep code changes focused on addressing the selected review tasks",
     "- follow existing architecture patterns",
     "- verify each selected review thread or grouped task is fully addressed before finishing",
-    `- run \`${formatCommandForDisplay(buildCommand)}\` before finishing if code changes are made`,
+    "- do not run build, test, commit, push, or pull request commands; git-ai will handle execution after you exit",
+    "- finish with a concise final summary and then exit cleanly",
     "- do not modify `.git-ai/` unless needed for local workflow artifacts",
     "- do not commit `.git-ai/` files",
   ].join("\n");
@@ -63,11 +63,11 @@ export function writePullRequestFixWorkspaceFiles(
   pullRequest: PullRequestDetails,
   tasks: PullRequestReviewTask[],
   workspace: PullRequestFixWorkspace,
-  buildCommand: string[],
+  _buildCommand: string[],
   linkedIssues: PullRequestLinkedIssueContext[]
 ): void {
   const createdAt = new Date().toISOString();
-  const prompt = buildPullRequestFixCodexPrompt(repoRoot, workspace, buildCommand);
+  const prompt = buildPullRequestFixCodexPrompt(repoRoot, workspace);
   const selectedComments = tasks.flatMap((task) => task.comments);
 
   writeFileSync(
@@ -89,6 +89,7 @@ export function writePullRequestFixWorkspaceFiles(
         snapshotFile: toRepoRelativePath(repoRoot, workspace.snapshotFilePath),
         promptFile: toRepoRelativePath(repoRoot, workspace.promptFilePath),
         outputLog: toRepoRelativePath(repoRoot, workspace.outputLogPath),
+        finalMessageFile: toRepoRelativePath(repoRoot, workspace.finalMessageFilePath),
         runDir: toRepoRelativePath(repoRoot, workspace.runDir),
         linkedIssues: linkedIssues.map((issue) => ({
           number: issue.number,
@@ -117,6 +118,7 @@ export function writePullRequestFixWorkspaceFiles(
     )}\n`,
     "utf8"
   );
+  writeFileSync(workspace.finalMessageFilePath, "", "utf8");
   writeFileSync(
     workspace.outputLogPath,
     [
@@ -125,6 +127,7 @@ export function writePullRequestFixWorkspaceFiles(
       `Created: ${createdAt}`,
       `Snapshot file: ${toRepoRelativePath(repoRoot, workspace.snapshotFilePath)}`,
       `Prompt file: ${toRepoRelativePath(repoRoot, workspace.promptFilePath)}`,
+      `Final message file: ${toRepoRelativePath(repoRoot, workspace.finalMessageFilePath)}`,
       "",
     ].join("\n"),
     "utf8"

--- a/packages/cli/src/workflows/pr-fix-tests/run.ts
+++ b/packages/cli/src/workflows/pr-fix-tests/run.ts
@@ -24,7 +24,10 @@ type RunPrFixTestsCommandOptions = {
   promptForLine(prompt: string): Promise<string>;
   runCodex(
     repoRoot: string,
-    workspace: Pick<PullRequestFixTestsWorkspace, "promptFilePath" | "outputLogPath">
+    workspace: Pick<
+      PullRequestFixTestsWorkspace,
+      "promptFilePath" | "outputLogPath" | "finalMessageFilePath"
+    >
   ): void;
   verifyBuild(repoRoot: string, buildCommand: string[], outputLogPath: string): void;
   hasChanges(repoRoot: string): boolean;
@@ -117,10 +120,9 @@ export async function runPrFixTestsCommand(
     linkedIssues
   );
 
-  console.log("Opening an interactive Codex session in this terminal...");
-  console.log("Complete the selected automated test changes in Codex.");
-  console.log("When Codex exits, git-ai will resume with build and commit steps.");
+  console.log("Running Codex non-interactively for the selected test suggestions...");
   options.runCodex(options.repoRoot, workspace);
+  console.log("Codex phase completed. Resuming build and commit steps.");
 
   console.log("Verifying build...");
   options.verifyBuild(

--- a/packages/cli/src/workflows/pr-fix-tests/types.ts
+++ b/packages/cli/src/workflows/pr-fix-tests/types.ts
@@ -6,6 +6,7 @@ export type PullRequestFixTestsWorkspace = {
   promptFilePath: string;
   metadataFilePath: string;
   outputLogPath: string;
+  finalMessageFilePath: string;
 };
 
 export type PullRequestLinkedIssueContext = IssueDetails & {

--- a/packages/cli/src/workflows/pr-fix-tests/workspace.test.ts
+++ b/packages/cli/src/workflows/pr-fix-tests/workspace.test.ts
@@ -106,6 +106,7 @@ describe("pr-fix-tests workspace", () => {
       snapshotFile: string;
       promptFile: string;
       outputLog: string;
+      finalMessageFile: string;
       runDir: string;
     };
     const outputLog = readFileSync(workspace.outputLogPath, "utf8");
@@ -122,7 +123,10 @@ describe("pr-fix-tests workspace", () => {
     );
     expect(prompt).toContain("Use `.git-ai/runs/");
     expect(prompt).toContain("- keep code changes focused on implementing automated tests");
-    expect(prompt).toContain("- run `pnpm build` before finishing if code changes are made");
+    expect(prompt).toContain(
+      "- do not run build, test, commit, push, or pull request commands; git-ai will handle execution after you exit"
+    );
+    expect(prompt).toContain("- finish with a concise final summary and then exit cleanly");
 
     expect(metadata.prNumber).toBe(71);
     expect(metadata.linkedIssues).toEqual([
@@ -151,14 +155,19 @@ describe("pr-fix-tests workspace", () => {
     expect(metadata.snapshotFile).toMatch(/\.git-ai\/runs\/.+\/pr-test-suggestions\.md$/);
     expect(metadata.promptFile).toMatch(/\.git-ai\/runs\/.+\/prompt\.md$/);
     expect(metadata.outputLog).toMatch(/\.git-ai\/runs\/.+\/output\.log$/);
+    expect(metadata.finalMessageFile).toMatch(
+      /\.git-ai\/runs\/.+\/codex-final-message\.md$/
+    );
     expect(metadata.runDir).toMatch(/\.git-ai\/runs\/.+-pr-71-fix-tests$/);
+    expect(readFileSync(workspace.finalMessageFilePath, "utf8")).toBe("");
 
     expect(outputLog).toContain("# git-ai pr fix-tests run log");
     expect(outputLog).toContain("Snapshot file: .git-ai/runs/");
     expect(outputLog).toContain("Prompt file: .git-ai/runs/");
+    expect(outputLog).toContain("Final message file: .git-ai/runs/");
   });
 
-  it("formats the configured build command in the generated Codex prompt", () => {
+  it("instructs Codex to exit cleanly and leave execution to git-ai", () => {
     const repoRoot = createTempRepoRoot();
     const workspace = createPullRequestFixTestsWorkspace(repoRoot, 88);
 
@@ -202,7 +211,10 @@ describe("pr-fix-tests workspace", () => {
     );
 
     expect(readFileSync(workspace.promptFilePath, "utf8")).toContain(
-      '- run `pnpm exec vitest --project "cli smoke"` before finishing if code changes are made'
+      "do not run build, test, commit, push, or pull request commands"
+    );
+    expect(readFileSync(workspace.promptFilePath, "utf8")).toContain(
+      "finish with a concise final summary and then exit cleanly"
     );
   });
 });

--- a/packages/cli/src/workflows/pr-fix-tests/workspace.ts
+++ b/packages/cli/src/workflows/pr-fix-tests/workspace.ts
@@ -1,6 +1,5 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { formatCommandForDisplay } from "../../config";
 import type { PullRequestDetails } from "../../forge";
 import { formatRunTimestamp, toRepoRelativePath } from "../../run-artifacts";
 import { formatPullRequestTestSuggestionsSnapshot } from "./snapshot";
@@ -30,13 +29,13 @@ export function createPullRequestFixTestsWorkspace(
     promptFilePath: resolve(runDir, "prompt.md"),
     metadataFilePath: resolve(runDir, "metadata.json"),
     outputLogPath: resolve(runDir, "output.log"),
+    finalMessageFilePath: resolve(runDir, "codex-final-message.md"),
   };
 }
 
 function buildPullRequestFixTestsCodexPrompt(
   repoRoot: string,
-  workspace: PullRequestFixTestsWorkspace,
-  buildCommand: string[]
+  workspace: PullRequestFixTestsWorkspace
 ): string {
   const snapshotFile = toRepoRelativePath(repoRoot, workspace.snapshotFilePath);
   const runDir = toRepoRelativePath(repoRoot, workspace.runDir);
@@ -53,7 +52,8 @@ function buildPullRequestFixTestsCodexPrompt(
     "- follow existing architecture and test patterns",
     "- preserve current behavior outside the selected testing scope",
     "- verify each selected test suggestion is addressed before finishing",
-    `- run \`${formatCommandForDisplay(buildCommand)}\` before finishing if code changes are made`,
+    "- do not run build, test, commit, push, or pull request commands; git-ai will handle execution after you exit",
+    "- finish with a concise final summary and then exit cleanly",
     "- do not modify `.git-ai/` unless needed for local workflow artifacts",
     "- do not commit `.git-ai/` files",
   ].join("\n");
@@ -65,11 +65,11 @@ export function writePullRequestFixTestsWorkspaceFiles(
   selectedSuggestions: PullRequestTestSuggestion[],
   suggestionsComment: PullRequestTestSuggestionsComment,
   workspace: PullRequestFixTestsWorkspace,
-  buildCommand: string[],
+  _buildCommand: string[],
   linkedIssues: PullRequestLinkedIssueContext[]
 ): void {
   const createdAt = new Date().toISOString();
-  const prompt = buildPullRequestFixTestsCodexPrompt(repoRoot, workspace, buildCommand);
+  const prompt = buildPullRequestFixTestsCodexPrompt(repoRoot, workspace);
 
   writeFileSync(
     workspace.snapshotFilePath,
@@ -100,6 +100,7 @@ export function writePullRequestFixTestsWorkspaceFiles(
         snapshotFile: toRepoRelativePath(repoRoot, workspace.snapshotFilePath),
         promptFile: toRepoRelativePath(repoRoot, workspace.promptFilePath),
         outputLog: toRepoRelativePath(repoRoot, workspace.outputLogPath),
+        finalMessageFile: toRepoRelativePath(repoRoot, workspace.finalMessageFilePath),
         runDir: toRepoRelativePath(repoRoot, workspace.runDir),
         linkedIssues: linkedIssues.map((issue) => ({
           number: issue.number,
@@ -121,6 +122,7 @@ export function writePullRequestFixTestsWorkspaceFiles(
     )}\n`,
     "utf8"
   );
+  writeFileSync(workspace.finalMessageFilePath, "", "utf8");
   writeFileSync(
     workspace.outputLogPath,
     [
@@ -129,6 +131,7 @@ export function writePullRequestFixTestsWorkspaceFiles(
       `Created: ${createdAt}`,
       `Snapshot file: ${toRepoRelativePath(repoRoot, workspace.snapshotFilePath)}`,
       `Prompt file: ${toRepoRelativePath(repoRoot, workspace.promptFilePath)}`,
+      `Final message file: ${toRepoRelativePath(repoRoot, workspace.finalMessageFilePath)}`,
       "",
     ].join("\n"),
     "utf8"


### PR DESCRIPTION
Closes #73

<!-- git-ai:pr-assistant:start -->
## PR Assistant

### Summary
This pull request addresses issue #73 by modifying the Codex execution workflow to run non-interactively and ensure it terminates cleanly before proceeding with subsequent steps in the PR workflow. This change enhances the reliability of the automation process by ensuring that Codex outputs a final summary that is captured for later use.

### Key changes
- Updated the Codex execution to run non-interactively, allowing for smoother integration into the automated workflow.
- Introduced a mechanism to store Codex's final summary in a designated file, improving traceability of Codex outputs.
- Modified documentation to reflect changes in the workflow, clarifying the new non-interactive execution model.

### Risk areas
No additional diff-grounded risk areas identified.

### Reviewer focus
- Verify that the Codex execution correctly handles non-interactive mode and that the final summary is properly saved.
- Check that the updated documentation accurately describes the new workflow and that it aligns with the code changes.
<!-- git-ai:pr-assistant:end -->