### PR TITLE
Offer to commit after changes are made during PR review

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ You only need extra tooling for advanced workflows:
 - the configured interactive runtime on `PATH` for `git-ai issue draft`, local interactive `git-ai issue <number>` runs, `git-ai pr fix-comments <pr-number>`, and `git-ai pr fix-tests <pr-number>`
   default: `codex`
   `ai.runtime.type: "claude-code"`: `claude`
-- `codex` on `PATH` for `git-ai pr prepare-review <pr-number>`, which generates the review brief, then leaves you in an interactive Codex session for follow-up questions or fixes, reusing a linked issue session when possible
+- `codex` on `PATH` for `git-ai pr prepare-review <pr-number>`, which generates the review brief, leaves you in an interactive Codex session for follow-up questions or fixes, and then offers the same reviewed commit-message flow as other local fix workflows when that session makes changes
 - `codex` plus authenticated GitHub access for `git-ai issue <number> --mode unattended` and `git-ai issue batch ...`
 - `gh`, `GH_TOKEN`, or `GITHUB_TOKEN` for GitHub-backed issue and pull request flows
 
@@ -92,7 +92,7 @@ You only need extra tooling for advanced workflows:
 - `git-ai setup`: guided repository onboarding for `git-ai`
 - `git-ai review`: review the current diff or a branch comparison
 - `git-ai issue ...`: draft issues, generate issue plans, run single-issue flows, and queue unattended issue batches
-- `git-ai pr prepare-review <pr-number>`: check out a reviewer-ready PR branch and generate a persisted local review brief
+- `git-ai pr prepare-review <pr-number>`: check out a reviewer-ready PR branch, generate a persisted local review brief, and optionally review a follow-up fix commit
 - `git-ai pr fix-comments <pr-number>`: fix selected PR review comments with Codex
 - `git-ai pr fix-tests <pr-number>`: implement selected AI PR test suggestions with Codex
 - `git-ai test-backlog`: find high-value automated testing gaps
@@ -375,7 +375,7 @@ Available subcommands:
 
 | Command | What it does |
 | --- | --- |
-| `git-ai pr prepare-review <pr-number>` | Fetches pull request metadata and linked issues, requires a clean working tree, checks out the best available local review branch for the PR, writes `.git-ai/` run artifacts, generates `review-brief.md`, prints the saved brief path plus a terminal preview, and then leaves you in an interactive Codex session on that branch for follow-up review questions or requested fixes. |
+| `git-ai pr prepare-review <pr-number>` | Fetches pull request metadata and linked issues, requires a clean working tree, checks out the best available local review branch for the PR, writes `.git-ai/` run artifacts, generates `review-brief.md`, prints the saved brief path plus a terminal preview, and then leaves you in an interactive Codex session on that branch for follow-up review questions or requested fixes. After that session exits, `git-ai` exits cleanly if nothing changed, or else runs the configured build command and offers the same reviewed commit-message flow used by the other local fix workflows. |
 | `git-ai pr fix-comments <pr-number>` | Fetches pull request metadata and review comments from the configured forge, filters out obviously non-actionable comments, groups nearby threads into selectable review tasks, preserves non-trivial replies as thread context, writes richer `.git-ai/` run artifacts, opens the configured interactive runtime, runs the configured build command, and then previews a proposed commit message that you can edit, accept, or skip. |
 | `git-ai pr fix-tests <pr-number>` | Fetches pull request metadata and PR issue comments from the configured forge, finds the managed AI Test Suggestions comment, parses structured suggestion areas into selectable tasks, writes focused `.git-ai/` run artifacts, opens the configured interactive runtime, runs the configured build command, and then previews a proposed commit message that you can edit, accept, or skip. |
 
@@ -389,6 +389,8 @@ Important behavior:
 - otherwise `git-ai pr prepare-review <pr-number>` checks out the local PR head branch when it already exists, or fetches the PR head into a dedicated `review/pr-<pr-number>-<slug>` branch
 - `git-ai pr prepare-review <pr-number>` writes `prompt.md`, `metadata.json`, `output.log`, and `review-brief.md` under a timestamped `.git-ai/runs/` directory and may also write supporting workflow artifacts there
 - after generating the brief, `git-ai pr prepare-review <pr-number>` drops you into an interactive Codex shell so you can ask follow-up questions or request fixes before exiting Codex
+- after that interactive session exits, `git-ai pr prepare-review <pr-number>` exits without build or commit steps if nothing changed
+- if the follow-up session changed files, `git-ai pr prepare-review <pr-number>` runs the configured build command and then previews a proposed commit message that you can accept, edit, or skip
 - when a linked issue has a live saved Codex session, `git-ai pr prepare-review <pr-number>` reuses it for brief generation and the follow-up interactive session; stale sessions are warned about and fall back to a fresh run
 - local PR comment-fix runs require the configured runtime CLI on `PATH`
 - local PR test-fix runs require the configured runtime CLI on `PATH`

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1385,7 +1385,7 @@ describe("CLI integration", () => {
     );
   });
 
-  it("runs pr prepare-review, reuses the linked issue branch and resumes a live Codex session", async () => {
+  it("runs pr prepare-review, reuses the linked issue branch, and exits cleanly when follow-up makes no changes", async () => {
     const beforeRuns = listRunDirectories();
     const issueNumber = 211;
     const branchName = "feat/issue-211-review-setup";
@@ -1454,7 +1454,7 @@ describe("CLI integration", () => {
       );
     vi.stubGlobal("fetch", fetchMock);
 
-    const { run, spawnSync } = await loadCli({
+    const { run, spawnSync, generateCommitMessage } = await loadCli({
       execFileSyncImpl: (command, args) => {
         if (command === "git" && args[0] === "status") {
           return "";
@@ -1518,6 +1518,10 @@ describe("CLI integration", () => {
 
     process.env.GITHUB_TOKEN = "test-token";
     process.argv = ["node", "git-ai", "pr", "prepare-review", "87"];
+    const messages: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((message?: unknown) => {
+      messages.push(String(message ?? ""));
+    });
 
     await run();
 
@@ -1595,6 +1599,17 @@ describe("CLI integration", () => {
         stdio: "inherit",
       })
     );
+    expect(messages.join("\n")).toContain(
+      "Codex exited without producing any file changes to review or commit."
+    );
+    expect(generateCommitMessage).not.toHaveBeenCalled();
+    expect(
+      spawnSync.mock.calls.some(
+        ([command, args]) =>
+          command === "pnpm" ||
+          (command === "git" && Array.isArray(args) && args[0] === "commit")
+      )
+    ).toBe(false);
   });
 
   it("falls back to a fresh Codex run when the linked issue session is stale", async () => {
@@ -1773,6 +1788,389 @@ describe("CLI integration", () => {
         stdio: "inherit",
       })
     );
+  });
+
+  it("runs pr prepare-review follow-up fixes through build verification and reviewed commit flow", async () => {
+    const beforeRuns = listRunDirectories();
+    const headBranchName = "feat/prepare-review-follow-up";
+    let gitStatusCallCount = 0;
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      createFetchResponse({
+        number: 206,
+        title: "Tighten prepare-review follow-up fixes",
+        body: "Keep the reviewer workflow open for follow-up fixes and commit review.",
+        html_url: "https://github.com/DevwareUK/git-ai/pull/206",
+        base: { ref: "main" },
+        head: { ref: headBranchName },
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    process.env.OPENAI_API_KEY = "test-key";
+    const { run, spawnSync, generateCommitMessage } = await loadCli({
+      commitMessageResult: {
+        title: "fix: review follow-up fixes for PR #206",
+        body: "Generated after the interactive prepare-review session.",
+      },
+      readlineAnswers: ["y"],
+      execFileSyncImpl: (command, args) => {
+        if (command === "git" && args[0] === "status") {
+          gitStatusCallCount += 1;
+          return gitStatusCallCount === 1
+            ? ""
+            : " M packages/cli/src/workflows/pr-prepare-review/run.ts\n";
+        }
+
+        if (command === "git" && args[0] === "remote") {
+          return "git@github.com:DevwareUK/git-ai.git\n";
+        }
+
+        if (command === "git" && args[0] === "diff" && args[1] === "--name-only") {
+          return "packages/cli/src/workflows/pr-prepare-review/run.ts\n";
+        }
+
+        if (
+          command === "git" &&
+          args[0] === "diff" &&
+          args[1] === "HEAD" &&
+          args[2] === "--" &&
+          args[3] === "packages/cli/src/workflows/pr-prepare-review/run.ts"
+        ) {
+          return [
+            "diff --git a/packages/cli/src/workflows/pr-prepare-review/run.ts b/packages/cli/src/workflows/pr-prepare-review/run.ts",
+            "--- a/packages/cli/src/workflows/pr-prepare-review/run.ts",
+            "+++ b/packages/cli/src/workflows/pr-prepare-review/run.ts",
+            "@@ -1,1 +1,2 @@",
+            '-console.log(\"before\");',
+            '+console.log(\"after\");',
+          ].join("\n");
+        }
+
+        throw new Error(`Unexpected execFileSync call: ${command} ${args.join(" ")}`);
+      },
+      spawnSyncImpl: (command, args) => {
+        if (command === "gh" && args[0] === "--version") {
+          return { status: 1, error: new Error("gh is unavailable") };
+        }
+
+        if (command === "codex" && args[0] === "--version") {
+          return { status: 0 };
+        }
+
+        if (command === "git" && args[0] === "rev-parse" && args[2] === headBranchName) {
+          return { status: 0 };
+        }
+
+        if (command === "git" && args[0] === "checkout" && args[1] === headBranchName) {
+          return { status: 0, stdout: "", stderr: "" };
+        }
+
+        if (command === "codex" && args[0] === "exec" && args[1] === "--full-auto") {
+          const createdRunDir = listRunDirectories().find(
+            (entry) => !beforeRuns.includes(entry)
+          );
+          if (!createdRunDir) {
+            throw new Error("Expected a prepare-review run directory before fresh Codex run.");
+          }
+
+          writeFileSync(
+            resolve(REPO_ROOT, ".git-ai", "runs", createdRunDir, "review-brief.md"),
+            ["# Review Brief", "", "## Reviewer Commands", "- `pnpm build`"].join("\n"),
+            "utf8"
+          );
+
+          return { status: 0, stdout: "brief generated\n", stderr: "" };
+        }
+
+        if (command === "codex" && args[0] === "--sandbox") {
+          return { status: 0 };
+        }
+
+        if (command === "pnpm" && args[0] === "--version") {
+          return { status: 0 };
+        }
+
+        if (command === "pnpm" && args[0] === "build") {
+          return { status: 0, stdout: "build ok\n", stderr: "" };
+        }
+
+        if (command === "git" && args[0] === "add") {
+          return { status: 0 };
+        }
+
+        if (command === "git" && args[0] === "commit") {
+          return { status: 0 };
+        }
+
+        throw new Error(`Unexpected spawnSync call: ${command} ${args.join(" ")}`);
+      },
+    });
+
+    process.env.GITHUB_TOKEN = "test-token";
+    process.argv = ["node", "git-ai", "pr", "prepare-review", "206"];
+    const stdout = captureStdout();
+
+    await run();
+
+    const createdRunDir = listRunDirectories().find((entry) => !beforeRuns.includes(entry));
+    expect(createdRunDir).toBeDefined();
+
+    const runDirPath = resolve(REPO_ROOT, ".git-ai", "runs", createdRunDir as string);
+    const outputLogPath = resolve(runDirPath, "output.log");
+    cleanupTargets.add(runDirPath);
+
+    const commitCall = spawnSync.mock.calls.find(
+      ([command, args]) =>
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "commit"
+    );
+    expect(commitCall).toBeDefined();
+    const commitArgs = commitCall?.[1] as string[];
+    expect(commitArgs).toEqual(["commit", "-F", expect.stringContaining("commit-message.txt")]);
+    expect(readFileSync(commitArgs[2], "utf8")).toContain(
+      "fix: review follow-up fixes for PR #206"
+    );
+    expect(readFileSync(outputLogPath, "utf8")).toContain("$ pnpm build");
+    expect(stdout.output()).toContain("Proposed commit message");
+    expect(generateCommitMessage).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.stringContaining(
+        "diff --git a/packages/cli/src/workflows/pr-prepare-review/run.ts b/packages/cli/src/workflows/pr-prepare-review/run.ts"
+      )
+    );
+  });
+
+  it("leaves pr prepare-review follow-up changes uncommitted when the reviewed message is declined", async () => {
+    const beforeRuns = listRunDirectories();
+    const headBranchName = "feat/prepare-review-skip-commit";
+    let gitStatusCallCount = 0;
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      createFetchResponse({
+        number: 207,
+        title: "Skip prepare-review follow-up commit",
+        body: "Offer commit review after the follow-up session.",
+        html_url: "https://github.com/DevwareUK/git-ai/pull/207",
+        base: { ref: "main" },
+        head: { ref: headBranchName },
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    process.env.OPENAI_API_KEY = "test-key";
+    const { run, spawnSync } = await loadCli({
+      commitMessageResult: {
+        title: "fix: stage follow-up prepare-review changes",
+      },
+      readlineAnswers: ["n"],
+      execFileSyncImpl: (command, args) => {
+        if (command === "git" && args[0] === "status") {
+          gitStatusCallCount += 1;
+          return gitStatusCallCount === 1 ? "" : " M README.md\n";
+        }
+
+        if (command === "git" && args[0] === "remote") {
+          return "git@github.com:DevwareUK/git-ai.git\n";
+        }
+
+        if (command === "git" && args[0] === "diff" && args[1] === "--name-only") {
+          return "README.md\n";
+        }
+
+        if (
+          command === "git" &&
+          args[0] === "diff" &&
+          args[1] === "HEAD" &&
+          args[2] === "--" &&
+          args[3] === "README.md"
+        ) {
+          return [
+            "diff --git a/README.md b/README.md",
+            "--- a/README.md",
+            "+++ b/README.md",
+            "@@ -1,1 +1,2 @@",
+            "-old",
+            "+new",
+          ].join("\n");
+        }
+
+        throw new Error(`Unexpected execFileSync call: ${command} ${args.join(" ")}`);
+      },
+      spawnSyncImpl: (command, args) => {
+        if (command === "gh" && args[0] === "--version") {
+          return { status: 1, error: new Error("gh is unavailable") };
+        }
+
+        if (command === "codex" && args[0] === "--version") {
+          return { status: 0 };
+        }
+
+        if (command === "git" && args[0] === "rev-parse" && args[2] === headBranchName) {
+          return { status: 0 };
+        }
+
+        if (command === "git" && args[0] === "checkout" && args[1] === headBranchName) {
+          return { status: 0, stdout: "", stderr: "" };
+        }
+
+        if (command === "codex" && args[0] === "exec" && args[1] === "--full-auto") {
+          const createdRunDir = listRunDirectories().find(
+            (entry) => !beforeRuns.includes(entry)
+          );
+          if (!createdRunDir) {
+            throw new Error("Expected a prepare-review run directory before fresh Codex run.");
+          }
+
+          writeFileSync(
+            resolve(REPO_ROOT, ".git-ai", "runs", createdRunDir, "review-brief.md"),
+            ["# Review Brief", "", "## Reviewer Commands", "- `pnpm build`"].join("\n"),
+            "utf8"
+          );
+
+          return { status: 0, stdout: "brief generated\n", stderr: "" };
+        }
+
+        if (command === "codex" && args[0] === "--sandbox") {
+          return { status: 0 };
+        }
+
+        if (command === "pnpm" && args[0] === "--version") {
+          return { status: 0 };
+        }
+
+        if (command === "pnpm" && args[0] === "build") {
+          return { status: 0, stdout: "build ok\n", stderr: "" };
+        }
+
+        if (command === "git" && args[0] === "add") {
+          return { status: 0 };
+        }
+
+        if (command === "git" && args[0] === "commit") {
+          return { status: 0 };
+        }
+
+        throw new Error(`Unexpected spawnSync call: ${command} ${args.join(" ")}`);
+      },
+    });
+
+    process.env.GITHUB_TOKEN = "test-token";
+    process.argv = ["node", "git-ai", "pr", "prepare-review", "207"];
+
+    const messages: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((message?: unknown) => {
+      messages.push(String(message ?? ""));
+    });
+    await run();
+
+    expect(messages.join("\n")).toContain("Leaving the generated changes uncommitted.");
+    expect(
+      spawnSync.mock.calls.some(
+        ([command, args]) =>
+          command === "git" &&
+          Array.isArray(args) &&
+          args[0] === "commit"
+      )
+    ).toBe(false);
+  });
+
+  it("stops pr prepare-review before commit review when the follow-up build fails", async () => {
+    const beforeRuns = listRunDirectories();
+    const headBranchName = "feat/prepare-review-build-failure";
+    let gitStatusCallCount = 0;
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      createFetchResponse({
+        number: 208,
+        title: "Fail prepare-review follow-up build",
+        body: "Build verification must stop before commit creation.",
+        html_url: "https://github.com/DevwareUK/git-ai/pull/208",
+        base: { ref: "main" },
+        head: { ref: headBranchName },
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { run, spawnSync, generateCommitMessage } = await loadCli({
+      readlineAnswers: ["y"],
+      execFileSyncImpl: (command, args) => {
+        if (command === "git" && args[0] === "status") {
+          gitStatusCallCount += 1;
+          return gitStatusCallCount === 1 ? "" : " M README.md\n";
+        }
+
+        if (command === "git" && args[0] === "remote") {
+          return "git@github.com:DevwareUK/git-ai.git\n";
+        }
+
+        throw new Error(`Unexpected execFileSync call: ${command} ${args.join(" ")}`);
+      },
+      spawnSyncImpl: (command, args) => {
+        if (command === "gh" && args[0] === "--version") {
+          return { status: 1, error: new Error("gh is unavailable") };
+        }
+
+        if (command === "codex" && args[0] === "--version") {
+          return { status: 0 };
+        }
+
+        if (command === "git" && args[0] === "rev-parse" && args[2] === headBranchName) {
+          return { status: 0 };
+        }
+
+        if (command === "git" && args[0] === "checkout" && args[1] === headBranchName) {
+          return { status: 0, stdout: "", stderr: "" };
+        }
+
+        if (command === "codex" && args[0] === "exec" && args[1] === "--full-auto") {
+          const createdRunDir = listRunDirectories().find(
+            (entry) => !beforeRuns.includes(entry)
+          );
+          if (!createdRunDir) {
+            throw new Error("Expected a prepare-review run directory before fresh Codex run.");
+          }
+
+          writeFileSync(
+            resolve(REPO_ROOT, ".git-ai", "runs", createdRunDir, "review-brief.md"),
+            ["# Review Brief", "", "## Reviewer Commands", "- `pnpm build`"].join("\n"),
+            "utf8"
+          );
+
+          return { status: 0, stdout: "brief generated\n", stderr: "" };
+        }
+
+        if (command === "codex" && args[0] === "--sandbox") {
+          return { status: 0 };
+        }
+
+        if (command === "pnpm" && args[0] === "--version") {
+          return { status: 0 };
+        }
+
+        if (command === "pnpm" && args[0] === "build") {
+          return { status: 1, stdout: "", stderr: "build failed\n" };
+        }
+
+        if (command === "git" && args[0] === "commit") {
+          return { status: 0 };
+        }
+
+        throw new Error(`Unexpected spawnSync call: ${command} ${args.join(" ")}`);
+      },
+    });
+
+    process.env.GITHUB_TOKEN = "test-token";
+    process.argv = ["node", "git-ai", "pr", "prepare-review", "208"];
+
+    await expect(run()).rejects.toThrow("Build failed. Changes were not committed.");
+    expect(generateCommitMessage).not.toHaveBeenCalled();
+    expect(
+      spawnSync.mock.calls.some(
+        ([command, args]) =>
+          command === "git" &&
+          Array.isArray(args) &&
+          args[0] === "commit"
+      )
+    ).toBe(false);
   });
 
   it("fetches a dedicated local review branch when no saved issue state or local head branch exists", async () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -53,6 +53,10 @@ import {
   type ReviewedGeneratedText,
   validateCommitMessage,
 } from "./generated-text-review";
+import {
+  finalizeRuntimeChanges,
+  generateDiffBasedCommitProposal,
+} from "./runtime-change-review";
 import { resolveRuntimeRepoRoot } from "./repo-root";
 import {
   findTrackedRuntimeSessionById,
@@ -2014,39 +2018,6 @@ function createStandaloneIssueFinalizeRunDir(repoRoot: string, issueNumber: numb
   return runDir;
 }
 
-async function reviewCommitMessage(
-  repoRoot: string,
-  issueNumber: number,
-  prompt: string,
-  initialMessage: string,
-  runDir?: string
-): Promise<ReviewedGeneratedText | null> {
-  const reviewRunDir = runDir ?? createStandaloneIssueFinalizeRunDir(repoRoot, issueNumber);
-  return reviewGeneratedText({
-    filePath: resolve(reviewRunDir, "commit-message.txt"),
-    initialContent: initialMessage,
-    previewHeading: "Proposed commit message",
-    prompt,
-    emptyContentMessage: "Commit message cannot be empty.",
-    editorDescription: "commit message",
-    promptForLine,
-    validate: validateCommitMessage,
-  });
-}
-
-async function generateIssueCommitProposal(
-  repoRoot: string,
-  provider: AIProvider
-): Promise<{ diff: string; initialMessage: string }> {
-  const diff = readIssueWorkflowDiff(repoRoot);
-  const result = await generateCommitMessage(provider, diff);
-
-  return {
-    diff,
-    initialMessage: formatCommitMessage(result.title, result.body),
-  };
-}
-
 function createAutoAcceptedGeneratedText(
   filePath: string,
   content: string
@@ -2067,7 +2038,11 @@ async function finalizeIssueRunUnattended(
   provider: AIProvider,
   runDir: string
 ): Promise<Extract<FinalizeIssueRunResult, { committed: true }>> {
-  const proposal = await generateIssueCommitProposal(repoRoot, provider);
+  const proposal = await generateDiffBasedCommitProposal(
+    repoRoot,
+    provider,
+    readIssueWorkflowDiff
+  );
   const commitMessage = createAutoAcceptedGeneratedText(
     resolve(runDir, "commit-message.txt"),
     proposal.initialMessage
@@ -2376,6 +2351,12 @@ async function runPrCommand(): Promise<void> {
       buildCommand: repositoryConfig.buildCommand,
       forge: getRepositoryForge(repoRoot),
       ensureCleanWorkingTree,
+      promptForLine,
+      hasChanges,
+      verifyBuild,
+      commitGeneratedChanges,
+      readDiff: readIssueWorkflowDiff,
+      createProvider: async (providerRepoRoot) => createProvider(providerRepoRoot),
     });
     return;
   }
@@ -3021,28 +3002,32 @@ async function finalizeIssueRun(
   provider: AIProvider,
   runDir?: string
 ): Promise<FinalizeIssueRunResult> {
-  const proposal = await generateIssueCommitProposal(repoRoot, provider);
-  const reviewedCommitMessage = await reviewCommitMessage(
+  const proposal = await generateDiffBasedCommitProposal(
     repoRoot,
-    issueNumber,
-    "Commit generated changes with this message? [Y/n/m]: ",
-    proposal.initialMessage,
-    runDir
+    provider,
+    readIssueWorkflowDiff
   );
-
-  if (!reviewedCommitMessage) {
-    console.log("Leaving the generated changes uncommitted.");
+  const reviewRunDir = runDir ?? createStandaloneIssueFinalizeRunDir(repoRoot, issueNumber);
+  const finalized = await finalizeRuntimeChanges({
+    repoRoot,
+    runDir: reviewRunDir,
+    commitPrompt: "Commit generated changes with this message? [Y/n/m]: ",
+    promptForLine,
+    hasChanges,
+    commitGeneratedChanges,
+    resolveInitialCommitMessage: async () => proposal.initialMessage,
+    noChangesMessage: "The interactive runtime completed without producing any file changes to commit.",
+  });
+  if (!finalized.committed) {
     return {
       committed: false,
     };
   }
 
-  console.log("Committing generated changes...");
-  commitGeneratedChanges(repoRoot, reviewedCommitMessage);
   return {
     committed: true,
     diff: proposal.diff,
-    commitMessage: reviewedCommitMessage,
+    commitMessage: finalized.commitMessage,
   };
 }
 

--- a/packages/cli/src/runtime-change-review.test.ts
+++ b/packages/cli/src/runtime-change-review.test.ts
@@ -1,0 +1,120 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { finalizeRuntimeChanges } from "./runtime-change-review";
+
+const cleanupTargets = new Set<string>();
+
+function createRunDir(): string {
+  const runDir = mkdtempSync(resolve(tmpdir(), "git-ai-runtime-change-review-"));
+  cleanupTargets.add(runDir);
+  return runDir;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+
+  for (const target of cleanupTargets) {
+    rmSync(target, { recursive: true, force: true });
+  }
+  cleanupTargets.clear();
+});
+
+describe("finalizeRuntimeChanges", () => {
+  it("returns without committing when no changes exist before build verification", async () => {
+    const run = vi.fn();
+    const promptForLine = vi.fn();
+    const resolveInitialCommitMessage = vi.fn();
+    const commitGeneratedChanges = vi.fn();
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await expect(
+      finalizeRuntimeChanges({
+        repoRoot: "/repo",
+        runDir: createRunDir(),
+        commitPrompt: "Commit generated changes? [Y/n/m]: ",
+        promptForLine,
+        hasChanges: vi.fn().mockReturnValue(false),
+        commitGeneratedChanges,
+        resolveInitialCommitMessage,
+        noChangesMessage: "No follow-up changes were made.",
+        noChangesAction: "return",
+        verifyBuild: {
+          buildCommand: ["pnpm", "build"],
+          outputLogPath: "/tmp/output.log",
+          run,
+        },
+        checkForChangesBeforeBuild: true,
+      })
+    ).resolves.toEqual({
+      committed: false,
+      reason: "no-changes",
+    });
+
+    expect(run).not.toHaveBeenCalled();
+    expect(promptForLine).not.toHaveBeenCalled();
+    expect(resolveInitialCommitMessage).not.toHaveBeenCalled();
+    expect(commitGeneratedChanges).not.toHaveBeenCalled();
+    expect(consoleLog).toHaveBeenCalledWith("No follow-up changes were made.");
+  });
+
+  it("stops before commit review when build verification fails", async () => {
+    const promptForLine = vi.fn();
+    const resolveInitialCommitMessage = vi.fn();
+    const commitGeneratedChanges = vi.fn();
+
+    await expect(
+      finalizeRuntimeChanges({
+        repoRoot: "/repo",
+        runDir: createRunDir(),
+        commitPrompt: "Commit generated changes? [Y/n/m]: ",
+        promptForLine,
+        hasChanges: vi.fn().mockReturnValue(true),
+        commitGeneratedChanges,
+        resolveInitialCommitMessage,
+        noChangesMessage: "No follow-up changes were made.",
+        noChangesAction: "return",
+        verifyBuild: {
+          buildCommand: ["pnpm", "build"],
+          outputLogPath: "/tmp/output.log",
+          run: vi.fn(() => {
+            throw new Error("Build failed.");
+          }),
+        },
+        checkForChangesBeforeBuild: true,
+      })
+    ).rejects.toThrow("Build failed.");
+
+    expect(promptForLine).not.toHaveBeenCalled();
+    expect(resolveInitialCommitMessage).not.toHaveBeenCalled();
+    expect(commitGeneratedChanges).not.toHaveBeenCalled();
+  });
+
+  it("leaves generated changes uncommitted when the reviewed commit message is declined", async () => {
+    const commitGeneratedChanges = vi.fn();
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await expect(
+      finalizeRuntimeChanges({
+        repoRoot: "/repo",
+        runDir: createRunDir(),
+        commitPrompt: "Commit generated changes? [Y/n/m]: ",
+        promptForLine: vi.fn().mockResolvedValue("n"),
+        hasChanges: vi.fn().mockReturnValue(true),
+        commitGeneratedChanges,
+        resolveInitialCommitMessage: vi
+          .fn()
+          .mockResolvedValue("fix: keep follow-up changes uncommitted\n"),
+        noChangesMessage: "No follow-up changes were made.",
+        noChangesAction: "return",
+      })
+    ).resolves.toEqual({
+      committed: false,
+      reason: "declined",
+    });
+
+    expect(commitGeneratedChanges).not.toHaveBeenCalled();
+    expect(consoleLog).toHaveBeenCalledWith("Leaving the generated changes uncommitted.");
+  });
+});

--- a/packages/cli/src/runtime-change-review.ts
+++ b/packages/cli/src/runtime-change-review.ts
@@ -1,0 +1,140 @@
+import { resolve } from "node:path";
+import { generateCommitMessage } from "@git-ai/core";
+import type { AIProvider } from "@git-ai/providers";
+import {
+  reviewGeneratedText,
+  type ReviewedGeneratedText,
+  validateCommitMessage,
+} from "./generated-text-review";
+
+function formatCommitMessage(title: string, body?: string): string {
+  return body ? `${title}\n\n${body}\n` : `${title}\n`;
+}
+
+export async function generateDiffBasedCommitProposal(
+  repoRoot: string,
+  provider: AIProvider,
+  readDiff: (repoRoot: string) => string
+): Promise<{ diff: string; initialMessage: string }> {
+  const diff = readDiff(repoRoot);
+  const result = await generateCommitMessage(provider, diff);
+
+  return {
+    diff,
+    initialMessage: formatCommitMessage(result.title, result.body),
+  };
+}
+
+type ReviewCommitMessageOptions = {
+  runDir: string;
+  initialMessage: string;
+  prompt: string;
+  promptForLine(prompt: string): Promise<string>;
+};
+
+export async function reviewCommitMessage(
+  options: ReviewCommitMessageOptions
+): Promise<ReviewedGeneratedText | null> {
+  return reviewGeneratedText({
+    filePath: resolve(options.runDir, "commit-message.txt"),
+    initialContent: options.initialMessage,
+    previewHeading: "Proposed commit message",
+    prompt: options.prompt,
+    emptyContentMessage: "Commit message cannot be empty.",
+    editorDescription: "commit message",
+    promptForLine: options.promptForLine,
+    validate: validateCommitMessage,
+  });
+}
+
+type FinalizeRuntimeChangesOptions = {
+  repoRoot: string;
+  runDir: string;
+  commitPrompt: string;
+  promptForLine(prompt: string): Promise<string>;
+  hasChanges(repoRoot: string): boolean;
+  commitGeneratedChanges(repoRoot: string, commitMessage: ReviewedGeneratedText): void;
+  resolveInitialCommitMessage(): Promise<string>;
+  noChangesMessage: string;
+  noChangesAction?: "return" | "throw";
+  verifyBuild?: {
+    buildCommand: string[];
+    outputLogPath: string;
+    run(repoRoot: string, buildCommand: string[], outputLogPath: string): void;
+  };
+  checkForChangesBeforeBuild?: boolean;
+};
+
+function handleNoChanges(
+  action: "return" | "throw",
+  message: string
+): Extract<
+  Awaited<ReturnType<typeof finalizeRuntimeChanges>>,
+  { committed: false; reason: "no-changes" }
+> {
+  if (action === "throw") {
+    throw new Error(message);
+  }
+
+  console.log(message);
+  return {
+    committed: false,
+    reason: "no-changes",
+  };
+}
+
+export async function finalizeRuntimeChanges(
+  options: FinalizeRuntimeChangesOptions
+): Promise<
+  | {
+      committed: false;
+      reason: "declined" | "no-changes";
+    }
+  | {
+      committed: true;
+      commitMessage: ReviewedGeneratedText;
+    }
+> {
+  const noChangesAction = options.noChangesAction ?? "throw";
+  const checkForChangesBeforeBuild = options.checkForChangesBeforeBuild ?? false;
+
+  if (checkForChangesBeforeBuild && !options.hasChanges(options.repoRoot)) {
+    return handleNoChanges(noChangesAction, options.noChangesMessage);
+  }
+
+  if (options.verifyBuild) {
+    console.log("Verifying build...");
+    options.verifyBuild.run(
+      options.repoRoot,
+      options.verifyBuild.buildCommand,
+      options.verifyBuild.outputLogPath
+    );
+  }
+
+  if (!checkForChangesBeforeBuild && !options.hasChanges(options.repoRoot)) {
+    return handleNoChanges(noChangesAction, options.noChangesMessage);
+  }
+
+  const initialCommitMessage = await options.resolveInitialCommitMessage();
+  const reviewedCommitMessage = await reviewCommitMessage({
+    runDir: options.runDir,
+    initialMessage: initialCommitMessage,
+    prompt: options.commitPrompt,
+    promptForLine: options.promptForLine,
+  });
+  if (!reviewedCommitMessage) {
+    console.log("Leaving the generated changes uncommitted.");
+    return {
+      committed: false,
+      reason: "declined",
+    };
+  }
+
+  console.log("Committing generated changes...");
+  options.commitGeneratedChanges(options.repoRoot, reviewedCommitMessage);
+
+  return {
+    committed: true,
+    commitMessage: reviewedCommitMessage,
+  };
+}

--- a/packages/cli/src/workflows/pr-fix-comments/run.ts
+++ b/packages/cli/src/workflows/pr-fix-comments/run.ts
@@ -1,14 +1,10 @@
-import { resolve } from "node:path";
 import type {
   PullRequestDetails,
   PullRequestReviewComment,
   RepositoryForge,
 } from "../../forge";
-import {
-  reviewGeneratedText,
-  type ReviewedGeneratedText,
-  validateCommitMessage,
-} from "../../generated-text-review";
+import type { ReviewedGeneratedText } from "../../generated-text-review";
+import { finalizeRuntimeChanges } from "../../runtime-change-review";
 import {
   buildPullRequestReviewTasks,
   buildPullRequestReviewThreads,
@@ -243,21 +239,15 @@ export async function runPrFixCommentsCommand(
     );
   }
 
-  const reviewedCommitMessage = await reviewGeneratedText({
-    filePath: resolve(workspace.runDir, "commit-message.txt"),
-    initialContent: `fix: address PR review comments for #${pullRequest.number}\n`,
-    previewHeading: "Proposed commit message",
-    prompt: "Commit fixes with this message? [Y/n/m]: ",
-    emptyContentMessage: "Commit message cannot be empty.",
-    editorDescription: "commit message",
+  await finalizeRuntimeChanges({
+    repoRoot: options.repoRoot,
+    runDir: workspace.runDir,
+    commitPrompt: "Commit fixes with this message? [Y/n/m]: ",
     promptForLine: options.promptForLine,
-    validate: validateCommitMessage,
+    hasChanges: options.hasChanges,
+    commitGeneratedChanges: options.commitGeneratedChanges,
+    resolveInitialCommitMessage: async () =>
+      `fix: address PR review comments for #${pullRequest.number}\n`,
+    noChangesMessage: `${runtime.displayName} completed without producing any file changes to commit.`,
   });
-  if (!reviewedCommitMessage) {
-    console.log("Leaving the generated changes uncommitted.");
-    return;
-  }
-
-  console.log("Committing generated changes...");
-  options.commitGeneratedChanges(options.repoRoot, reviewedCommitMessage);
 }

--- a/packages/cli/src/workflows/pr-fix-tests/run.ts
+++ b/packages/cli/src/workflows/pr-fix-tests/run.ts
@@ -1,10 +1,6 @@
-import { resolve } from "node:path";
 import type { PullRequestDetails, RepositoryForge } from "../../forge";
-import {
-  reviewGeneratedText,
-  type ReviewedGeneratedText,
-  validateCommitMessage,
-} from "../../generated-text-review";
+import type { ReviewedGeneratedText } from "../../generated-text-review";
+import { finalizeRuntimeChanges } from "../../runtime-change-review";
 import {
   findManagedTestSuggestionsComment,
   parseManagedTestSuggestionsComment,
@@ -144,21 +140,15 @@ export async function runPrFixTestsCommand(
     );
   }
 
-  const reviewedCommitMessage = await reviewGeneratedText({
-    filePath: resolve(workspace.runDir, "commit-message.txt"),
-    initialContent: `test: address AI test suggestions for PR #${pullRequest.number}\n`,
-    previewHeading: "Proposed commit message",
-    prompt: "Commit fixes with this message? [Y/n/m]: ",
-    emptyContentMessage: "Commit message cannot be empty.",
-    editorDescription: "commit message",
+  await finalizeRuntimeChanges({
+    repoRoot: options.repoRoot,
+    runDir: workspace.runDir,
+    commitPrompt: "Commit fixes with this message? [Y/n/m]: ",
     promptForLine: options.promptForLine,
-    validate: validateCommitMessage,
+    hasChanges: options.hasChanges,
+    commitGeneratedChanges: options.commitGeneratedChanges,
+    resolveInitialCommitMessage: async () =>
+      `test: address AI test suggestions for PR #${pullRequest.number}\n`,
+    noChangesMessage: `${runtime.displayName} completed without producing any file changes to commit.`,
   });
-  if (!reviewedCommitMessage) {
-    console.log("Leaving the generated changes uncommitted.");
-    return;
-  }
-
-  console.log("Committing generated changes...");
-  options.commitGeneratedChanges(options.repoRoot, reviewedCommitMessage);
 }

--- a/packages/cli/src/workflows/pr-prepare-review/run.test.ts
+++ b/packages/cli/src/workflows/pr-prepare-review/run.test.ts
@@ -1,0 +1,268 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PullRequestDetails, RepositoryForge } from "../../forge";
+import type { PullRequestPrepareReviewWorkspace } from "./types";
+
+vi.mock("node:child_process", () => ({
+  spawnSync: vi.fn(),
+}));
+
+vi.mock("./snapshot", () => ({
+  fetchLinkedIssuesForPullRequest: vi.fn(),
+}));
+
+vi.mock("./workspace", () => ({
+  appendPullRequestPrepareReviewWarning: vi.fn(),
+  createPullRequestPrepareReviewWorkspace: vi.fn(),
+  initializePullRequestPrepareReviewOutputLog: vi.fn(),
+  writePullRequestPrepareReviewMetadata: vi.fn(),
+  writePullRequestPrepareReviewWorkspaceFiles: vi.fn(),
+}));
+
+vi.mock("../../runtime", () => ({
+  findTrackedRuntimeSessionById: vi.fn(),
+  getInteractiveRuntimeByType: vi.fn(),
+  launchUnattendedRuntime: vi.fn(),
+}));
+
+vi.mock("../../runtime-change-review", () => ({
+  finalizeRuntimeChanges: vi.fn(),
+  generateDiffBasedCommitProposal: vi.fn(),
+}));
+
+import { runPrPrepareReviewCommand } from "./run";
+import { fetchLinkedIssuesForPullRequest } from "./snapshot";
+import {
+  createPullRequestPrepareReviewWorkspace,
+  initializePullRequestPrepareReviewOutputLog,
+  writePullRequestPrepareReviewMetadata,
+  writePullRequestPrepareReviewWorkspaceFiles,
+} from "./workspace";
+import {
+  getInteractiveRuntimeByType,
+  launchUnattendedRuntime,
+} from "../../runtime";
+import {
+  finalizeRuntimeChanges,
+  generateDiffBasedCommitProposal,
+} from "../../runtime-change-review";
+
+const cleanupTargets = new Set<string>();
+
+function createPullRequest(): PullRequestDetails {
+  return {
+    number: 206,
+    title: "Tighten prepare-review follow-up fixes",
+    body: "Closes #205\n\nCarry the review follow-up flow through commit proposal generation.",
+    url: "https://github.com/DevwareUK/git-ai/pull/206",
+    baseRefName: "main",
+    headRefName: "feat/prepare-review-follow-up",
+  };
+}
+
+function createForge(): {
+  forge: RepositoryForge;
+  fetchPullRequestDetails: ReturnType<typeof vi.fn>;
+} {
+  const fetchPullRequestDetails = vi.fn().mockResolvedValue(createPullRequest());
+
+  return {
+    forge: {
+      type: "github",
+      isAuthenticated: () => true,
+      fetchIssueDetails: vi.fn(),
+      fetchIssuePlanComment: vi.fn(),
+      fetchPullRequestDetails,
+      fetchPullRequestIssueComments: vi.fn(),
+      fetchPullRequestReviewComments: vi.fn(),
+      createIssuePlanComment: vi.fn(),
+      createDraftIssue: vi.fn(),
+      createOrReuseIssue: vi.fn(),
+      createPullRequest: vi.fn(),
+    },
+    fetchPullRequestDetails,
+  };
+}
+
+function createWorkspace(repoRoot: string): PullRequestPrepareReviewWorkspace {
+  const runDir = resolve(
+    repoRoot,
+    ".git-ai/runs/20260417T155614124Z-pr-206-prepare-review"
+  );
+  mkdirSync(runDir, { recursive: true });
+
+  return {
+    runDir,
+    snapshotFilePath: resolve(runDir, "pr-review-prepare.md"),
+    promptFilePath: resolve(runDir, "prompt.md"),
+    interactivePromptFilePath: resolve(runDir, "interactive-prompt.md"),
+    metadataFilePath: resolve(runDir, "metadata.json"),
+    outputLogPath: resolve(runDir, "output.log"),
+    reviewBriefFilePath: resolve(runDir, "review-brief.md"),
+    assistantLastMessageFilePath: resolve(runDir, "assistant-last-message.txt"),
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+
+  for (const target of cleanupTargets) {
+    rmSync(target, { recursive: true, force: true });
+  }
+  cleanupTargets.clear();
+});
+
+describe("runPrPrepareReviewCommand", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  });
+
+  it("passes a diff-based commit proposal into runtime finalization after interactive follow-up changes", async () => {
+    const repoRoot = mkdtempSync(resolve(tmpdir(), "git-ai-pr-prepare-review-"));
+    cleanupTargets.add(repoRoot);
+
+    const workspace = createWorkspace(repoRoot);
+    const { forge, fetchPullRequestDetails } = createForge();
+    const interactiveLaunch = vi.fn();
+    const provider = { name: "openai" } as unknown;
+    const createProvider = vi.fn().mockResolvedValue({ provider });
+    const readDiff = vi.fn().mockReturnValue("diff --git a/file b/file");
+    const verifyBuild = vi.fn();
+    const commitGeneratedChanges = vi.fn();
+
+    vi.mocked(fetchLinkedIssuesForPullRequest).mockResolvedValue([]);
+    vi.mocked(createPullRequestPrepareReviewWorkspace).mockReturnValue(workspace);
+    vi.mocked(initializePullRequestPrepareReviewOutputLog).mockImplementation(
+      () => undefined
+    );
+    vi.mocked(writePullRequestPrepareReviewWorkspaceFiles).mockImplementation(
+      () => undefined
+    );
+    vi.mocked(writePullRequestPrepareReviewMetadata).mockImplementation(() => undefined);
+    vi.mocked(getInteractiveRuntimeByType).mockReturnValue({
+      checkAvailability: () => ({ available: true }),
+      launch: interactiveLaunch,
+    });
+    vi.mocked(launchUnattendedRuntime).mockImplementation(
+      (_type, _repoRoot, suppliedWorkspace) => {
+        writeFileSync(
+          suppliedWorkspace.reviewBriefFilePath,
+          "# Reviewer focus\n\n- Inspect the follow-up fix.\n",
+          "utf8"
+        );
+
+        return {
+          invocation: "new",
+          sessionId: "codex-session-42",
+        };
+      }
+    );
+    vi.mocked(generateDiffBasedCommitProposal).mockResolvedValue({
+      diff: "diff --git a/file b/file",
+      initialMessage:
+        "fix: apply review follow-up changes\n\nKeep the review branch ready for commit.\n",
+    });
+    vi.mocked(finalizeRuntimeChanges).mockImplementation(async (options) => {
+      await expect(options.resolveInitialCommitMessage()).resolves.toBe(
+        "fix: apply review follow-up changes\n\nKeep the review branch ready for commit.\n"
+      );
+
+      return {
+        committed: true,
+        commitMessage: {
+          content:
+            "fix: apply review follow-up changes\n\nKeep the review branch ready for commit.\n",
+          filePath: resolve(options.runDir, "commit-message.txt"),
+        },
+      };
+    });
+    vi.mocked(spawnSync).mockImplementation((command, args) => {
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "-C" &&
+        args[2] === "rev-parse" &&
+        args[3] === "--verify" &&
+        args[4] === createPullRequest().headRefName
+      ) {
+        return { status: 0 } as never;
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "checkout" &&
+        args[1] === createPullRequest().headRefName
+      ) {
+        return {
+          status: 0,
+          stdout: "",
+          stderr: "",
+        } as never;
+      }
+
+      throw new Error(`Unexpected spawnSync call: ${command} ${String(args)}`);
+    });
+
+    await runPrPrepareReviewCommand({
+      prNumber: 206,
+      repoRoot,
+      buildCommand: ["pnpm", "build"],
+      forge,
+      ensureCleanWorkingTree: vi.fn(),
+      promptForLine: vi.fn(),
+      hasChanges: vi.fn().mockReturnValue(true),
+      verifyBuild,
+      commitGeneratedChanges,
+      readDiff,
+      createProvider,
+    });
+
+    expect(fetchPullRequestDetails).toHaveBeenCalledWith(206);
+    expect(createPullRequestPrepareReviewWorkspace).toHaveBeenCalledWith(repoRoot, 206);
+    expect(launchUnattendedRuntime).toHaveBeenCalledWith("codex", repoRoot, workspace, {
+      resumeSessionId: undefined,
+      outputLastMessageFilePath: workspace.assistantLastMessageFilePath,
+    });
+    expect(interactiveLaunch).toHaveBeenCalledWith(
+      repoRoot,
+      {
+        promptFilePath: workspace.interactivePromptFilePath,
+        outputLogPath: workspace.outputLogPath,
+      },
+      {
+        resumeSessionId: "codex-session-42",
+      }
+    );
+    expect(finalizeRuntimeChanges).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoRoot,
+        runDir: workspace.runDir,
+        commitPrompt: "Commit generated changes with this message? [Y/n/m]: ",
+        promptForLine: expect.any(Function),
+        hasChanges: expect.any(Function),
+        commitGeneratedChanges,
+        noChangesMessage:
+          "Codex exited without producing any file changes to review or commit.",
+        noChangesAction: "return",
+        checkForChangesBeforeBuild: true,
+        verifyBuild: {
+          buildCommand: ["pnpm", "build"],
+          outputLogPath: workspace.outputLogPath,
+          run: verifyBuild,
+        },
+      })
+    );
+    expect(createProvider).toHaveBeenCalledWith(repoRoot);
+    expect(generateDiffBasedCommitProposal).toHaveBeenCalledWith(
+      repoRoot,
+      provider,
+      readDiff
+    );
+  });
+});

--- a/packages/cli/src/workflows/pr-prepare-review/run.ts
+++ b/packages/cli/src/workflows/pr-prepare-review/run.ts
@@ -1,9 +1,17 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync, appendFileSync } from "node:fs";
 import { resolve } from "node:path";
+import type { AIProvider } from "@git-ai/providers";
 import { formatCommandForDisplay } from "../../config";
 import type { RepositoryForge } from "../../forge";
-import { printGeneratedTextPreview } from "../../generated-text-review";
+import {
+  printGeneratedTextPreview,
+  type ReviewedGeneratedText,
+} from "../../generated-text-review";
+import {
+  finalizeRuntimeChanges,
+  generateDiffBasedCommitProposal,
+} from "../../runtime-change-review";
 import {
   findTrackedRuntimeSessionById,
   getInteractiveRuntimeByType,
@@ -35,6 +43,12 @@ type RunPrPrepareReviewCommandOptions = {
   buildCommand: string[];
   forge: RepositoryForge;
   ensureCleanWorkingTree(repoRoot: string): void;
+  promptForLine(prompt: string): Promise<string>;
+  hasChanges(repoRoot: string): boolean;
+  verifyBuild(repoRoot: string, buildCommand: string[], outputLogPath: string): void;
+  commitGeneratedChanges(repoRoot: string, commitMessage: ReviewedGeneratedText): void;
+  readDiff(repoRoot: string): string;
+  createProvider(repoRoot: string): Promise<{ provider: AIProvider }>;
 };
 
 function appendRunLog(
@@ -439,14 +453,44 @@ export async function runPrPrepareReviewCommand(
     interactiveRuntime.launch(options.repoRoot, interactiveWorkspace, {
       resumeSessionId: interactiveResumeSessionId,
     });
+  } else {
+    console.log(
+      "Opening a fresh interactive Codex session in this terminal because the generated session id could not be recovered..."
+    );
+    console.log(
+      "You can now ask follow-up review questions or request fixes before exiting Codex."
+    );
+    interactiveRuntime.launch(options.repoRoot, interactiveWorkspace);
+  }
+
+  if (!options.hasChanges(options.repoRoot)) {
+    console.log("Codex exited without producing any file changes to review or commit.");
     return;
   }
 
-  console.log(
-    "Opening a fresh interactive Codex session in this terminal because the generated session id could not be recovered..."
-  );
-  console.log(
-    "You can now ask follow-up review questions or request fixes before exiting Codex."
-  );
-  interactiveRuntime.launch(options.repoRoot, interactiveWorkspace);
+  await finalizeRuntimeChanges({
+    repoRoot: options.repoRoot,
+    runDir: workspace.runDir,
+    commitPrompt: "Commit generated changes with this message? [Y/n/m]: ",
+    promptForLine: options.promptForLine,
+    hasChanges: options.hasChanges,
+    commitGeneratedChanges: options.commitGeneratedChanges,
+    resolveInitialCommitMessage: async () => {
+      const { provider } = await options.createProvider(options.repoRoot);
+      const proposal = await generateDiffBasedCommitProposal(
+        options.repoRoot,
+        provider,
+        options.readDiff
+      );
+      return proposal.initialMessage;
+    },
+    noChangesMessage: "Codex exited without producing any file changes to review or commit.",
+    noChangesAction: "return",
+    verifyBuild: {
+      buildCommand: options.buildCommand,
+      outputLogPath: workspace.outputLogPath,
+      run: options.verifyBuild,
+    },
+    checkForChangesBeforeBuild: true,
+  });
 }


### PR DESCRIPTION
Closes: #107

<!-- git-ai:pr-assistant:start -->
## PR Assistant

### Summary
This pull request enhances the `git-ai` CLI by improving the `pr prepare-review` command to support follow-up changes during PR reviews. It introduces a mechanism to offer a commit message proposal after changes are made in an interactive Codex session, allowing for a smoother workflow when addressing review comments or suggestions.

### Key changes
- Updated the `git-ai pr prepare-review <pr-number>` command to generate a commit message proposal after an interactive Codex session if changes were made.
- Introduced the `finalizeRuntimeChanges` function to handle the commit process, including build verification and user prompts for committing changes.
- Refactored existing workflows for fixing comments and tests to utilize the new commit proposal mechanism, ensuring consistency across commands.

### Risk areas
- Changes to the commit proposal and build verification logic may introduce issues if the build fails or if the commit message handling does not work as expected.

### Reviewer focus
- Verify that the new commit proposal flow works correctly in various scenarios, including when no changes are made and when the user declines to commit.
- Check that the build verification process is correctly integrated and that failures are handled gracefully.
- Ensure that existing workflows for fixing comments and tests are functioning as intended with the new changes.
<!-- git-ai:pr-assistant:end -->