### PR TITLE
Fix: Fix guided issue-draft flow when `missingInformation` is empty but clarification output is usable

### DIFF
--- a/packages/contracts/src/issue-draft.test.ts
+++ b/packages/contracts/src/issue-draft.test.ts
@@ -53,4 +53,35 @@ describe("Issue draft schemas", () => {
 
     expect(parsed.status).toBe("clarify");
   });
+
+  it("accepts clarification guidance output when missingInformation is empty", () => {
+    const parsed = IssueDraftGuidanceOutput.parse({
+      status: "clarify",
+      assistantSummary: "The rough idea is usable, but the workflow details still need one follow-up.",
+      missingInformation: [],
+      questions: [
+        "Should the first version stop after generating the local draft, or should it also create the GitHub issue automatically?",
+      ],
+    });
+
+    expect(parsed).toMatchObject({
+      status: "clarify",
+      missingInformation: [],
+    });
+  });
+
+  it("defaults missingInformation to an empty array when it is omitted", () => {
+    const parsed = IssueDraftGuidanceOutput.parse({
+      status: "clarify",
+      assistantSummary: "The rough idea is usable, but one implementation decision still needs confirmation.",
+      questions: [
+        "Should the flow keep the current markdown sections, or should it add a technical considerations section when needed?",
+      ],
+    });
+
+    expect(parsed).toMatchObject({
+      status: "clarify",
+      missingInformation: [],
+    });
+  });
 });

--- a/packages/contracts/src/issue-draft.ts
+++ b/packages/contracts/src/issue-draft.ts
@@ -54,7 +54,7 @@ export const IssueDraftGuidanceClarify = z.object({
     .min(1, "assistantSummary must be non-empty"),
   missingInformation: z
     .array(z.string().trim().min(1, "missingInformation items must be non-empty"))
-    .min(1, "missingInformation must contain at least one item"),
+    .default([]),
   questions: z
     .array(z.string().trim().min(1, "questions items must be non-empty"))
     .min(1, "questions must contain at least one item")

--- a/packages/core/src/issue-draft.test.ts
+++ b/packages/core/src/issue-draft.test.ts
@@ -101,4 +101,65 @@ describe("generateIssueDraft", () => {
       ],
     });
   });
+
+  it("accepts clarification guidance when missingInformation is empty", async () => {
+    const result = await generateIssueDraftGuidance(
+      {
+        generateText: async () =>
+          JSON.stringify({
+            status: "clarify",
+            assistantSummary:
+              "The rough idea is usable, but one workflow decision still needs confirmation.",
+            missingInformation: [],
+            questions: [
+              "Should the first version stop after saving the local draft, or should it also create the GitHub issue automatically?",
+            ],
+          }),
+      },
+      {
+        featureIdea: "Turn issue draft into a guided issue-spec workflow.",
+        repositoryContext: "CLI lives in packages/cli and issue drafting logic lives in packages/core.",
+      }
+    );
+
+    expect(result).toEqual({
+      status: "clarify",
+      assistantSummary:
+        "The rough idea is usable, but one workflow decision still needs confirmation.",
+      missingInformation: [],
+      questions: [
+        "Should the first version stop after saving the local draft, or should it also create the GitHub issue automatically?",
+      ],
+    });
+  });
+
+  it("defaults missingInformation when the model omits it from a clarify response", async () => {
+    const result = await generateIssueDraftGuidance(
+      {
+        generateText: async () =>
+          JSON.stringify({
+            status: "clarify",
+            assistantSummary:
+              "The rough idea is usable, but one formatting decision still needs confirmation.",
+            questions: [
+              "Should the generated draft keep the current sections only, or add technical considerations when the repository context suggests them?",
+            ],
+          }),
+      },
+      {
+        featureIdea: "Turn issue draft into a guided issue-spec workflow.",
+        repositoryContext: "CLI lives in packages/cli and issue drafting logic lives in packages/core.",
+      }
+    );
+
+    expect(result).toEqual({
+      status: "clarify",
+      assistantSummary:
+        "The rough idea is usable, but one formatting decision still needs confirmation.",
+      missingInformation: [],
+      questions: [
+        "Should the generated draft keep the current sections only, or add technical considerations when the repository context suggests them?",
+      ],
+    });
+  });
 });

--- a/packages/core/src/issue-draft.ts
+++ b/packages/core/src/issue-draft.ts
@@ -92,6 +92,7 @@ function buildGuidancePrompt(input: IssueDraftGuidanceInputType): string {
     "}",
     "",
     'Use "clarify" only when genuinely important implementation details are still missing.',
+    'When using "clarify", include one or more concrete "missingInformation" items where practical, but return an empty array if the follow-up questions are still useful and no concise items fit.',
     'Use "ready" when the issue is sufficiently specified for a strong implementation-ready draft.',
     "Do not wrap JSON in markdown fences.",
     "",


### PR DESCRIPTION
Closes #86

<!-- git-ai:pr-assistant:start -->
## PR Assistant

### Summary
This pull request enhances the issue draft guidance flow by allowing the `missingInformation` field to be empty or omitted without causing validation errors. This change improves the flexibility of the guidance output, ensuring that useful clarification can still be provided even when no specific missing information is identified.

### Key changes
- Updated the validation schema for `missingInformation` to default to an empty array instead of requiring at least one item.
- Added tests to confirm that the system correctly handles cases where `missingInformation` is empty or omitted in the guidance output.

### Risk areas
No additional diff-grounded risk areas identified.

### Reviewer focus
- Verify that the changes to the validation schema do not introduce unintended side effects in other parts of the application.
- Check the new tests to ensure they accurately reflect the intended behavior of the guidance output.
<!-- git-ai:pr-assistant:end -->