### PR TITLE
Add `git-ai pr prepare-review <pr-number>` command for streamlined PR reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ You only need extra tooling for advanced workflows:
 - the configured interactive runtime on `PATH` for `git-ai issue draft`, local interactive `git-ai issue <number>` runs, `git-ai pr fix-comments <pr-number>`, and `git-ai pr fix-tests <pr-number>`
   default: `codex`
   `ai.runtime.type: "claude-code"`: `claude`
+- `codex` on `PATH` for `git-ai pr prepare-review <pr-number>`, which generates the review brief, then leaves you in an interactive Codex session for follow-up questions or fixes, reusing a linked issue session when possible
 - `codex` plus authenticated GitHub access for `git-ai issue <number> --mode unattended` and `git-ai issue batch ...`
 - `gh`, `GH_TOKEN`, or `GITHUB_TOKEN` for GitHub-backed issue and pull request flows
 
@@ -91,6 +92,7 @@ You only need extra tooling for advanced workflows:
 - `git-ai setup`: guided repository onboarding for `git-ai`
 - `git-ai review`: review the current diff or a branch comparison
 - `git-ai issue ...`: draft issues, generate issue plans, run single-issue flows, and queue unattended issue batches
+- `git-ai pr prepare-review <pr-number>`: check out a reviewer-ready PR branch and generate a persisted local review brief
 - `git-ai pr fix-comments <pr-number>`: fix selected PR review comments with Codex
 - `git-ai pr fix-tests <pr-number>`: implement selected AI PR test suggestions with Codex
 - `git-ai test-backlog`: find high-value automated testing gaps
@@ -364,6 +366,7 @@ Important behavior:
 Usage:
 
 ```bash
+git-ai pr prepare-review <pr-number>
 git-ai pr fix-comments <pr-number>
 git-ai pr fix-tests <pr-number>
 ```
@@ -372,13 +375,21 @@ Available subcommands:
 
 | Command | What it does |
 | --- | --- |
+| `git-ai pr prepare-review <pr-number>` | Fetches pull request metadata and linked issues, requires a clean working tree, checks out the best available local review branch for the PR, writes `.git-ai/` run artifacts, generates `review-brief.md`, prints the saved brief path plus a terminal preview, and then leaves you in an interactive Codex session on that branch for follow-up review questions or requested fixes. |
 | `git-ai pr fix-comments <pr-number>` | Fetches pull request metadata and review comments from the configured forge, filters out obviously non-actionable comments, groups nearby threads into selectable review tasks, preserves non-trivial replies as thread context, writes richer `.git-ai/` run artifacts, opens the configured interactive runtime, runs the configured build command, and then previews a proposed commit message that you can edit, accept, or skip. |
 | `git-ai pr fix-tests <pr-number>` | Fetches pull request metadata and PR issue comments from the configured forge, finds the managed AI Test Suggestions comment, parses structured suggestion areas into selectable tasks, writes focused `.git-ai/` run artifacts, opens the configured interactive runtime, runs the configured build command, and then previews a proposed commit message that you can edit, accept, or skip. |
 
 Important behavior:
 
+- `git-ai pr prepare-review <pr-number>` requires a clean working tree before it starts
 - `git-ai pr fix-comments <pr-number>` requires a clean working tree before it starts
 - `git-ai pr fix-tests <pr-number>` requires a clean working tree before it starts
+- `git-ai pr prepare-review <pr-number>` requires `codex` on `PATH`
+- `git-ai pr prepare-review <pr-number>` reuses a linked issue branch when exactly one linked issue has saved local state and that branch still exists locally
+- otherwise `git-ai pr prepare-review <pr-number>` checks out the local PR head branch when it already exists, or fetches the PR head into a dedicated `review/pr-<pr-number>-<slug>` branch
+- `git-ai pr prepare-review <pr-number>` writes `prompt.md`, `metadata.json`, `output.log`, and `review-brief.md` under a timestamped `.git-ai/runs/` directory and may also write supporting workflow artifacts there
+- after generating the brief, `git-ai pr prepare-review <pr-number>` drops you into an interactive Codex shell so you can ask follow-up questions or request fixes before exiting Codex
+- when a linked issue has a live saved Codex session, `git-ai pr prepare-review <pr-number>` reuses it for brief generation and the follow-up interactive session; stale sessions are warned about and fall back to a fresh run
 - local PR comment-fix runs require the configured runtime CLI on `PATH`
 - local PR test-fix runs require the configured runtime CLI on `PATH`
 - PR comment-fix and test-fix runs execute the configured `buildCommand`, defaulting to `pnpm build`

--- a/packages/cli/src/commands/pr.ts
+++ b/packages/cli/src/commands/pr.ts
@@ -1,10 +1,11 @@
 export type PrCommandOptions = {
-  action: "fix-comments" | "fix-tests";
+  action: "fix-comments" | "fix-tests" | "prepare-review";
   prNumber: number;
 };
 
 export const PR_USAGE = [
   "Usage:",
+  "  git-ai pr prepare-review <pr-number>",
   "  git-ai pr fix-comments <pr-number>",
   "  git-ai pr fix-tests <pr-number>",
 ].join("\n");
@@ -16,7 +17,11 @@ export function parsePrCommandArgs(
   const prArgs = args.slice(1);
   const subcommand = prArgs[0];
 
-  if (subcommand !== "fix-comments" && subcommand !== "fix-tests") {
+  if (
+    subcommand !== "fix-comments" &&
+    subcommand !== "fix-tests" &&
+    subcommand !== "prepare-review"
+  ) {
     throw new Error(`Unknown pr subcommand "${subcommand ?? ""}". ${PR_USAGE}`);
   }
 

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -731,7 +731,10 @@ async function loadCli(options: {
     generatePRDescription,
     generateIssueResolutionPlan,
     mergePRAssistantSection: prAssistantBody.mergePRAssistantSection,
+    PR_ASSISTANT_END_MARKER: prAssistantBody.PR_ASSISTANT_END_MARKER,
+    PR_ASSISTANT_START_MARKER: prAssistantBody.PR_ASSISTANT_START_MARKER,
     StructuredGenerationError,
+    stripManagedPRAssistantSection: prAssistantBody.stripManagedPRAssistantSection,
     resolveRepositoryConfig: vi.fn((config?: {
       ai?: {
         runtime?: { type?: "codex" | "claude-code" };
@@ -940,6 +943,16 @@ describe("CLI integration", () => {
     expect(parsePrCommandArgs(["pr", "fix-tests", "74"])).toEqual({
       action: "fix-tests",
       prNumber: 74,
+    });
+  });
+
+  it("parses pr prepare-review as a dedicated pr subcommand", async () => {
+    process.env.GIT_AI_DISABLE_AUTO_RUN = "1";
+    const { parsePrCommandArgs } = await loadCli();
+
+    expect(parsePrCommandArgs(["pr", "prepare-review", "75"])).toEqual({
+      action: "prepare-review",
+      prNumber: 75,
     });
   });
 
@@ -1347,6 +1360,569 @@ describe("CLI integration", () => {
     expect(stdout.output()).toContain("README.md");
     expect(stdout.output()).toContain("## Linked issue");
     expect(stdout.output()).toContain("packages/cli/src/index.ts:412");
+  });
+
+  it("fails pr prepare-review clearly when repository forge support is disabled", async () => {
+    await withRepositoryConfig(
+      JSON.stringify(
+        {
+          forge: {
+            type: "none",
+          },
+        },
+        null,
+        2
+      ),
+      async () => {
+        const { run } = await loadCli();
+
+        process.argv = ["node", "git-ai", "pr", "prepare-review", "87"];
+
+        await expect(run()).rejects.toThrow(
+          "Repository forge support is disabled by .git-ai/config.json. Configure `forge.type` to enable pull request workflows."
+        );
+      }
+    );
+  });
+
+  it("runs pr prepare-review, reuses the linked issue branch and resumes a live Codex session", async () => {
+    const beforeRuns = listRunDirectories();
+    const issueNumber = 211;
+    const branchName = "feat/issue-211-review-setup";
+    const sessionId = "019d9001-aaaa-7bbb-8ccc-ddddeeeeffff";
+    const codexHome = createMockCodexHome();
+    const sessionStateDir = resolve(REPO_ROOT, ".git-ai", "issues", String(issueNumber));
+
+    writeMockCodexSession(codexHome, sessionId, REPO_ROOT, "2026-04-10T08:15:00.000Z");
+    mkdirSync(sessionStateDir, { recursive: true });
+    writeFileSync(
+      resolve(sessionStateDir, "session.json"),
+      `${JSON.stringify(
+        {
+          issueNumber,
+          runtimeType: "codex",
+          branchName,
+          issueDir: `.git-ai/issues/${issueNumber}-review-setup`,
+          runDir: ".git-ai/runs/20260410T081500000Z-issue-211",
+          promptFile: ".git-ai/runs/20260410T081500000Z-issue-211/prompt.md",
+          outputLog: ".git-ai/runs/20260410T081500000Z-issue-211/output.log",
+          sessionId,
+          sandboxMode: "workspace-write",
+          approvalPolicy: "on-request",
+          createdAt: "2026-04-10T08:15:00.000Z",
+          updatedAt: "2026-04-10T08:15:00.000Z",
+        },
+        null,
+        2
+      )}\n`,
+      "utf8"
+    );
+    cleanupTargets.add(sessionStateDir);
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        createFetchResponse({
+          number: 87,
+          title: "Prepare a review workspace",
+          body: [
+            "Fixes #211",
+            "",
+            "Set up a reviewer-ready local workspace for this pull request.",
+            "",
+            "<!-- git-ai:pr-assistant:start -->",
+            "## PR Assistant",
+            "",
+            "### Summary",
+            "Reuse linked issue state when available.",
+            "",
+            "### Reviewer focus",
+            "- Confirm the saved branch and session are reused when safe.",
+            "<!-- git-ai:pr-assistant:end -->",
+          ].join("\n"),
+          html_url: "https://github.com/DevwareUK/git-ai/pull/87",
+          base: { ref: "main" },
+          head: { ref: "feat/pr-review-workspace" },
+        })
+      )
+      .mockResolvedValueOnce(
+        createFetchResponse({
+          title: "Add PR review workspace setup",
+          body: "Reuse saved issue state when preparing a local PR review.",
+          html_url: "https://github.com/DevwareUK/git-ai/issues/211",
+        })
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { run, spawnSync } = await loadCli({
+      execFileSyncImpl: (command, args) => {
+        if (command === "git" && args[0] === "status") {
+          return "";
+        }
+
+        if (command === "git" && args[0] === "remote") {
+          return "git@github.com:DevwareUK/git-ai.git\n";
+        }
+
+        throw new Error(`Unexpected execFileSync call: ${command} ${args.join(" ")}`);
+      },
+      spawnSyncImpl: (command, args) => {
+        if (command === "gh" && args[0] === "--version") {
+          return { status: 1, error: new Error("gh is unavailable") };
+        }
+
+        if (command === "codex" && args[0] === "--version") {
+          return { status: 0 };
+        }
+
+        if (command === "git" && args[0] === "rev-parse" && args[2] === branchName) {
+          return { status: 0 };
+        }
+
+        if (command === "git" && args[0] === "checkout" && args[1] === branchName) {
+          return { status: 0, stdout: "", stderr: "" };
+        }
+
+        if (command === "codex" && args[0] === "exec" && args[1] === "resume") {
+          const createdRunDir = listRunDirectories().find(
+            (entry) => !beforeRuns.includes(entry)
+          );
+          if (!createdRunDir) {
+            throw new Error("Expected a prepare-review run directory before Codex resume.");
+          }
+
+          writeFileSync(
+            resolve(REPO_ROOT, ".git-ai", "runs", createdRunDir, "review-brief.md"),
+            [
+              "# Review Brief",
+              "",
+              "## Reviewer Commands",
+              "- `pnpm build`",
+              "",
+              "## Focus Areas",
+              "- Confirm the linked issue branch and session were reused.",
+            ].join("\n"),
+            "utf8"
+          );
+
+          return { status: 0, stdout: "brief generated\n", stderr: "" };
+        }
+
+        if (command === "codex" && args[0] === "resume" && args[1] === sessionId) {
+          return { status: 0 };
+        }
+
+        throw new Error(`Unexpected spawnSync call: ${command} ${args.join(" ")}`);
+      },
+    });
+
+    process.env.GITHUB_TOKEN = "test-token";
+    process.argv = ["node", "git-ai", "pr", "prepare-review", "87"];
+
+    await run();
+
+    const createdRunDir = listRunDirectories().find((entry) => !beforeRuns.includes(entry));
+    expect(createdRunDir).toBeDefined();
+
+    const runDirPath = resolve(REPO_ROOT, ".git-ai", "runs", createdRunDir as string);
+    const snapshotFilePath = resolve(runDirPath, "pr-review-prepare.md");
+    const promptFilePath = resolve(runDirPath, "prompt.md");
+    const interactivePromptFilePath = resolve(runDirPath, "interactive-prompt.md");
+    const metadataFilePath = resolve(runDirPath, "metadata.json");
+    const outputLogPath = resolve(runDirPath, "output.log");
+    const reviewBriefPath = resolve(runDirPath, "review-brief.md");
+    cleanupTargets.add(runDirPath);
+
+    expect(readFileSync(snapshotFilePath, "utf8")).toContain(
+      "# Pull Request Review Preparation Snapshot"
+    );
+    expect(readFileSync(snapshotFilePath, "utf8")).toContain(
+      "## Managed PR Assistant Section"
+    );
+    expect(readFileSync(snapshotFilePath, "utf8")).toContain(
+      "Reuse saved issue state when preparing a local PR review."
+    );
+    expect(readFileSync(promptFilePath, "utf8")).toContain(
+      "Write the final Markdown review brief"
+    );
+    expect(readFileSync(interactivePromptFilePath, "utf8")).toContain(
+      "stay in this interactive session so the user can ask follow-up review questions or request fixes"
+    );
+    expect(readFileSync(promptFilePath, "utf8")).toContain(
+      "do not modify tracked repository files"
+    );
+    expect(readFileSync(promptFilePath, "utf8")).toContain("pnpm build");
+    expect(readFileSync(outputLogPath, "utf8")).toContain("# git-ai pr prepare-review run log");
+    expect(readFileSync(outputLogPath, "utf8")).toContain(`git checkout ${branchName}`);
+    expect(readFileSync(reviewBriefPath, "utf8")).toContain("## Reviewer Commands");
+    expect(JSON.parse(readFileSync(metadataFilePath, "utf8"))).toMatchObject({
+      flow: "pr-prepare-review",
+      prNumber: 87,
+      checkout: {
+        source: "issue-branch",
+        branchName,
+        linkedIssueNumber: 211,
+      },
+      runtime: {
+        type: "codex",
+        invocation: "resume",
+        sessionId,
+        linkedIssueNumber: 211,
+        warnings: [],
+      },
+      linkedIssues: [
+        {
+          number: 211,
+          savedBranch: branchName,
+          savedRuntimeType: "codex",
+          savedSessionId: sessionId,
+        },
+      ],
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(spawnSync).toHaveBeenCalledWith(
+      "codex",
+      expect.arrayContaining(["exec", "resume", "--full-auto", sessionId]),
+      expect.objectContaining({
+        cwd: REPO_ROOT,
+      })
+    );
+    expect(spawnSync).toHaveBeenCalledWith(
+      "codex",
+      expect.arrayContaining(["resume", sessionId, "--sandbox", "workspace-write"]),
+      expect.objectContaining({
+        cwd: REPO_ROOT,
+        stdio: "inherit",
+      })
+    );
+  });
+
+  it("falls back to a fresh Codex run when the linked issue session is stale", async () => {
+    const beforeRuns = listRunDirectories();
+    const issueNumber = 212;
+    const branchName = "feat/issue-212-review-setup";
+    const staleSessionId = "019d9002-0000-7111-8222-933344445555";
+    const sessionStateDir = resolve(REPO_ROOT, ".git-ai", "issues", String(issueNumber));
+
+    createMockCodexHome();
+    mkdirSync(sessionStateDir, { recursive: true });
+    writeFileSync(
+      resolve(sessionStateDir, "session.json"),
+      `${JSON.stringify(
+        {
+          issueNumber,
+          runtimeType: "codex",
+          branchName,
+          issueDir: `.git-ai/issues/${issueNumber}-review-setup`,
+          runDir: ".git-ai/runs/20260410T091500000Z-issue-212",
+          promptFile: ".git-ai/runs/20260410T091500000Z-issue-212/prompt.md",
+          outputLog: ".git-ai/runs/20260410T091500000Z-issue-212/output.log",
+          sessionId: staleSessionId,
+          sandboxMode: "workspace-write",
+          approvalPolicy: "on-request",
+          createdAt: "2026-04-10T09:15:00.000Z",
+          updatedAt: "2026-04-10T09:15:00.000Z",
+        },
+        null,
+        2
+      )}\n`,
+      "utf8"
+    );
+    cleanupTargets.add(sessionStateDir);
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        createFetchResponse({
+          number: 88,
+          title: "Prepare another review workspace",
+          body: "Fixes #212\n\nRegenerate the reviewer brief when the old session is gone.",
+          html_url: "https://github.com/DevwareUK/git-ai/pull/88",
+          base: { ref: "main" },
+          head: { ref: "feat/pr-review-workspace-stale" },
+        })
+      )
+      .mockResolvedValueOnce(
+        createFetchResponse({
+          title: "Handle stale saved Codex sessions",
+          body: "Warn and fall back instead of failing the reviewer workflow.",
+          html_url: "https://github.com/DevwareUK/git-ai/issues/212",
+        })
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { run, spawnSync } = await loadCli({
+      execFileSyncImpl: (command, args) => {
+        if (command === "git" && args[0] === "status") {
+          return "";
+        }
+
+        if (command === "git" && args[0] === "remote") {
+          return "git@github.com:DevwareUK/git-ai.git\n";
+        }
+
+        throw new Error(`Unexpected execFileSync call: ${command} ${args.join(" ")}`);
+      },
+      spawnSyncImpl: (command, args) => {
+        if (command === "gh" && args[0] === "--version") {
+          return { status: 1, error: new Error("gh is unavailable") };
+        }
+
+        if (command === "codex" && args[0] === "--version") {
+          return { status: 0 };
+        }
+
+        if (command === "git" && args[0] === "rev-parse" && args[2] === branchName) {
+          return { status: 0 };
+        }
+
+        if (command === "git" && args[0] === "checkout" && args[1] === branchName) {
+          return { status: 0, stdout: "", stderr: "" };
+        }
+
+        if (command === "codex" && args[0] === "exec" && args[1] === "--full-auto") {
+          const createdRunDir = listRunDirectories().find(
+            (entry) => !beforeRuns.includes(entry)
+          );
+          if (!createdRunDir) {
+            throw new Error("Expected a prepare-review run directory before fresh Codex run.");
+          }
+
+          writeFileSync(
+            resolve(REPO_ROOT, ".git-ai", "runs", createdRunDir, "review-brief.md"),
+            [
+              "# Review Brief",
+              "",
+              "## Reviewer Commands",
+              "- `pnpm build`",
+            ].join("\n"),
+            "utf8"
+          );
+
+          return { status: 0, stdout: "brief generated\n", stderr: "" };
+        }
+
+        if (command === "codex" && args[0] === "--sandbox") {
+          return { status: 0 };
+        }
+
+        throw new Error(`Unexpected spawnSync call: ${command} ${args.join(" ")}`);
+      },
+    });
+
+    process.env.GITHUB_TOKEN = "test-token";
+    process.argv = ["node", "git-ai", "pr", "prepare-review", "88"];
+
+    await run();
+
+    const createdRunDir = listRunDirectories().find((entry) => !beforeRuns.includes(entry));
+    expect(createdRunDir).toBeDefined();
+
+    const runDirPath = resolve(REPO_ROOT, ".git-ai", "runs", createdRunDir as string);
+    const snapshotFilePath = resolve(runDirPath, "pr-review-prepare.md");
+    const interactivePromptFilePath = resolve(runDirPath, "interactive-prompt.md");
+    const metadataFilePath = resolve(runDirPath, "metadata.json");
+    const outputLogPath = resolve(runDirPath, "output.log");
+    cleanupTargets.add(runDirPath);
+
+    expect(readFileSync(snapshotFilePath, "utf8")).toContain("## Runtime Warnings");
+    expect(readFileSync(interactivePromptFilePath, "utf8")).toContain(
+      "Read the generated review brief"
+    );
+    expect(readFileSync(outputLogPath, "utf8")).toContain(
+      `Warning: Saved Codex session ${staleSessionId} for linked issue #212 is no longer available. Falling back to a fresh review brief generation run.`
+    );
+    expect(JSON.parse(readFileSync(metadataFilePath, "utf8"))).toMatchObject({
+      checkout: {
+        source: "issue-branch",
+        branchName,
+        linkedIssueNumber: 212,
+      },
+      runtime: {
+        invocation: "new",
+        linkedIssueNumber: 212,
+        warnings: [
+          `Saved Codex session ${staleSessionId} for linked issue #212 is no longer available. Falling back to a fresh review brief generation run.`,
+        ],
+      },
+    });
+    expect(spawnSync).not.toHaveBeenCalledWith(
+      "codex",
+      expect.arrayContaining(["exec", "resume", "--full-auto", staleSessionId]),
+      expect.any(Object)
+    );
+    expect(spawnSync).toHaveBeenCalledWith(
+      "codex",
+      expect.arrayContaining(["exec", "--full-auto", "--cd", REPO_ROOT]),
+      expect.objectContaining({
+        cwd: REPO_ROOT,
+      })
+    );
+    expect(spawnSync).toHaveBeenCalledWith(
+      "codex",
+      expect.arrayContaining([
+        "--sandbox",
+        "workspace-write",
+        "--ask-for-approval",
+        "on-request",
+        "--cd",
+        REPO_ROOT,
+      ]),
+      expect.objectContaining({
+        cwd: REPO_ROOT,
+        stdio: "inherit",
+      })
+    );
+  });
+
+  it("fetches a dedicated local review branch when no saved issue state or local head branch exists", async () => {
+    const beforeRuns = listRunDirectories();
+    const reviewBranchName = "review/pr-205-prepare-a-review-workspace";
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      createFetchResponse({
+        number: 205,
+        title: "Prepare a review workspace",
+        body: "Generate a local reviewer brief for this pull request.",
+        html_url: "https://github.com/DevwareUK/git-ai/pull/205",
+        base: { ref: "main" },
+        head: { ref: "feat/prepare-review-workspace" },
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { run, spawnSync } = await loadCli({
+      execFileSyncImpl: (command, args) => {
+        if (command === "git" && args[0] === "status") {
+          return "";
+        }
+
+        if (command === "git" && args[0] === "remote") {
+          return "git@github.com:DevwareUK/git-ai.git\n";
+        }
+
+        throw new Error(`Unexpected execFileSync call: ${command} ${args.join(" ")}`);
+      },
+      spawnSyncImpl: (command, args) => {
+        if (command === "gh" && args[0] === "--version") {
+          return { status: 1, error: new Error("gh is unavailable") };
+        }
+
+        if (command === "codex" && args[0] === "--version") {
+          return { status: 0 };
+        }
+
+        if (command === "git" && args[0] === "rev-parse") {
+          return { status: 1, error: new Error("missing") };
+        }
+
+        if (
+          command === "git" &&
+          args[0] === "fetch" &&
+          args[1] === "origin" &&
+          args[2] === `pull/205/head:${reviewBranchName}`
+        ) {
+          return { status: 0, stdout: "", stderr: "" };
+        }
+
+        if (command === "git" && args[0] === "checkout" && args[1] === reviewBranchName) {
+          return { status: 0, stdout: "", stderr: "" };
+        }
+
+        if (command === "codex" && args[0] === "exec" && args[1] === "--full-auto") {
+          const createdRunDir = listRunDirectories().find(
+            (entry) => !beforeRuns.includes(entry)
+          );
+          if (!createdRunDir) {
+            throw new Error("Expected a prepare-review run directory before fresh Codex run.");
+          }
+
+          writeFileSync(
+            resolve(REPO_ROOT, ".git-ai", "runs", createdRunDir, "review-brief.md"),
+            [
+              "# Review Brief",
+              "",
+              "## Reviewer Commands",
+              "- `pnpm build`",
+              "",
+              "## Focus Areas",
+              "- Review the fetched branch diff against `main`.",
+            ].join("\n"),
+            "utf8"
+          );
+
+          return { status: 0, stdout: "brief generated\n", stderr: "" };
+        }
+
+        if (command === "codex" && args[0] === "--sandbox") {
+          return { status: 0 };
+        }
+
+        throw new Error(`Unexpected spawnSync call: ${command} ${args.join(" ")}`);
+      },
+    });
+
+    process.env.GITHUB_TOKEN = "test-token";
+    process.argv = ["node", "git-ai", "pr", "prepare-review", "205"];
+
+    await run();
+
+    const createdRunDir = listRunDirectories().find((entry) => !beforeRuns.includes(entry));
+    expect(createdRunDir).toBeDefined();
+
+    const runDirPath = resolve(REPO_ROOT, ".git-ai", "runs", createdRunDir as string);
+    const snapshotFilePath = resolve(runDirPath, "pr-review-prepare.md");
+    const interactivePromptFilePath = resolve(runDirPath, "interactive-prompt.md");
+    const metadataFilePath = resolve(runDirPath, "metadata.json");
+    const outputLogPath = resolve(runDirPath, "output.log");
+    cleanupTargets.add(runDirPath);
+
+    expect(readFileSync(snapshotFilePath, "utf8")).toContain(
+      "Fetched PR head into dedicated local review branch"
+    );
+    expect(readFileSync(interactivePromptFilePath, "utf8")).toContain(
+      "Remain available for follow-up questions and requested fixes"
+    );
+    expect(readFileSync(outputLogPath, "utf8")).toContain(
+      `git fetch origin pull/205/head:${reviewBranchName}`
+    );
+    expect(readFileSync(outputLogPath, "utf8")).toContain(
+      `git checkout ${reviewBranchName}`
+    );
+    expect(JSON.parse(readFileSync(metadataFilePath, "utf8"))).toMatchObject({
+      prNumber: 205,
+      checkout: {
+        source: "fetched-review",
+        branchName: reviewBranchName,
+        headRefName: "feat/prepare-review-workspace",
+      },
+      runtime: {
+        invocation: "new",
+        warnings: [],
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(spawnSync).toHaveBeenCalledWith(
+      "git",
+      ["fetch", "origin", `pull/205/head:${reviewBranchName}`],
+      expect.objectContaining({
+        cwd: REPO_ROOT,
+      })
+    );
+    expect(spawnSync).toHaveBeenCalledWith(
+      "codex",
+      expect.arrayContaining([
+        "--sandbox",
+        "workspace-write",
+        "--ask-for-approval",
+        "on-request",
+        "--cd",
+        REPO_ROOT,
+      ]),
+      expect.objectContaining({
+        cwd: REPO_ROOT,
+        stdio: "inherit",
+      })
+    );
   });
 
   it("runs pr fix-comments, writes run artifacts, verifies the build, and commits the result", async () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -72,6 +72,7 @@ import {
 } from "./run-artifacts";
 import { parseSetupCommandArgs, runSetupCommand } from "./setup";
 import { runPrFixCommentsCommand } from "./workflows/pr-fix-comments/run";
+import { runPrPrepareReviewCommand } from "./workflows/pr-prepare-review/run";
 import { runPrFixTestsCommand } from "./workflows/pr-fix-tests/run";
 
 export { parseSetupCommandArgs };
@@ -2367,6 +2368,17 @@ async function runPrCommand(): Promise<void> {
   const repoRoot = getDefaultRepoRoot();
   const prCommand = parsePrCommandArgs(getCliArgs());
   const repositoryConfig = getRepositoryConfig(repoRoot);
+
+  if (prCommand.action === "prepare-review") {
+    await runPrPrepareReviewCommand({
+      prNumber: prCommand.prNumber,
+      repoRoot,
+      buildCommand: repositoryConfig.buildCommand,
+      forge: getRepositoryForge(repoRoot),
+      ensureCleanWorkingTree,
+    });
+    return;
+  }
 
   if (prCommand.action === "fix-comments") {
     await runPrFixCommentsCommand({

--- a/packages/cli/src/workflows/pr-prepare-review/run.ts
+++ b/packages/cli/src/workflows/pr-prepare-review/run.ts
@@ -1,0 +1,452 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync, appendFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { formatCommandForDisplay } from "../../config";
+import type { RepositoryForge } from "../../forge";
+import { printGeneratedTextPreview } from "../../generated-text-review";
+import {
+  findTrackedRuntimeSessionById,
+  getInteractiveRuntimeByType,
+  launchUnattendedRuntime,
+} from "../../runtime";
+import {
+  getIssueSessionStateFilePath,
+  toRepoRelativePath,
+} from "../../run-artifacts";
+import { fetchLinkedIssuesForPullRequest } from "./snapshot";
+import type {
+  PullRequestPrepareReviewCheckoutTarget,
+  PullRequestPrepareReviewIssueSessionState,
+  PullRequestPrepareReviewLinkedIssueState,
+  PullRequestPrepareReviewRuntimePlan,
+  PullRequestPrepareReviewWorkspace,
+} from "./types";
+import {
+  appendPullRequestPrepareReviewWarning,
+  createPullRequestPrepareReviewWorkspace,
+  initializePullRequestPrepareReviewOutputLog,
+  writePullRequestPrepareReviewMetadata,
+  writePullRequestPrepareReviewWorkspaceFiles,
+} from "./workspace";
+
+type RunPrPrepareReviewCommandOptions = {
+  prNumber: number;
+  repoRoot: string;
+  buildCommand: string[];
+  forge: RepositoryForge;
+  ensureCleanWorkingTree(repoRoot: string): void;
+};
+
+function appendRunLog(
+  outputLogPath: string,
+  command: string,
+  args: string[],
+  stdout: string,
+  stderr: string
+): void {
+  const renderedCommand = [command, ...args]
+    .map((value) => (value.includes(" ") ? JSON.stringify(value) : value))
+    .join(" ");
+
+  appendFileSync(
+    outputLogPath,
+    [`$ ${renderedCommand}`, stdout, stderr, ""].join("\n"),
+    "utf8"
+  );
+}
+
+function runTrackedCommand(
+  repoRoot: string,
+  workspace: PullRequestPrepareReviewWorkspace,
+  command: string,
+  args: string[],
+  errorMessage: string
+): string {
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    maxBuffer: 10 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const stdout = result.stdout ?? "";
+  const stderr = result.stderr ?? "";
+
+  appendRunLog(workspace.outputLogPath, command, args, stdout, stderr);
+
+  if (stdout) {
+    process.stdout.write(stdout);
+  }
+
+  if (stderr) {
+    process.stderr.write(stderr);
+  }
+
+  if (result.error) {
+    throw new Error(`${errorMessage} ${result.error.message}`);
+  }
+
+  if (result.status !== 0) {
+    throw new Error(errorMessage);
+  }
+
+  return stdout;
+}
+
+function localBranchExists(repoRoot: string, branchName: string): boolean {
+  const result = spawnSync("git", ["-C", repoRoot, "rev-parse", "--verify", branchName], {
+    stdio: "ignore",
+  });
+
+  return !result.error && result.status === 0;
+}
+
+function slugifyPullRequestTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/['’]/g, "")
+    .replace(/[^a-z0-9\s-]/g, " ")
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48)
+    .replace(/^-+|-+$/g, "");
+}
+
+function resolveFetchedReviewBranchName(
+  repoRoot: string,
+  prNumber: number,
+  title: string
+): string {
+  const baseName = `review/pr-${prNumber}-${slugifyPullRequestTitle(title) || `pr-${prNumber}`}`;
+  let candidate = baseName;
+  let suffix = 2;
+
+  while (localBranchExists(repoRoot, candidate)) {
+    candidate = `${baseName}-${suffix}`;
+    suffix += 1;
+  }
+
+  return candidate;
+}
+
+function loadIssueSessionState(
+  repoRoot: string,
+  issueNumber: number
+): PullRequestPrepareReviewIssueSessionState | undefined {
+  const stateFilePath = getIssueSessionStateFilePath(repoRoot, issueNumber);
+  if (!existsSync(stateFilePath)) {
+    return undefined;
+  }
+
+  const parsed = JSON.parse(
+    readFileSync(stateFilePath, "utf8")
+  ) as Partial<PullRequestPrepareReviewIssueSessionState>;
+  const runtimeType =
+    parsed.runtimeType === undefined &&
+    (typeof parsed.sessionId === "string" || parsed.executionMode === "unattended")
+      ? "codex"
+      : parsed.runtimeType;
+
+  if (
+    parsed.issueNumber !== issueNumber ||
+    (runtimeType !== "codex" && runtimeType !== "claude-code") ||
+    typeof parsed.branchName !== "string" ||
+    typeof parsed.issueDir !== "string" ||
+    typeof parsed.runDir !== "string" ||
+    typeof parsed.promptFile !== "string" ||
+    typeof parsed.outputLog !== "string" ||
+    (parsed.sessionId !== undefined && typeof parsed.sessionId !== "string") ||
+    (parsed.sandboxMode !== undefined && typeof parsed.sandboxMode !== "string") ||
+    (parsed.approvalPolicy !== undefined &&
+      typeof parsed.approvalPolicy !== "string") ||
+    (parsed.executionMode !== undefined &&
+      parsed.executionMode !== "interactive" &&
+      parsed.executionMode !== "unattended") ||
+    typeof parsed.createdAt !== "string" ||
+    typeof parsed.updatedAt !== "string"
+  ) {
+    throw new Error(
+      `Issue session state at ${toRepoRelativePath(
+        repoRoot,
+        stateFilePath
+      )} is malformed. Remove it and rerun the linked issue workflow to recreate the local issue state.`
+    );
+  }
+
+  return {
+    ...parsed,
+    runtimeType,
+  } as PullRequestPrepareReviewIssueSessionState;
+}
+
+function resolvePullRequestCheckoutTarget(
+  repoRoot: string,
+  prNumber: number,
+  pullRequestTitle: string,
+  pullRequestHeadRefName: string,
+  linkedIssues: PullRequestPrepareReviewLinkedIssueState[]
+): PullRequestPrepareReviewCheckoutTarget {
+  const reusableIssueBranches = linkedIssues.filter(
+    (linkedIssue) =>
+      linkedIssue.sessionState !== undefined &&
+      localBranchExists(repoRoot, linkedIssue.sessionState.branchName)
+  );
+
+  if (reusableIssueBranches.length === 1) {
+    return {
+      source: "issue-branch",
+      branchName: reusableIssueBranches[0].sessionState?.branchName as string,
+      linkedIssueNumber: reusableIssueBranches[0].issue.number,
+    };
+  }
+
+  if (localBranchExists(repoRoot, pullRequestHeadRefName)) {
+    return {
+      source: "local-head",
+      branchName: pullRequestHeadRefName,
+    };
+  }
+
+  return {
+    source: "fetched-review",
+    branchName: resolveFetchedReviewBranchName(repoRoot, prNumber, pullRequestTitle),
+    headRefName: pullRequestHeadRefName,
+  };
+}
+
+function resolvePullRequestRuntimePlan(
+  repoRoot: string,
+  checkoutTarget: PullRequestPrepareReviewCheckoutTarget,
+  linkedIssues: PullRequestPrepareReviewLinkedIssueState[]
+): PullRequestPrepareReviewRuntimePlan {
+  if (checkoutTarget.source !== "issue-branch") {
+    return {
+      invocation: "new",
+      warnings: [],
+    };
+  }
+
+  const linkedIssue = linkedIssues.find(
+    (candidate) => candidate.issue.number === checkoutTarget.linkedIssueNumber
+  );
+  const sessionState = linkedIssue?.sessionState;
+  if (!sessionState || sessionState.runtimeType !== "codex" || !sessionState.sessionId) {
+    return {
+      invocation: "new",
+      warnings: [],
+    };
+  }
+
+  const trackedSession = findTrackedRuntimeSessionById(
+    "codex",
+    repoRoot,
+    sessionState.sessionId
+  );
+  if (!trackedSession) {
+    return {
+      invocation: "new",
+      linkedIssueNumber: checkoutTarget.linkedIssueNumber,
+      warnings: [
+        `Saved Codex session ${sessionState.sessionId} for linked issue #${checkoutTarget.linkedIssueNumber} is no longer available. Falling back to a fresh review brief generation run.`,
+      ],
+    };
+  }
+
+  return {
+    invocation: "resume",
+    sessionId: sessionState.sessionId,
+    linkedIssueNumber: checkoutTarget.linkedIssueNumber,
+    warnings: [],
+  };
+}
+
+function checkoutPullRequestReviewBranch(
+  repoRoot: string,
+  workspace: PullRequestPrepareReviewWorkspace,
+  checkoutTarget: PullRequestPrepareReviewCheckoutTarget,
+  prNumber: number
+): void {
+  if (checkoutTarget.source === "fetched-review") {
+    console.log(`Fetching PR #${prNumber} into ${checkoutTarget.branchName}...`);
+    runTrackedCommand(
+      repoRoot,
+      workspace,
+      "git",
+      [
+        "fetch",
+        "origin",
+        `pull/${prNumber}/head:${checkoutTarget.branchName}`,
+      ],
+      `Failed to fetch PR #${prNumber} into local branch "${checkoutTarget.branchName}".`
+    );
+  }
+
+  console.log(`Checking out ${checkoutTarget.branchName}...`);
+  runTrackedCommand(
+    repoRoot,
+    workspace,
+    "git",
+    ["checkout", checkoutTarget.branchName],
+    `Failed to check out branch "${checkoutTarget.branchName}".`
+  );
+}
+
+function ensureCodexAvailable(): void {
+  const runtime = getInteractiveRuntimeByType("codex");
+  const availability = runtime.checkAvailability();
+  if (!availability.available) {
+    throw new Error(
+      `\`git-ai pr prepare-review\` requires Codex because it generates the review brief in an unattended runtime. Configured Codex is unavailable because ${availability.reason}.`
+    );
+  }
+}
+
+export async function runPrPrepareReviewCommand(
+  options: RunPrPrepareReviewCommandOptions
+): Promise<void> {
+  if (options.forge.type === "none") {
+    throw new Error(
+      "Repository forge support is disabled by .git-ai/config.json. Configure `forge.type` to enable pull request workflows."
+    );
+  }
+
+  ensureCodexAvailable();
+  options.ensureCleanWorkingTree(options.repoRoot);
+
+  console.log(`Fetching pull request #${options.prNumber}...`);
+  const pullRequest = await options.forge.fetchPullRequestDetails(options.prNumber);
+  const linkedIssues = (
+    await fetchLinkedIssuesForPullRequest(options.forge, pullRequest)
+  ).map((issue) => ({
+    issue,
+    sessionState: loadIssueSessionState(options.repoRoot, issue.number),
+  }));
+
+  const checkoutTarget = resolvePullRequestCheckoutTarget(
+    options.repoRoot,
+    pullRequest.number,
+    pullRequest.title,
+    pullRequest.headRefName,
+    linkedIssues
+  );
+  const runtimePlan = resolvePullRequestRuntimePlan(
+    options.repoRoot,
+    checkoutTarget,
+    linkedIssues
+  );
+  const workspace = createPullRequestPrepareReviewWorkspace(
+    options.repoRoot,
+    pullRequest.number
+  );
+
+  initializePullRequestPrepareReviewOutputLog(options.repoRoot, workspace);
+  for (const warning of runtimePlan.warnings) {
+    console.log(`Warning: ${warning}`);
+    appendPullRequestPrepareReviewWarning(workspace, warning);
+  }
+
+  checkoutPullRequestReviewBranch(
+    options.repoRoot,
+    workspace,
+    checkoutTarget,
+    pullRequest.number
+  );
+
+  writePullRequestPrepareReviewWorkspaceFiles(
+    options.repoRoot,
+    workspace,
+    {
+      pullRequest,
+      linkedIssues,
+      checkoutTarget,
+      runtimePlan,
+      buildCommandDisplay: formatCommandForDisplay(options.buildCommand),
+    },
+    options.buildCommand
+  );
+  writePullRequestPrepareReviewMetadata(options.repoRoot, workspace, {
+    pullRequest,
+    linkedIssues,
+    checkoutTarget,
+    runtimePlan,
+    buildCommandDisplay: formatCommandForDisplay(options.buildCommand),
+  }, runtimePlan);
+
+  console.log(
+    runtimePlan.invocation === "resume"
+      ? `Resuming Codex session ${runtimePlan.sessionId} to generate the review brief...`
+      : "Starting a fresh unattended Codex run to generate the review brief..."
+  );
+  const runtimeLaunch = launchUnattendedRuntime("codex", options.repoRoot, workspace, {
+    resumeSessionId: runtimePlan.sessionId,
+    outputLastMessageFilePath: workspace.assistantLastMessageFilePath,
+  });
+  const finalizedRuntimePlan: PullRequestPrepareReviewRuntimePlan = {
+    ...runtimePlan,
+    invocation: runtimeLaunch.invocation,
+    sessionId: runtimeLaunch.sessionId,
+  };
+  writePullRequestPrepareReviewMetadata(options.repoRoot, workspace, {
+    pullRequest,
+    linkedIssues,
+    checkoutTarget,
+    runtimePlan: finalizedRuntimePlan,
+    buildCommandDisplay: formatCommandForDisplay(options.buildCommand),
+  }, finalizedRuntimePlan);
+
+  if (!existsSync(workspace.reviewBriefFilePath)) {
+    throw new Error(
+      `Codex did not write the review brief to ${toRepoRelativePath(
+        options.repoRoot,
+        workspace.reviewBriefFilePath
+      )}.`
+    );
+  }
+
+  const reviewBrief = readFileSync(workspace.reviewBriefFilePath, "utf8").trim();
+  if (!reviewBrief) {
+    throw new Error(
+      `Codex wrote an empty review brief at ${toRepoRelativePath(
+        options.repoRoot,
+        workspace.reviewBriefFilePath
+      )}.`
+    );
+  }
+
+  process.stdout.write(
+    `Review brief written to ${toRepoRelativePath(
+      options.repoRoot,
+      workspace.reviewBriefFilePath
+    )}\n`
+  );
+  printGeneratedTextPreview("Generated review brief", reviewBrief);
+
+  const interactiveRuntime = getInteractiveRuntimeByType("codex");
+  const interactiveWorkspace = {
+    promptFilePath: workspace.interactivePromptFilePath,
+    outputLogPath: workspace.outputLogPath,
+  };
+  const interactiveResumeSessionId = runtimeLaunch.sessionId;
+
+  if (interactiveResumeSessionId) {
+    console.log(
+      `Opening an interactive Codex session in this terminal by resuming ${interactiveResumeSessionId}...`
+    );
+    console.log(
+      "You can now ask follow-up review questions or request fixes before exiting Codex."
+    );
+    interactiveRuntime.launch(options.repoRoot, interactiveWorkspace, {
+      resumeSessionId: interactiveResumeSessionId,
+    });
+    return;
+  }
+
+  console.log(
+    "Opening a fresh interactive Codex session in this terminal because the generated session id could not be recovered..."
+  );
+  console.log(
+    "You can now ask follow-up review questions or request fixes before exiting Codex."
+  );
+  interactiveRuntime.launch(options.repoRoot, interactiveWorkspace);
+}

--- a/packages/cli/src/workflows/pr-prepare-review/snapshot.ts
+++ b/packages/cli/src/workflows/pr-prepare-review/snapshot.ts
@@ -1,0 +1,114 @@
+import {
+  PR_ASSISTANT_END_MARKER,
+  PR_ASSISTANT_START_MARKER,
+  stripManagedPRAssistantSection,
+} from "@git-ai/core";
+import { fetchLinkedIssuesForPullRequest } from "../pr-fix-comments/snapshot";
+import type { PullRequestPrepareReviewSnapshotInput } from "./types";
+
+export { fetchLinkedIssuesForPullRequest };
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function extractManagedPRAssistantSection(body: string): string | undefined {
+  const pattern = new RegExp(
+    `${escapeRegExp(PR_ASSISTANT_START_MARKER)}\\s*([\\s\\S]*?)\\s*${escapeRegExp(
+      PR_ASSISTANT_END_MARKER
+    )}`,
+    "m"
+  );
+  const match = body.match(pattern);
+  return match?.[1]?.trim() || undefined;
+}
+
+function formatCheckoutSource(
+  checkoutTarget: PullRequestPrepareReviewSnapshotInput["checkoutTarget"]
+): string {
+  if (checkoutTarget.source === "issue-branch") {
+    return `Reused saved local issue branch from issue #${checkoutTarget.linkedIssueNumber}`;
+  }
+
+  if (checkoutTarget.source === "local-head") {
+    return "Reused existing local PR head branch";
+  }
+
+  return `Fetched PR head into dedicated local review branch from ${checkoutTarget.headRefName}`;
+}
+
+export function formatPullRequestPrepareReviewSnapshot(
+  input: PullRequestPrepareReviewSnapshotInput
+): string {
+  const manualBody =
+    stripManagedPRAssistantSection(input.pullRequest.body)?.trim() ||
+    "(No pull request body provided.)";
+  const managedAssistantSection = extractManagedPRAssistantSection(input.pullRequest.body);
+  const lines = [
+    "# Pull Request Review Preparation Snapshot",
+    "",
+    "## Pull Request",
+    "",
+    `- PR number: ${input.pullRequest.number}`,
+    `- Title: ${input.pullRequest.title}`,
+    `- URL: ${input.pullRequest.url}`,
+    `- Base branch: ${input.pullRequest.baseRefName}`,
+    `- Head branch: ${input.pullRequest.headRefName}`,
+    "",
+    "## Pull Request Body",
+    "",
+    manualBody,
+  ];
+
+  if (managedAssistantSection) {
+    lines.push("", "## Managed PR Assistant Section", "", managedAssistantSection);
+  }
+
+  if (input.linkedIssues.length > 0) {
+    lines.push("", "## Linked Issues");
+
+    for (const linkedIssue of input.linkedIssues) {
+      lines.push(
+        "",
+        `### Issue #${linkedIssue.issue.number}: ${linkedIssue.issue.title}`,
+        "",
+        `- URL: ${linkedIssue.issue.url}`
+      );
+
+      if (linkedIssue.sessionState) {
+        lines.push(
+          `- Saved branch: ${linkedIssue.sessionState.branchName}`,
+          `- Saved runtime: ${linkedIssue.sessionState.runtimeType}`,
+          `- Saved session id: ${linkedIssue.sessionState.sessionId ?? "None"}`
+        );
+      } else {
+        lines.push("- Saved local issue state: None found");
+      }
+
+      lines.push("", linkedIssue.issue.body.trim() || "(No issue body provided.)");
+    }
+  }
+
+  lines.push(
+    "",
+    "## Local Review Workspace",
+    "",
+    `- Checkout source: ${formatCheckoutSource(input.checkoutTarget)}`,
+    `- Checked out branch: ${input.checkoutTarget.branchName}`,
+    `- Runtime invocation: ${input.runtimePlan.invocation}`,
+    `- Runtime session reuse: ${
+      input.runtimePlan.sessionId
+        ? `Reusing linked issue #${input.runtimePlan.linkedIssueNumber} session ${input.runtimePlan.sessionId}`
+        : "Starting a fresh Codex brief-generation run"
+    }`,
+    `- Configured verification command: ${input.buildCommandDisplay}`
+  );
+
+  if (input.runtimePlan.warnings.length > 0) {
+    lines.push("", "## Runtime Warnings", "");
+    lines.push(...input.runtimePlan.warnings.map((warning) => `- ${warning}`));
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}

--- a/packages/cli/src/workflows/pr-prepare-review/types.ts
+++ b/packages/cli/src/workflows/pr-prepare-review/types.ts
@@ -1,0 +1,66 @@
+import type { InteractiveRuntimeType } from "../../runtime";
+import type { PullRequestDetails } from "../../forge";
+import type { PullRequestLinkedIssueContext } from "../pr-fix-comments/types";
+
+export type PullRequestPrepareReviewWorkspace = {
+  runDir: string;
+  snapshotFilePath: string;
+  promptFilePath: string;
+  interactivePromptFilePath: string;
+  metadataFilePath: string;
+  outputLogPath: string;
+  reviewBriefFilePath: string;
+  assistantLastMessageFilePath: string;
+};
+
+export type PullRequestPrepareReviewIssueSessionState = {
+  issueNumber: number;
+  runtimeType: InteractiveRuntimeType;
+  branchName: string;
+  issueDir: string;
+  runDir: string;
+  promptFile: string;
+  outputLog: string;
+  sessionId?: string;
+  sandboxMode?: string;
+  approvalPolicy?: string;
+  executionMode?: "interactive" | "unattended";
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type PullRequestPrepareReviewLinkedIssueState = {
+  issue: PullRequestLinkedIssueContext;
+  sessionState?: PullRequestPrepareReviewIssueSessionState;
+};
+
+export type PullRequestPrepareReviewCheckoutTarget =
+  | {
+      source: "issue-branch";
+      branchName: string;
+      linkedIssueNumber: number;
+    }
+  | {
+      source: "local-head";
+      branchName: string;
+    }
+  | {
+      source: "fetched-review";
+      branchName: string;
+      headRefName: string;
+    };
+
+export type PullRequestPrepareReviewRuntimePlan = {
+  invocation: "new" | "resume";
+  sessionId?: string;
+  linkedIssueNumber?: number;
+  warnings: string[];
+};
+
+export type PullRequestPrepareReviewSnapshotInput = {
+  pullRequest: PullRequestDetails;
+  linkedIssues: PullRequestPrepareReviewLinkedIssueState[];
+  checkoutTarget: PullRequestPrepareReviewCheckoutTarget;
+  runtimePlan: PullRequestPrepareReviewRuntimePlan;
+  buildCommandDisplay: string;
+};

--- a/packages/cli/src/workflows/pr-prepare-review/workspace.ts
+++ b/packages/cli/src/workflows/pr-prepare-review/workspace.ts
@@ -1,0 +1,220 @@
+import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { formatCommandForDisplay } from "../../config";
+import { formatRunTimestamp, toRepoRelativePath } from "../../run-artifacts";
+import { formatPullRequestPrepareReviewSnapshot } from "./snapshot";
+import type {
+  PullRequestPrepareReviewRuntimePlan,
+  PullRequestPrepareReviewSnapshotInput,
+  PullRequestPrepareReviewWorkspace,
+} from "./types";
+
+export function createPullRequestPrepareReviewWorkspace(
+  repoRoot: string,
+  prNumber: number
+): PullRequestPrepareReviewWorkspace {
+  const runDir = resolve(
+    repoRoot,
+    ".git-ai",
+    "runs",
+    `${formatRunTimestamp()}-pr-${prNumber}-prepare-review`
+  );
+
+  mkdirSync(runDir, { recursive: true });
+
+  return {
+    runDir,
+    snapshotFilePath: resolve(runDir, "pr-review-prepare.md"),
+    promptFilePath: resolve(runDir, "prompt.md"),
+    interactivePromptFilePath: resolve(runDir, "interactive-prompt.md"),
+    metadataFilePath: resolve(runDir, "metadata.json"),
+    outputLogPath: resolve(runDir, "output.log"),
+    reviewBriefFilePath: resolve(runDir, "review-brief.md"),
+    assistantLastMessageFilePath: resolve(runDir, "assistant-last-message.txt"),
+  };
+}
+
+function buildPullRequestPrepareReviewPrompt(
+  repoRoot: string,
+  workspace: PullRequestPrepareReviewWorkspace,
+  buildCommand: string[]
+): string {
+  const snapshotFile = toRepoRelativePath(repoRoot, workspace.snapshotFilePath);
+  const reviewBriefFile = toRepoRelativePath(repoRoot, workspace.reviewBriefFilePath);
+  const runDir = toRepoRelativePath(repoRoot, workspace.runDir);
+
+  return [
+    "You are working in the current repository.",
+    "You are preparing a local pull request review brief for a human reviewer.",
+    "",
+    `Read the pull request review preparation snapshot at \`${snapshotFile}\` before writing anything.`,
+    `Write the final Markdown review brief to \`${reviewBriefFile}\`.`,
+    `Use \`${runDir}\` for run artifacts created by this workflow.`,
+    "",
+    "Instructions to the coding agent:",
+    "- inspect the repository only as needed to prepare the review brief",
+    "- do not modify tracked repository files; only write the requested review brief and local workflow artifacts under `.git-ai/`",
+    "- base the brief on the checked-out repository state, the PR context in the snapshot, and the current diff against the PR base branch",
+    "- use the pull request body, linked issues, and managed PR assistant content only as supporting context when they are relevant",
+    "- include the checked-out branch and the checkout source that was already chosen for this review workspace",
+    "- include whether the review brief generation reused an existing Codex session or started a fresh run",
+    "- include concrete local commands the reviewer should run to install, build, start, or otherwise inspect the change locally",
+    `- always include at least one concrete command; if no better reviewer-specific command is obvious, include \`${formatCommandForDisplay(
+      buildCommand
+    )}\` as the fallback verification command`,
+    "- do not actually start long-running services or install dependencies; only recommend commands for the reviewer to run",
+    "- call out the most important reviewer focus areas grounded in the diff and supporting context",
+    "- if you cannot confidently determine how to view the change locally, include a short fallback note explaining that uncertainty",
+    "- keep the brief concise and practical for a human reviewer",
+    "",
+    "The review brief should contain short sections covering:",
+    "- PR details",
+    "- Local checkout state",
+    "- Reviewer commands",
+    "- Reviewer focus areas",
+    "- Any fallback notes or caveats",
+    "",
+    "When the brief is complete and saved, stop.",
+  ].join("\n");
+}
+
+function buildPullRequestPrepareReviewInteractivePrompt(
+  repoRoot: string,
+  workspace: PullRequestPrepareReviewWorkspace
+): string {
+  const snapshotFile = toRepoRelativePath(repoRoot, workspace.snapshotFilePath);
+  const reviewBriefFile = toRepoRelativePath(repoRoot, workspace.reviewBriefFilePath);
+  const runDir = toRepoRelativePath(repoRoot, workspace.runDir);
+
+  return [
+    "You are working in the current repository.",
+    "A pull request review brief has already been generated for this repository state.",
+    "",
+    `Read the pull request review preparation snapshot at \`${snapshotFile}\` for context if needed.`,
+    `Read the generated review brief at \`${reviewBriefFile}\` before answering questions.`,
+    `Use \`${runDir}\` for any additional local workflow artifacts created during this follow-up session.`,
+    "",
+    "Instructions to the coding agent:",
+    "- stay in this interactive session so the user can ask follow-up review questions or request fixes",
+    "- do not make code changes unless the user explicitly asks for them",
+    "- when asked review questions, ground your answers in the checked-out branch state, the review brief, and the current diff against the PR base branch",
+    "- if the user asks for fixes, keep changes focused on the requested review feedback and verify them appropriately before finishing",
+    "- do not rewrite the review brief unless the user explicitly asks you to update it",
+    "",
+    "Remain available for follow-up questions and requested fixes until the user exits the session.",
+  ].join("\n");
+}
+
+export function initializePullRequestPrepareReviewOutputLog(
+  repoRoot: string,
+  workspace: PullRequestPrepareReviewWorkspace
+): void {
+  writeFileSync(
+    workspace.outputLogPath,
+    [
+      "# git-ai pr prepare-review run log",
+      "",
+      `Created: ${new Date().toISOString()}`,
+      `Snapshot file: ${toRepoRelativePath(repoRoot, workspace.snapshotFilePath)}`,
+      `Prompt file: ${toRepoRelativePath(repoRoot, workspace.promptFilePath)}`,
+      `Interactive prompt file: ${toRepoRelativePath(
+        repoRoot,
+        workspace.interactivePromptFilePath
+      )}`,
+      `Review brief: ${toRepoRelativePath(repoRoot, workspace.reviewBriefFilePath)}`,
+      "",
+    ].join("\n"),
+    "utf8"
+  );
+}
+
+export function appendPullRequestPrepareReviewWarning(
+  workspace: PullRequestPrepareReviewWorkspace,
+  warning: string
+): void {
+  appendFileSync(workspace.outputLogPath, `Warning: ${warning}\n`, "utf8");
+}
+
+export function writePullRequestPrepareReviewWorkspaceFiles(
+  repoRoot: string,
+  workspace: PullRequestPrepareReviewWorkspace,
+  snapshotInput: PullRequestPrepareReviewSnapshotInput,
+  buildCommand: string[]
+): void {
+  writeFileSync(
+    workspace.snapshotFilePath,
+    formatPullRequestPrepareReviewSnapshot(snapshotInput),
+    "utf8"
+  );
+  writeFileSync(
+    workspace.promptFilePath,
+    `${buildPullRequestPrepareReviewPrompt(repoRoot, workspace, buildCommand)}\n`,
+    "utf8"
+  );
+  writeFileSync(
+    workspace.interactivePromptFilePath,
+    `${buildPullRequestPrepareReviewInteractivePrompt(repoRoot, workspace)}\n`,
+    "utf8"
+  );
+}
+
+export function writePullRequestPrepareReviewMetadata(
+  repoRoot: string,
+  workspace: PullRequestPrepareReviewWorkspace,
+  snapshotInput: PullRequestPrepareReviewSnapshotInput,
+  runtimePlan: PullRequestPrepareReviewRuntimePlan
+): void {
+  writeFileSync(
+    workspace.metadataFilePath,
+    `${JSON.stringify(
+      {
+        createdAt: new Date().toISOString(),
+        flow: "pr-prepare-review",
+        prNumber: snapshotInput.pullRequest.number,
+        prTitle: snapshotInput.pullRequest.title,
+        prUrl: snapshotInput.pullRequest.url,
+        baseRefName: snapshotInput.pullRequest.baseRefName,
+        headRefName: snapshotInput.pullRequest.headRefName,
+        snapshotFile: toRepoRelativePath(repoRoot, workspace.snapshotFilePath),
+        promptFile: toRepoRelativePath(repoRoot, workspace.promptFilePath),
+        interactivePromptFile: toRepoRelativePath(
+          repoRoot,
+          workspace.interactivePromptFilePath
+        ),
+        outputLog: toRepoRelativePath(repoRoot, workspace.outputLogPath),
+        runDir: toRepoRelativePath(repoRoot, workspace.runDir),
+        reviewBriefFile: toRepoRelativePath(repoRoot, workspace.reviewBriefFilePath),
+        checkout: {
+          source: snapshotInput.checkoutTarget.source,
+          branchName: snapshotInput.checkoutTarget.branchName,
+          linkedIssueNumber:
+            snapshotInput.checkoutTarget.source === "issue-branch"
+              ? snapshotInput.checkoutTarget.linkedIssueNumber
+              : undefined,
+          headRefName:
+            snapshotInput.checkoutTarget.source === "fetched-review"
+              ? snapshotInput.checkoutTarget.headRefName
+              : undefined,
+        },
+        runtime: {
+          type: "codex",
+          invocation: runtimePlan.invocation,
+          sessionId: runtimePlan.sessionId,
+          linkedIssueNumber: runtimePlan.linkedIssueNumber,
+          warnings: runtimePlan.warnings,
+        },
+        linkedIssues: snapshotInput.linkedIssues.map((linkedIssue) => ({
+          number: linkedIssue.issue.number,
+          title: linkedIssue.issue.title,
+          url: linkedIssue.issue.url,
+          savedBranch: linkedIssue.sessionState?.branchName,
+          savedRuntimeType: linkedIssue.sessionState?.runtimeType,
+          savedSessionId: linkedIssue.sessionState?.sessionId,
+        })),
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+}


### PR DESCRIPTION
## Summary
This change introduces a new command, `git-ai pr prepare-review <pr-number>`, which automates the setup of a local environment for reviewing pull requests. It simplifies the process by checking out the appropriate branch, generating a review brief, and reusing existing Codex sessions when available.

## Changes
- Added a new subcommand `prepare-review` to the `git-ai pr` command set.
- The command fetches PR metadata and linked issues, ensuring a clean working tree before proceeding.
- It checks out the best available local review branch based on existing issue state or fetches a new branch if necessary.
- Generates a `review-brief.md` file with commands and focus areas for the reviewer.
- Integrates with Codex to allow follow-up questions after the review brief is generated.

## Testing
Reviewers can validate the functionality by running `git-ai pr prepare-review <pr-number>` in a repository with existing pull requests and linked issues. The command should correctly set up the environment and generate the review brief.

## Risk
There is a risk of failure if the repository's forge support is disabled, which will be clearly communicated to the user. Additionally, if a linked Codex session is stale, the command will fall back to generating a new session instead of failing outright.

Closes #105

<!-- git-ai:pr-assistant:start -->
## PR Assistant

### Summary
This pull request introduces a new command, `git-ai pr prepare-review <pr-number>`, designed to streamline the process of preparing a local environment for reviewing pull requests. The command automates branch checkout, generates a review brief, and facilitates interactive follow-up sessions using Codex, enhancing the efficiency of the review workflow.

### Key changes
- Added the `prepare-review` subcommand to the `git-ai pr` command set, which automates the setup for reviewing pull requests.
- Implemented functionality to fetch PR metadata and linked issues, ensuring a clean working tree before proceeding.
- Developed logic to check out the best available local review branch or fetch a new branch if necessary.
- Created a `review-brief.md` file that outlines commands and focus areas for the reviewer.
- Integrated with Codex to allow for interactive follow-up questions after the review brief is generated.

### Risk areas
- The command may fail if the repository's forge support is disabled, which is communicated to the user.
- If a linked Codex session is stale, the command will fall back to generating a new session instead of failing outright.

### Reviewer focus
- Verify that the `prepare-review` command correctly sets up the environment for a given PR number.
- Check that the generated review brief contains accurate and relevant information for the reviewer.
- Ensure that the command handles both fresh and stale Codex sessions appropriately.
<!-- git-ai:pr-assistant:end -->