### PR TITLE
Fix: Replace Numbered Codex End-Of-Run Options With Plain-Language Next Steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,9 @@ Use `draft` to hand a rough idea to an interactive Codex-led issue drafting flow
 git-ai issue 54
 ```
 
-This full local workflow fetches the configured issue, switches to the configured `baseBranch`, pulls the latest changes, creates the working branch, writes `.git-ai/` run artifacts, opens Codex, and then follows the final action chosen inside Codex. Choosing commit exits Codex, runs the configured build command, commits the result, and opens a pull request when the configured forge supports it. Choosing exit leaves the branch and any generated changes uncommitted without opening a pull request.
+This full local workflow fetches the configured issue, switches to the configured `baseBranch`, pulls the latest changes, creates the working branch, writes `.git-ai/` run artifacts, opens Codex, and resumes automatically when you exit the Codex session. After Codex returns control, `git-ai` runs the configured build command, commits the result, and opens a pull request when the configured forge supports it.
 
-At the end of a successful local Codex run, the generated prompt asks Codex to finish with an explicit done-state summary plus next-step options for refining, committing, or exiting. Selecting commit now records the action and closes Codex immediately so the outer `git-ai issue` flow can resume automatically without a separate `/exit`.
+At the end of a successful local Codex run, the generated prompt asks Codex to finish with an explicit done-state summary, a short note about how to see the result in action or what was verified, and plain-language next steps. If you want more changes, keep talking to Codex. When you are satisfied and want `git-ai` to resume, type `/exit`.
 
 If you need separate setup and completion steps:
 
@@ -290,9 +290,8 @@ Important behavior:
 - `git-ai issue plan <number>` requires `OPENAI_API_KEY` the first time it generates a plan comment
 - local full issue runs require the `codex` CLI on `PATH`
 - full local issue runs execute the configured `buildCommand`, defaulting to `pnpm build`
-- local interactive Codex prompts end with an explicit done-state summary instead of silently stopping
-- choosing `Commit & create PR` inside a local issue run exits Codex automatically before `git-ai` resumes the build, commit, and PR steps
-- for local full issue runs, choosing `Exit` inside Codex skips the automatic build, commit, and PR steps
+- local interactive Codex prompts end with an explicit done-state summary, a short note about how to see the result or what was verified, and plain-language next steps
+- for local full issue runs, `git-ai` resumes the build, commit, and PR steps after you exit Codex
 - issue preparation checks out and pulls the configured `baseBranch`, defaulting to `main`
 - PR creation uses the configured `baseBranch`, defaulting to `main`
 - GitHub-backed PR creation requires `gh` to be installed and authenticated
@@ -326,7 +325,7 @@ Important behavior:
 - local PR comment-fix runs require the `codex` CLI on `PATH`
 - local PR test-fix runs require the `codex` CLI on `PATH`
 - PR comment-fix and test-fix runs execute the configured `buildCommand`, defaulting to `pnpm build`
-- local interactive Codex prompts end with an explicit done-state summary and commit/exit options
+- local interactive Codex prompts end with an explicit done-state summary, a short note about how to see the result or what was verified, and plain-language next steps
 - the command expects the relevant PR branch to already be checked out locally before Codex starts editing
 - the interactive selector accepts numbered thread choices and, when available, grouped task choices like `g1`; `all` still selects every individual thread
 - `git-ai pr fix-tests <pr-number>` accepts `all`, `none`, or a comma-separated suggestion list like `1,2`

--- a/packages/cli/src/codex-done-state.test.ts
+++ b/packages/cli/src/codex-done-state.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { buildCodexDoneStateInstructions } from "./codex-done-state";
+
+describe("buildCodexDoneStateInstructions", () => {
+  it("uses plain-language next steps for interactive prompts", () => {
+    const instructions = buildCodexDoneStateInstructions({
+      mode: "interactive",
+      readyLabel: "Ready to commit",
+    }).join("\n");
+
+    expect(instructions).toContain("✅ Implementation complete");
+    expect(instructions).toContain(
+      "add a short explanation of how to see the change in action"
+    );
+    expect(instructions).toContain(
+      "continue by giving further instruction or type `/exit`"
+    );
+    expect(instructions).toContain(
+      "do not present numbered menus or tell the user to pick from fixed option labels"
+    );
+    expect(instructions).not.toContain("[1] Continue refining");
+    expect(instructions).not.toContain("/commit");
+  });
+
+  it("keeps non-interactive prompts from asking for more input", () => {
+    const instructions = buildCodexDoneStateInstructions({
+      mode: "non-interactive",
+      readyLabel: "Ready for the next automation step",
+    }).join("\n");
+
+    expect(instructions).toContain("✅ Implementation complete");
+    expect(instructions).toContain(
+      "add a short explanation of how to see the change in action"
+    );
+    expect(instructions).toContain(
+      "do not ask for input or wait for a reply after printing the done state"
+    );
+    expect(instructions).not.toContain("continue by giving further instruction");
+    expect(instructions).not.toContain("[1] Continue refining");
+  });
+});

--- a/packages/cli/src/codex-done-state.ts
+++ b/packages/cli/src/codex-done-state.ts
@@ -3,7 +3,6 @@ type CodexDoneStateMode = "interactive" | "non-interactive";
 type CodexDoneStateOptions = {
   mode: CodexDoneStateMode;
   readyLabel: string;
-  primaryActionLabel: string;
 };
 
 export function buildCodexDoneStateInstructions(
@@ -18,6 +17,7 @@ export function buildCodexDoneStateInstructions(
     `- ${options.readyLabel}`,
     "```",
     "- keep the summary high level and avoid dumping a full diff",
+    "- after the done-state block, add a short explanation of how to see the change in action, or if the work is not user-visible, what you verified or changed in practical terms",
   ];
 
   if (options.mode === "non-interactive") {
@@ -29,13 +29,7 @@ export function buildCodexDoneStateInstructions(
 
   return [
     ...sharedLines,
-    "Then present these next-step options exactly:",
-    "```text",
-    "[1] Continue refining",
-    `[2] ${options.primaryActionLabel}`,
-    "[3] Exit",
-    "```",
-    "- after printing the done state, stop and wait for the user's next instruction",
-    "- treat `/continue`, `/commit`, and `/exit` as valid follow-up replies",
+    "- after that explanation, end with plain-language next steps telling the user they can continue by giving further instruction or type `/exit` when they are satisfied and want to hand control back to `git-ai`",
+    "- do not present numbered menus or tell the user to pick from fixed option labels",
   ];
 }

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1130,7 +1130,11 @@ describe("CLI integration", () => {
     );
     expect(readFileSync(promptFilePath, "utf8")).toContain("keep code changes focused");
     expect(readFileSync(promptFilePath, "utf8")).toContain("✅ Implementation complete");
-    expect(readFileSync(promptFilePath, "utf8")).toContain("[2] Commit changes");
+    expect(readFileSync(promptFilePath, "utf8")).toContain(
+      "continue by giving further instruction or type `/exit`"
+    );
+    expect(readFileSync(promptFilePath, "utf8")).not.toContain("[2] Commit changes");
+    expect(readFileSync(promptFilePath, "utf8")).not.toContain("/commit");
     expect(readFileSync(outputLogPath, "utf8")).toContain("# git-ai pr fix-comments run log");
     expect(JSON.parse(readFileSync(metadataFilePath, "utf8"))).toMatchObject({
       prNumber: 88,
@@ -1430,7 +1434,11 @@ describe("CLI integration", () => {
       "implementing automated tests for the selected areas"
     );
     expect(readFileSync(promptFilePath, "utf8")).toContain("✅ Implementation complete");
-    expect(readFileSync(promptFilePath, "utf8")).toContain("[2] Commit changes");
+    expect(readFileSync(promptFilePath, "utf8")).toContain(
+      "continue by giving further instruction or type `/exit`"
+    );
+    expect(readFileSync(promptFilePath, "utf8")).not.toContain("[2] Commit changes");
+    expect(readFileSync(promptFilePath, "utf8")).not.toContain("/commit");
     expect(readFileSync(outputLogPath, "utf8")).toContain("# git-ai pr fix-tests run log");
     expect(JSON.parse(readFileSync(metadataFilePath, "utf8"))).toMatchObject({
       prNumber: 91,
@@ -2618,17 +2626,14 @@ describe("CLI integration", () => {
         `https://github.com/DevwareUK/git-ai/issues/${issueNumber}#issuecomment-613`,
       mode: "github-action",
     });
-    expect(JSON.parse(readFileSync(metadataFilePath, "utf8"))).toMatchObject({
-      completionFile: `${output.runDir}/codex-result.json`,
-    });
     expect(readFileSync(githubOutputPath, "utf8")).toContain("branch_name<<");
     expect(readFileSync(githubOutputPath, "utf8")).toContain(output.branchName);
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it("writes local issue prompts that exit Codex immediately after /commit", async () => {
+  it("writes local issue prompts with plain-language next steps", async () => {
     const issueNumber = 91235;
-    const issueTitle = "Local issue prompt exits after commit selection";
+    const issueTitle = "Local issue prompt uses conversational completion guidance";
 
     const fetchMock = vi
       .fn()
@@ -2697,25 +2702,25 @@ describe("CLI integration", () => {
 
     expect(output.mode).toBe("local");
     expect(readFileSync(promptFilePath, "utf8")).toContain(
-      '[2] Commit & create PR'
+      "add a short explanation of how to see the change in action"
     );
     expect(readFileSync(promptFilePath, "utf8")).toContain(
-      'for `/commit`, write `{"action":"commit"}` and then exit Codex immediately so `git-ai` can resume the build, commit, and PR flow'
+      "continue by giving further instruction or type `/exit` when they are satisfied and want to hand control back to `git-ai`"
     );
-    expect(readFileSync(promptFilePath, "utf8")).toContain(
-      'for `/exit`, write `{"action":"exit"}` and then exit Codex immediately'
-    );
+    expect(readFileSync(promptFilePath, "utf8")).not.toContain("[1] Continue refining");
+    expect(readFileSync(promptFilePath, "utf8")).not.toContain("/commit");
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it("skips build, commit, and PR creation when Codex exits a full issue run", async () => {
+  it("continues with build and commit flow when Codex exits a full issue run", async () => {
     const issueNumber = 145;
+    let gitStatusCallCount = 0;
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(
         createFetchResponse({
-          title: "Respect exit from interactive issue runs",
-          body: "The outer issue workflow should not auto-commit after /exit.",
+          title: "Resume issue automation after the Codex session exits",
+          body: "The outer issue workflow should continue after a normal Codex exit.",
           html_url: `https://github.com/DevwareUK/git-ai/issues/${issueNumber}`,
         })
       )
@@ -2725,7 +2730,8 @@ describe("CLI integration", () => {
     const { run, spawnSync } = await loadCli({
       execFileSyncImpl: (command, args) => {
         if (command === "git" && args[0] === "status") {
-          return "";
+          gitStatusCallCount += 1;
+          return gitStatusCallCount === 1 ? "" : " M packages/cli/src/index.ts\n";
         }
 
         if (command === "git" && args[0] === "remote") {
@@ -2771,25 +2777,31 @@ describe("CLI integration", () => {
         }
 
         if (command === "codex") {
-          const latestRunDir = listRunDirectories().at(-1);
-          if (!latestRunDir) {
-            throw new Error("Expected an issue run directory before launching Codex.");
-          }
-
-          writeFileSync(
-            resolve(REPO_ROOT, ".git-ai", "runs", latestRunDir, "codex-result.json"),
-            `${JSON.stringify({ action: "exit" })}\n`
-          );
-
           return { status: 0 };
         }
 
-        if (
-          command === "pnpm" ||
-          (command === "git" && ["add", "commit", "push"].includes(args[0] ?? "")) ||
-          (command === "gh" && args[0] === "pr" && args[1] === "create")
-        ) {
-          throw new Error(`Unexpected post-exit command: ${command} ${args.join(" ")}`);
+        if (command === "pnpm" && args[0] === "--version") {
+          return { status: 0 };
+        }
+
+        if (command === "pnpm" && args[0] === "build") {
+          return { status: 0, stdout: "built\n", stderr: "" };
+        }
+
+        if (command === "git" && args[0] === "add") {
+          return { status: 0 };
+        }
+
+        if (command === "git" && args[0] === "commit") {
+          return { status: 0 };
+        }
+
+        if (command === "git" && args[0] === "push") {
+          return { status: 0, stdout: "", stderr: "" };
+        }
+
+        if (command === "gh" && args[0] === "pr" && args[1] === "create") {
+          return { status: 0, stdout: "", stderr: "" };
         }
 
         throw new Error(`Unexpected spawnSync call: ${command} ${args.join(" ")}`);
@@ -2806,6 +2818,18 @@ describe("CLI integration", () => {
         cwd: REPO_ROOT,
         stdio: "inherit",
       })
+    );
+    expect(spawnSync).toHaveBeenCalledWith(
+      "pnpm",
+      ["build"],
+      expect.objectContaining({
+        encoding: "utf8",
+      })
+    );
+    expect(spawnSync).toHaveBeenCalledWith(
+      "git",
+      ["commit", "-m", "feat: address issue #145"],
+      expect.any(Object)
     );
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -53,11 +53,9 @@ type IssueWorkspace = {
   promptFilePath: string;
   metadataFilePath: string;
   outputLogPath: string;
-  completionFilePath: string;
 };
 
 type IssueExecutionMode = "local" | "github-action";
-type IssueCompletionAction = "commit" | "exit";
 type IssueDraftWorkspace = {
   runDir: string;
   draftFilePath: string;
@@ -1079,7 +1077,6 @@ function createIssueWorkspace(
     promptFilePath: resolve(runDir, "prompt.md"),
     metadataFilePath: resolve(runDir, "metadata.json"),
     outputLogPath: resolve(runDir, "output.log"),
-    completionFilePath: resolve(runDir, "codex-result.json"),
   };
 }
 
@@ -1159,24 +1156,10 @@ function buildCodexPrompt(
           "Do not wait for interactive user input.",
         ]
       : [];
-  const interactiveCompletionInstructions =
-    mode === "local"
-      ? [
-          `When the user chooses \`/commit\` or \`/exit\`, write the final choice to \`${toRepoRelativePath(
-            repoRoot,
-            workspace.completionFilePath
-          )}\` as JSON before you stop.`,
-          '- for `/commit`, write `{"action":"commit"}` and then exit Codex immediately so `git-ai` can resume the build, commit, and PR flow',
-          '- for `/exit`, write `{"action":"exit"}` and then exit Codex immediately',
-          "- for `/continue`, keep working and do not write the final action file yet",
-        ]
-      : [];
   const doneStateInstructions = buildCodexDoneStateInstructions({
     mode: mode === "github-action" ? "non-interactive" : "interactive",
     readyLabel:
       mode === "github-action" ? "Ready for the next automation step" : "Ready to commit",
-    primaryActionLabel:
-      mode === "github-action" ? "Exit" : "Commit & create PR",
   });
 
   return [
@@ -1196,9 +1179,6 @@ function buildCodexPrompt(
     "- do not commit `.git-ai/` files",
     "",
     ...doneStateInstructions,
-    ...(interactiveCompletionInstructions.length > 0
-      ? ["", ...interactiveCompletionInstructions]
-      : []),
   ].join("\n");
 }
 
@@ -1235,7 +1215,6 @@ function writeIssueWorkspaceFiles(
         issueDir: toRepoRelativePath(repoRoot, workspace.issueDir),
         issueFile: toRepoRelativePath(repoRoot, workspace.issueFilePath),
         promptFile: toRepoRelativePath(repoRoot, workspace.promptFilePath),
-        completionFile: toRepoRelativePath(repoRoot, workspace.completionFilePath),
         outputLog: toRepoRelativePath(repoRoot, workspace.outputLogPath),
       },
       null,
@@ -1348,9 +1327,8 @@ function runCodex(
   workspace: {
     promptFilePath: string;
     outputLogPath: string;
-    completionFilePath?: string;
   }
-): IssueCompletionAction | undefined {
+): void {
   if (!canRunCommand("codex")) {
     throw new Error(
       "The `codex` CLI is not available on PATH. Install it before running interactive git-ai Codex workflows."
@@ -1394,46 +1372,6 @@ function runCodex(
       "The interactive Codex session did not complete successfully."
     );
   }
-
-  if (!workspace.completionFilePath || !existsSync(workspace.completionFilePath)) {
-    return undefined;
-  }
-
-  const rawResult = readFileSync(workspace.completionFilePath, "utf8").trim();
-  if (!rawResult) {
-    return undefined;
-  }
-
-  let parsedResult: unknown;
-  try {
-    parsedResult = JSON.parse(rawResult);
-  } catch {
-    throw new Error(
-      `Invalid Codex completion result in ${toRepoRelativePath(
-        repoRoot,
-        workspace.completionFilePath
-      )}. Expected JSON like {"action":"commit"} or {"action":"exit"}.`
-    );
-  }
-
-  const action =
-    typeof parsedResult === "object" &&
-    parsedResult !== null &&
-    "action" in parsedResult &&
-    typeof parsedResult.action === "string"
-      ? parsedResult.action
-      : undefined;
-
-  if (action !== "commit" && action !== "exit") {
-    throw new Error(
-      `Invalid Codex completion action in ${toRepoRelativePath(
-        repoRoot,
-        workspace.completionFilePath
-      )}. Expected "commit" or "exit".`
-    );
-  }
-
-  return action;
 }
 
 function verifyBuild(repoRoot: string, buildCommand: string[], outputLogPath: string): void {
@@ -2250,16 +2188,7 @@ async function runIssueCommand(): Promise<void> {
   console.log("Opening an interactive Codex session in this terminal...");
   console.log("Complete the issue work in Codex.");
   console.log("When Codex exits, git-ai will resume with build and commit steps.");
-  const completionAction = runCodex(repoRoot, context.workspace);
-
-  if (completionAction === "exit") {
-    console.log("Leaving the generated changes uncommitted because Codex selected exit.");
-    return;
-  }
-
-  if (!completionAction) {
-    console.log("Codex did not record an explicit final action. Continuing with commit flow.");
-  }
+  runCodex(repoRoot, context.workspace);
 
   console.log("Verifying build...");
   verifyBuild(repoRoot, repositoryConfig.buildCommand, context.workspace.outputLogPath);

--- a/packages/cli/src/workflows/pr-fix-comments/workspace.ts
+++ b/packages/cli/src/workflows/pr-fix-comments/workspace.ts
@@ -44,7 +44,6 @@ function buildPullRequestFixCodexPrompt(
   const doneStateInstructions = buildCodexDoneStateInstructions({
     mode: "interactive",
     readyLabel: "Ready to commit",
-    primaryActionLabel: "Commit changes",
   });
 
   return [

--- a/packages/cli/src/workflows/pr-fix-tests/workspace.test.ts
+++ b/packages/cli/src/workflows/pr-fix-tests/workspace.test.ts
@@ -124,8 +124,12 @@ describe("pr-fix-tests workspace", () => {
     expect(prompt).toContain("- keep code changes focused on implementing automated tests");
     expect(prompt).toContain("- run `pnpm build` before finishing if code changes are made");
     expect(prompt).toContain("✅ Implementation complete");
-    expect(prompt).toContain("[2] Commit changes");
-    expect(prompt).toContain("treat `/continue`, `/commit`, and `/exit` as valid follow-up replies");
+    expect(prompt).toContain("add a short explanation of how to see the change in action");
+    expect(prompt).toContain(
+      "continue by giving further instruction or type `/exit` when they are satisfied and want to hand control back to `git-ai`"
+    );
+    expect(prompt).not.toContain("[2] Commit changes");
+    expect(prompt).not.toContain("/commit");
 
     expect(metadata.prNumber).toBe(71);
     expect(metadata.linkedIssues).toEqual([

--- a/packages/cli/src/workflows/pr-fix-tests/workspace.ts
+++ b/packages/cli/src/workflows/pr-fix-tests/workspace.ts
@@ -44,7 +44,6 @@ function buildPullRequestFixTestsCodexPrompt(
   const doneStateInstructions = buildCodexDoneStateInstructions({
     mode: "interactive",
     readyLabel: "Ready to commit",
-    primaryActionLabel: "Commit changes",
   });
 
   return [


### PR DESCRIPTION
Closes #90

<!-- git-ai:pr-assistant:start -->
## PR Assistant

### Summary
This pull request enhances the user experience of the Codex integration by replacing numbered options with plain-language next steps, streamlining the workflow for users. It aims to make interactions more conversational and intuitive, particularly at the end of Codex sessions.

### Key changes
- Updated the Codex workflow to provide plain-language next steps instead of numbered options, improving user clarity and engagement.
- Modified the behavior of the Codex session to automatically resume the `git-ai` workflow after exiting Codex, simplifying the transition back to the command line.
- Removed the need for explicit commit or exit commands, allowing users to type '/exit' to resume the workflow seamlessly.

### Risk areas
No additional diff-grounded risk areas identified.

### Reviewer focus
- Ensure that the new plain-language instructions are clear and correctly implemented in all relevant Codex prompts.
- Verify that the automatic resumption of the `git-ai` workflow after Codex exits functions as intended without introducing regressions.
- Check that the removal of numbered options does not affect the overall functionality or user experience negatively.
<!-- git-ai:pr-assistant:end -->