### PR TITLE
Enhance `git-ai pr prepare-review` to Push Reviewed Commits to PR Branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ You only need extra tooling for advanced workflows:
 - the configured interactive runtime on `PATH` for `git-ai issue draft`, local interactive `git-ai issue <number>` runs, `git-ai pr fix-comments <pr-number>`, and `git-ai pr fix-tests <pr-number>`
   default: `codex`
   `ai.runtime.type: "claude-code"`: `claude`
-- `codex` on `PATH` for `git-ai pr prepare-review <pr-number>`, which checks out a reviewer workspace, syncs it with the latest PR base branch, resolves merge conflicts in Codex when needed, generates the review brief, leaves you in an interactive Codex session for follow-up questions or fixes, and then offers the same reviewed commit-message flow as other local fix workflows when that session makes changes
+- `codex` on `PATH` for `git-ai pr prepare-review <pr-number>`, which checks out a reviewer workspace, syncs it with the latest PR base branch, resolves merge conflicts in Codex when needed, generates the review brief, leaves you in an interactive Codex session for follow-up questions or fixes, offers the same reviewed commit-message flow as other local fix workflows when that session makes changes, and pushes any new reviewed commits back to the PR head branch before exiting
 - `codex` plus authenticated GitHub access for `git-ai issue <number> --mode unattended` and `git-ai issue batch ...`
 - `gh`, `GH_TOKEN`, or `GITHUB_TOKEN` for GitHub-backed issue and pull request flows
 
@@ -92,7 +92,7 @@ You only need extra tooling for advanced workflows:
 - `git-ai setup`: guided repository onboarding for `git-ai`
 - `git-ai review`: review the current diff or a branch comparison
 - `git-ai issue ...`: draft issues, generate issue plans, run single-issue flows, and queue unattended issue batches
-- `git-ai pr prepare-review <pr-number>`: check out a reviewer-ready PR branch, sync it with the latest PR base branch, generate a persisted local review brief, and optionally review a follow-up fix commit
+- `git-ai pr prepare-review <pr-number>`: check out a reviewer-ready PR branch, sync it with the latest PR base branch, generate a persisted local review brief, optionally review a follow-up fix commit, and push any new reviewed commits back to the PR branch
 - `git-ai pr fix-comments <pr-number>`: fix selected PR review comments with Codex
 - `git-ai pr fix-tests <pr-number>`: implement selected AI PR test suggestions with Codex
 - `git-ai test-backlog`: find high-value automated testing gaps
@@ -375,7 +375,7 @@ Available subcommands:
 
 | Command | What it does |
 | --- | --- |
-| `git-ai pr prepare-review <pr-number>` | Fetches pull request metadata and linked issues, requires a clean working tree, checks out the best available local review branch for the PR, fetches the latest `origin/<base-branch>` tip, skips merging when the checked-out branch already contains that tip, otherwise merges the base branch into the review branch before brief generation, routes merge conflicts through an interactive Codex conflict-resolution session when needed, writes `.git-ai/` run artifacts, generates `review-brief.md`, prints the saved brief path plus a terminal preview, and then leaves you in an interactive Codex session on that branch for follow-up review questions or requested fixes. After that session exits, `git-ai` exits cleanly if nothing changed, or else runs the configured build command and offers the same reviewed commit-message flow used by the other local fix workflows. |
+| `git-ai pr prepare-review <pr-number>` | Fetches pull request metadata and linked issues, requires a clean working tree, checks out the best available local review branch for the PR, fetches the latest `origin/<base-branch>` tip, skips merging when the checked-out branch already contains that tip, otherwise merges the base branch into the review branch before brief generation, routes merge conflicts through an interactive Codex conflict-resolution session when needed, writes `.git-ai/` run artifacts, generates `review-brief.md`, prints the saved brief path plus a terminal preview, and then leaves you in an interactive Codex session on that branch for follow-up review questions or requested fixes. After that session exits, `git-ai` exits cleanly if there are no new reviewed commits to sync, or else runs the configured build command when there are follow-up file changes, offers the same reviewed commit-message flow used by the other local fix workflows, and pushes any new reviewed commits back to `origin/<pr-head-branch>`. |
 | `git-ai pr fix-comments <pr-number>` | Fetches pull request metadata and review comments from the configured forge, filters out obviously non-actionable comments, groups nearby threads into selectable review tasks, preserves non-trivial replies as thread context, writes richer `.git-ai/` run artifacts, opens the configured interactive runtime, runs the configured build command, and then previews a proposed commit message that you can edit, accept, or skip. |
 | `git-ai pr fix-tests <pr-number>` | Fetches pull request metadata and PR issue comments from the configured forge, finds the managed AI Test Suggestions comment, parses structured suggestion areas into selectable tasks, writes focused `.git-ai/` run artifacts, opens the configured interactive runtime, runs the configured build command, and then previews a proposed commit message that you can edit, accept, or skip. |
 
@@ -391,8 +391,8 @@ Important behavior:
 - if that base-branch merge conflicts, `git-ai pr prepare-review <pr-number>` opens a focused Codex conflict-resolution session and only continues to review-brief generation after the merge is fully resolved
 - `git-ai pr prepare-review <pr-number>` writes `prompt.md`, `metadata.json`, `output.log`, and `review-brief.md` under a timestamped `.git-ai/runs/` directory and may also write supporting workflow artifacts there
 - after generating the brief, `git-ai pr prepare-review <pr-number>` drops you into an interactive Codex shell so you can ask follow-up questions or request fixes before exiting Codex
-- after that interactive session exits, `git-ai pr prepare-review <pr-number>` exits without build or commit steps if nothing changed
-- if the follow-up session changed files, `git-ai pr prepare-review <pr-number>` runs the configured build command and then previews a proposed commit message that you can accept, edit, or skip
+- after that interactive session exits, `git-ai pr prepare-review <pr-number>` skips build and commit review if there are no follow-up file changes, but still pushes any new reviewed commits created by the workflow, such as a base-sync merge
+- if the follow-up session changed files, `git-ai pr prepare-review <pr-number>` runs the configured build command, previews a proposed commit message that you can accept, edit, or skip, and then pushes the resulting reviewed branch state back to the PR head branch when it is ahead of `origin/<pr-head-branch>`
 - when a linked issue has a live saved Codex session, `git-ai pr prepare-review <pr-number>` reuses it for brief generation and the follow-up interactive session; stale sessions are warned about and fall back to a fresh run
 - local PR comment-fix runs require the configured runtime CLI on `PATH`
 - local PR test-fix runs require the configured runtime CLI on `PATH`

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -2680,6 +2680,42 @@ describe("CLI integration", () => {
           };
         }
 
+        if (
+          command === "git" &&
+          args[0] === "fetch" &&
+          args[1] === "origin" &&
+          args[2] === headBranchName
+        ) {
+          return { status: 0, stdout: "", stderr: "" };
+        }
+
+        if (
+          command === "git" &&
+          args[0] === "rev-parse" &&
+          args[1] === `origin/${headBranchName}`
+        ) {
+          return { status: 0, stdout: "head-tip-209\n", stderr: "" };
+        }
+
+        if (
+          command === "git" &&
+          args[0] === "rev-list" &&
+          args[1] === "--left-right" &&
+          args[2] === "--count" &&
+          args[3] === `origin/${headBranchName}...HEAD`
+        ) {
+          return { status: 0, stdout: "0 1\n", stderr: "" };
+        }
+
+        if (
+          command === "git" &&
+          args[0] === "push" &&
+          args[1] === "origin" &&
+          args[2] === `HEAD:${headBranchName}`
+        ) {
+          return { status: 0, stdout: "pushed\n", stderr: "" };
+        }
+
         if (command === "codex" && args[0] === "exec" && args[1] === "--full-auto") {
           const createdRunDir = listRunDirectories().find(
             (entry) => !beforeRuns.includes(entry)
@@ -2740,6 +2776,9 @@ describe("CLI integration", () => {
     expect(readFileSync(outputLogPath, "utf8")).toContain(
       'Warning: Codex resolved the merge conflicts while merging origin/main into "feat/prepare-review-conflicts-resolved".'
     );
+    expect(readFileSync(outputLogPath, "utf8")).toContain(
+      `git push origin HEAD:${headBranchName}`
+    );
     expect(JSON.parse(readFileSync(metadataFilePath, "utf8"))).toMatchObject({
       baseSync: {
         remoteRef: "origin/main",
@@ -2760,6 +2799,13 @@ describe("CLI integration", () => {
           )
       )
     ).toBe(true);
+    expect(spawnSync).toHaveBeenCalledWith(
+      "git",
+      ["push", "origin", `HEAD:${headBranchName}`],
+      expect.objectContaining({
+        cwd: REPO_ROOT,
+      })
+    );
   });
 
   it("fails clearly when base-branch merge conflicts remain unresolved", async () => {

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1635,7 +1635,9 @@ describe("CLI integration", () => {
       spawnSync.mock.calls.some(
         ([command, args]) =>
           command === "pnpm" ||
-          (command === "git" && Array.isArray(args) && args[0] === "commit")
+          (command === "git" &&
+            Array.isArray(args) &&
+            (args[0] === "commit" || args[0] === "push"))
       )
     ).toBe(false);
   });
@@ -1975,6 +1977,33 @@ describe("CLI integration", () => {
           return { status: 0 };
         }
 
+        if (command === "git" && args[0] === "fetch" && args[1] === "origin" && args[2] === headBranchName) {
+          return { status: 0, stdout: "", stderr: "" };
+        }
+
+        if (command === "git" && args[0] === "rev-parse" && args[1] === `origin/${headBranchName}`) {
+          return { status: 0, stdout: "head-tip-206\n", stderr: "" };
+        }
+
+        if (
+          command === "git" &&
+          args[0] === "rev-list" &&
+          args[1] === "--left-right" &&
+          args[2] === "--count" &&
+          args[3] === `origin/${headBranchName}...HEAD`
+        ) {
+          return { status: 0, stdout: "0 1\n", stderr: "" };
+        }
+
+        if (
+          command === "git" &&
+          args[0] === "push" &&
+          args[1] === "origin" &&
+          args[2] === `HEAD:${headBranchName}`
+        ) {
+          return { status: 0, stdout: "pushed\n", stderr: "" };
+        }
+
         throw new Error(`Unexpected spawnSync call: ${command} ${args.join(" ")}`);
       },
     });
@@ -1982,6 +2011,10 @@ describe("CLI integration", () => {
     process.env.GITHUB_TOKEN = "test-token";
     process.argv = ["node", "git-ai", "pr", "prepare-review", "206"];
     const stdout = captureStdout();
+    const messages: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((message?: unknown) => {
+      messages.push(String(message ?? ""));
+    });
 
     await run();
 
@@ -2005,7 +2038,11 @@ describe("CLI integration", () => {
       "fix: review follow-up fixes for PR #206"
     );
     expect(readFileSync(outputLogPath, "utf8")).toContain("$ pnpm build");
+    expect(readFileSync(outputLogPath, "utf8")).toContain(`$ git push origin HEAD:${headBranchName}`);
     expect(stdout.output()).toContain("Proposed commit message");
+    expect(messages.join("\n")).toContain(
+      `Pushing reviewed updates to origin/${headBranchName}...`
+    );
     expect(generateCommitMessage).toHaveBeenCalledWith(
       expect.any(Object),
       expect.stringContaining(
@@ -2277,7 +2314,7 @@ describe("CLI integration", () => {
         ([command, args]) =>
           command === "git" &&
           Array.isArray(args) &&
-          args[0] === "commit"
+          (args[0] === "commit" || args[0] === "push")
       )
     ).toBe(false);
   });
@@ -2392,12 +2429,53 @@ describe("CLI integration", () => {
           return { status: 0 };
         }
 
+        if (
+          command === "git" &&
+          args[0] === "fetch" &&
+          args[1] === "origin" &&
+          args[2] === "feat/prepare-review-workspace"
+        ) {
+          return { status: 0, stdout: "", stderr: "" };
+        }
+
+        if (
+          command === "git" &&
+          args[0] === "rev-parse" &&
+          args[1] === "origin/feat/prepare-review-workspace"
+        ) {
+          return { status: 0, stdout: "head-tip-205\n", stderr: "" };
+        }
+
+        if (
+          command === "git" &&
+          args[0] === "rev-list" &&
+          args[1] === "--left-right" &&
+          args[2] === "--count" &&
+          args[3] === "origin/feat/prepare-review-workspace...HEAD"
+        ) {
+          return { status: 0, stdout: "0 1\n", stderr: "" };
+        }
+
+        if (
+          command === "git" &&
+          args[0] === "push" &&
+          args[1] === "origin" &&
+          args[2] === "HEAD:feat/prepare-review-workspace"
+        ) {
+          return { status: 0, stdout: "pushed\n", stderr: "" };
+        }
+
         throw new Error(`Unexpected spawnSync call: ${command} ${args.join(" ")}`);
       },
     });
 
     process.env.GITHUB_TOKEN = "test-token";
     process.argv = ["node", "git-ai", "pr", "prepare-review", "205"];
+    const stdout = captureStdout();
+    const messages: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((message?: unknown) => {
+      messages.push(String(message ?? ""));
+    });
 
     await run();
 
@@ -2429,6 +2507,9 @@ describe("CLI integration", () => {
     expect(readFileSync(outputLogPath, "utf8")).toContain("git fetch origin main");
     expect(readFileSync(outputLogPath, "utf8")).toContain(
       "git merge --no-edit --no-ff origin/main"
+    );
+    expect(readFileSync(outputLogPath, "utf8")).toContain(
+      "git push origin HEAD:feat/prepare-review-workspace"
     );
     expect(JSON.parse(readFileSync(metadataFilePath, "utf8"))).toMatchObject({
       prNumber: 205,
@@ -2462,6 +2543,16 @@ describe("CLI integration", () => {
       expect.objectContaining({
         cwd: REPO_ROOT,
       })
+    );
+    expect(spawnSync).toHaveBeenCalledWith(
+      "git",
+      ["push", "origin", "HEAD:feat/prepare-review-workspace"],
+      expect.objectContaining({
+        cwd: REPO_ROOT,
+      })
+    );
+    expect(messages.join("\n")).toContain(
+      "Pushing reviewed updates to origin/feat/prepare-review-workspace..."
     );
     expect(spawnSync).toHaveBeenCalledWith(
       "codex",

--- a/packages/cli/src/workflows/pr-prepare-review/run.test.ts
+++ b/packages/cli/src/workflows/pr-prepare-review/run.test.ts
@@ -161,7 +161,7 @@ describe("runPrPrepareReviewCommand", () => {
     vi.spyOn(process.stderr, "write").mockImplementation(() => true);
   });
 
-  it("passes a diff-based commit proposal into runtime finalization after interactive follow-up changes", async () => {
+  it("passes a diff-based commit proposal into runtime finalization and pushes an accepted follow-up commit", async () => {
     const repoRoot = mkdtempSync(resolve(tmpdir(), "git-ai-pr-prepare-review-"));
     cleanupTargets.add(repoRoot);
 
@@ -287,6 +287,46 @@ describe("runPrPrepareReviewCommand", () => {
         } as never;
       }
 
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "fetch" &&
+        args[1] === "origin" &&
+        args[2] === createPullRequest().headRefName
+      ) {
+        return createCommandResult(0);
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "rev-parse" &&
+        args[1] === `origin/${createPullRequest().headRefName}`
+      ) {
+        return createCommandResult(0, { stdout: "def456head\n" });
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "rev-list" &&
+        args[1] === "--left-right" &&
+        args[2] === "--count" &&
+        args[3] === `origin/${createPullRequest().headRefName}...HEAD`
+      ) {
+        return createCommandResult(0, { stdout: "0 1\n" });
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "push" &&
+        args[1] === "origin" &&
+        args[2] === `HEAD:${createPullRequest().headRefName}`
+      ) {
+        return createCommandResult(0);
+      }
+
       throw new Error(`Unexpected spawnSync call: ${command} ${String(args)}`);
     });
 
@@ -357,6 +397,11 @@ describe("runPrPrepareReviewCommand", () => {
       provider,
       readDiff
     );
+    expect(getGitCommandArgs()).toContainEqual([
+      "push",
+      "origin",
+      `HEAD:${createPullRequest().headRefName}`,
+    ]);
   });
 
   it("skips merging when the checked-out branch already contains the fetched base tip", async () => {
@@ -611,6 +656,46 @@ describe("runPrPrepareReviewCommand", () => {
         return createCommandResult(0);
       }
 
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "fetch" &&
+        args[1] === "origin" &&
+        args[2] === createPullRequest().headRefName
+      ) {
+        return createCommandResult(0);
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "rev-parse" &&
+        args[1] === `origin/${createPullRequest().headRefName}`
+      ) {
+        return createCommandResult(0, { stdout: "def456head\n" });
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "rev-list" &&
+        args[1] === "--left-right" &&
+        args[2] === "--count" &&
+        args[3] === `origin/${createPullRequest().headRefName}...HEAD`
+      ) {
+        return createCommandResult(0, { stdout: "0 1\n" });
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "push" &&
+        args[1] === "origin" &&
+        args[2] === `HEAD:${createPullRequest().headRefName}`
+      ) {
+        return createCommandResult(0);
+      }
+
       throw new Error(`Unexpected spawnSync call: ${command} ${String(args)}`);
     });
 
@@ -625,6 +710,15 @@ describe("runPrPrepareReviewCommand", () => {
       ["rev-parse", "origin/main"],
       ["merge-base", "--is-ancestor", "abc123base", "HEAD"],
       ["merge", "--no-edit", "--no-ff", "origin/main"],
+      ["fetch", "origin", createPullRequest().headRefName],
+      ["rev-parse", `origin/${createPullRequest().headRefName}`],
+      [
+        "rev-list",
+        "--left-right",
+        "--count",
+        `origin/${createPullRequest().headRefName}...HEAD`,
+      ],
+      ["push", "origin", `HEAD:${createPullRequest().headRefName}`],
     ]);
     expect(writePullRequestPrepareReviewWorkspaceFiles).toHaveBeenCalledWith(
       repoRoot,
@@ -646,6 +740,429 @@ describe("runPrPrepareReviewCommand", () => {
     );
     expect(launchUnattendedRuntime).toHaveBeenCalledOnce();
     expect(writePullRequestPrepareReviewConflictPrompt).not.toHaveBeenCalled();
+  });
+
+  it("pushes a merge-only fetched review branch back to the real PR head branch", async () => {
+    const repoRoot = mkdtempSync(resolve(tmpdir(), "git-ai-pr-prepare-review-"));
+    cleanupTargets.add(repoRoot);
+
+    const workspace = createWorkspace(repoRoot);
+    const { forge } = createForge();
+    const interactiveLaunch = vi.fn();
+    const fetchedBranchName = "review/pr-206-tighten-prepare-review-follow-up-fixes";
+
+    vi.mocked(fetchLinkedIssuesForPullRequest).mockResolvedValue([]);
+    vi.mocked(createPullRequestPrepareReviewWorkspace).mockReturnValue(workspace);
+    vi.mocked(initializePullRequestPrepareReviewOutputLog).mockImplementation(
+      () => undefined
+    );
+    vi.mocked(writePullRequestPrepareReviewWorkspaceFiles).mockImplementation(
+      () => undefined
+    );
+    vi.mocked(writePullRequestPrepareReviewMetadata).mockImplementation(() => undefined);
+    vi.mocked(getInteractiveRuntimeByType).mockReturnValue({
+      checkAvailability: () => ({ available: true }),
+      launch: interactiveLaunch,
+    });
+    vi.mocked(launchUnattendedRuntime).mockImplementation(
+      (_type, _repoRoot, suppliedWorkspace) => {
+        writeFileSync(
+          suppliedWorkspace.reviewBriefFilePath,
+          "# Reviewer focus\n\n- Inspect the merged base sync.\n",
+          "utf8"
+        );
+
+        return {
+          invocation: "new",
+          sessionId: "codex-session-merge-only-push",
+        };
+      }
+    );
+    vi.mocked(spawnSync).mockImplementation((command, args) => {
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "-C" &&
+        args[1] === repoRoot &&
+        args[2] === "rev-parse" &&
+        args[3] === "--verify" &&
+        args[4] === createPullRequest().headRefName
+      ) {
+        return createCommandResult(1);
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "-C" &&
+        args[1] === repoRoot &&
+        args[2] === "rev-parse" &&
+        args[3] === "--verify" &&
+        args[4] === fetchedBranchName
+      ) {
+        return createCommandResult(1);
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "fetch" &&
+        args[1] === "origin" &&
+        args[2] === `pull/206/head:${fetchedBranchName}`
+      ) {
+        return createCommandResult(0);
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "checkout" &&
+        args[1] === fetchedBranchName
+      ) {
+        return createCommandResult(0);
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "fetch" &&
+        args[1] === "origin" &&
+        args[2] === createPullRequest().baseRefName
+      ) {
+        return createCommandResult(0);
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "rev-parse" &&
+        args[1] === `origin/${createPullRequest().baseRefName}`
+      ) {
+        return createCommandResult(0, { stdout: "abc123base\n" });
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "merge-base" &&
+        args[1] === "--is-ancestor" &&
+        args[2] === "abc123base" &&
+        args[3] === "HEAD"
+      ) {
+        return createCommandResult(1);
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "merge" &&
+        args[1] === "--no-edit" &&
+        args[2] === "--no-ff" &&
+        args[3] === "origin/main"
+      ) {
+        return createCommandResult(0);
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "fetch" &&
+        args[1] === "origin" &&
+        args[2] === createPullRequest().headRefName
+      ) {
+        return createCommandResult(0);
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "rev-parse" &&
+        args[1] === `origin/${createPullRequest().headRefName}`
+      ) {
+        return createCommandResult(0, { stdout: "def456head\n" });
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "rev-list" &&
+        args[1] === "--left-right" &&
+        args[2] === "--count" &&
+        args[3] === `origin/${createPullRequest().headRefName}...HEAD`
+      ) {
+        return createCommandResult(0, { stdout: "0 1\n" });
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "push" &&
+        args[1] === "origin" &&
+        args[2] === `HEAD:${createPullRequest().headRefName}`
+      ) {
+        return createCommandResult(0);
+      }
+
+      throw new Error(`Unexpected spawnSync call: ${command} ${String(args)}`);
+    });
+
+    await runPrPrepareReviewCommand(createDefaultCommandOptions(repoRoot, forge));
+
+    expect(getGitCommandArgs()).toContainEqual([
+      "push",
+      "origin",
+      `HEAD:${createPullRequest().headRefName}`,
+    ]);
+    expect(getGitCommandArgs()).not.toContainEqual([
+      "push",
+      "origin",
+      `HEAD:${fetchedBranchName}`,
+    ]);
+  });
+
+  it("does not push when prepare-review exits without workflow-created commits", async () => {
+    const repoRoot = mkdtempSync(resolve(tmpdir(), "git-ai-pr-prepare-review-"));
+    cleanupTargets.add(repoRoot);
+
+    const workspace = createWorkspace(repoRoot);
+    const { forge } = createForge();
+    const interactiveLaunch = vi.fn();
+
+    vi.mocked(fetchLinkedIssuesForPullRequest).mockResolvedValue([]);
+    vi.mocked(createPullRequestPrepareReviewWorkspace).mockReturnValue(workspace);
+    vi.mocked(initializePullRequestPrepareReviewOutputLog).mockImplementation(
+      () => undefined
+    );
+    vi.mocked(writePullRequestPrepareReviewWorkspaceFiles).mockImplementation(
+      () => undefined
+    );
+    vi.mocked(writePullRequestPrepareReviewMetadata).mockImplementation(() => undefined);
+    vi.mocked(getInteractiveRuntimeByType).mockReturnValue({
+      checkAvailability: () => ({ available: true }),
+      launch: interactiveLaunch,
+    });
+    vi.mocked(launchUnattendedRuntime).mockImplementation(
+      (_type, _repoRoot, suppliedWorkspace) => {
+        writeFileSync(
+          suppliedWorkspace.reviewBriefFilePath,
+          "# Reviewer focus\n\n- Inspect the synced review branch.\n",
+          "utf8"
+        );
+
+        return {
+          invocation: "new",
+          sessionId: "codex-session-no-push",
+        };
+      }
+    );
+    vi.mocked(spawnSync).mockImplementation((command, args) => {
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "-C" &&
+        args[1] === repoRoot &&
+        args[2] === "rev-parse" &&
+        args[3] === "--verify" &&
+        args[4] === createPullRequest().headRefName
+      ) {
+        return createCommandResult(0);
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "checkout" &&
+        args[1] === createPullRequest().headRefName
+      ) {
+        return createCommandResult(0);
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "fetch" &&
+        args[1] === "origin" &&
+        args[2] === createPullRequest().baseRefName
+      ) {
+        return createCommandResult(0);
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "rev-parse" &&
+        args[1] === `origin/${createPullRequest().baseRefName}`
+      ) {
+        return createCommandResult(0, { stdout: "abc123base\n" });
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "merge-base" &&
+        args[1] === "--is-ancestor" &&
+        args[2] === "abc123base" &&
+        args[3] === "HEAD"
+      ) {
+        return createCommandResult(0);
+      }
+
+      throw new Error(`Unexpected spawnSync call: ${command} ${String(args)}`);
+    });
+
+    await runPrPrepareReviewCommand(createDefaultCommandOptions(repoRoot, forge));
+
+    expect(
+      getGitCommandArgs().some((args) => args[0] === "push" || args[0] === "rev-list")
+    ).toBe(false);
+  });
+
+  it("fails clearly when pushing reviewed updates back to the PR branch fails", async () => {
+    const repoRoot = mkdtempSync(resolve(tmpdir(), "git-ai-pr-prepare-review-"));
+    cleanupTargets.add(repoRoot);
+
+    const workspace = createWorkspace(repoRoot);
+    const { forge } = createForge();
+    const interactiveLaunch = vi.fn();
+
+    vi.mocked(fetchLinkedIssuesForPullRequest).mockResolvedValue([]);
+    vi.mocked(createPullRequestPrepareReviewWorkspace).mockReturnValue(workspace);
+    vi.mocked(initializePullRequestPrepareReviewOutputLog).mockImplementation(
+      () => undefined
+    );
+    vi.mocked(writePullRequestPrepareReviewWorkspaceFiles).mockImplementation(
+      () => undefined
+    );
+    vi.mocked(writePullRequestPrepareReviewMetadata).mockImplementation(() => undefined);
+    vi.mocked(getInteractiveRuntimeByType).mockReturnValue({
+      checkAvailability: () => ({ available: true }),
+      launch: interactiveLaunch,
+    });
+    vi.mocked(launchUnattendedRuntime).mockImplementation(
+      (_type, _repoRoot, suppliedWorkspace) => {
+        writeFileSync(
+          suppliedWorkspace.reviewBriefFilePath,
+          "# Reviewer focus\n\n- Inspect the merged base sync.\n",
+          "utf8"
+        );
+
+        return {
+          invocation: "new",
+          sessionId: "codex-session-push-failure",
+        };
+      }
+    );
+    vi.mocked(spawnSync).mockImplementation((command, args) => {
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "-C" &&
+        args[1] === repoRoot &&
+        args[2] === "rev-parse" &&
+        args[3] === "--verify" &&
+        args[4] === createPullRequest().headRefName
+      ) {
+        return createCommandResult(0);
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "checkout" &&
+        args[1] === createPullRequest().headRefName
+      ) {
+        return createCommandResult(0);
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "fetch" &&
+        args[1] === "origin" &&
+        args[2] === createPullRequest().baseRefName
+      ) {
+        return createCommandResult(0);
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "rev-parse" &&
+        args[1] === `origin/${createPullRequest().baseRefName}`
+      ) {
+        return createCommandResult(0, { stdout: "abc123base\n" });
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "merge-base" &&
+        args[1] === "--is-ancestor" &&
+        args[2] === "abc123base" &&
+        args[3] === "HEAD"
+      ) {
+        return createCommandResult(1);
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "merge" &&
+        args[1] === "--no-edit" &&
+        args[2] === "--no-ff" &&
+        args[3] === "origin/main"
+      ) {
+        return createCommandResult(0);
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "fetch" &&
+        args[1] === "origin" &&
+        args[2] === createPullRequest().headRefName
+      ) {
+        return createCommandResult(0);
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "rev-parse" &&
+        args[1] === `origin/${createPullRequest().headRefName}`
+      ) {
+        return createCommandResult(0, { stdout: "def456head\n" });
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "rev-list" &&
+        args[1] === "--left-right" &&
+        args[2] === "--count" &&
+        args[3] === `origin/${createPullRequest().headRefName}...HEAD`
+      ) {
+        return createCommandResult(0, { stdout: "0 1\n" });
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "push" &&
+        args[1] === "origin" &&
+        args[2] === `HEAD:${createPullRequest().headRefName}`
+      ) {
+        return createCommandResult(1, { stderr: "remote rejected\n" });
+      }
+
+      throw new Error(`Unexpected spawnSync call: ${command} ${String(args)}`);
+    });
+
+    await expect(
+      runPrPrepareReviewCommand(createDefaultCommandOptions(repoRoot, forge))
+    ).rejects.toThrow(
+      `Failed to push reviewed updates to origin/${createPullRequest().headRefName}.`
+    );
   });
 
   it("opens a conflict-resolution Codex session and continues once the base sync is resolved", async () => {
@@ -773,6 +1290,46 @@ describe("runPrPrepareReviewCommand", () => {
         return createCommandResult(0, {
           stdout: unmergedDiffChecks === 1 ? "src/conflict.ts\n" : "",
         });
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "fetch" &&
+        args[1] === "origin" &&
+        args[2] === createPullRequest().headRefName
+      ) {
+        return createCommandResult(0);
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "rev-parse" &&
+        args[1] === `origin/${createPullRequest().headRefName}`
+      ) {
+        return createCommandResult(0, { stdout: "def456head\n" });
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "rev-list" &&
+        args[1] === "--left-right" &&
+        args[2] === "--count" &&
+        args[3] === `origin/${createPullRequest().headRefName}...HEAD`
+      ) {
+        return createCommandResult(0, { stdout: "0 1\n" });
+      }
+
+      if (
+        command === "git" &&
+        Array.isArray(args) &&
+        args[0] === "push" &&
+        args[1] === "origin" &&
+        args[2] === `HEAD:${createPullRequest().headRefName}`
+      ) {
+        return createCommandResult(0);
       }
 
       throw new Error(`Unexpected spawnSync call: ${command} ${String(args)}`);

--- a/packages/cli/src/workflows/pr-prepare-review/run.ts
+++ b/packages/cli/src/workflows/pr-prepare-review/run.ts
@@ -158,6 +158,10 @@ function resolveBaseSyncRemoteRef(baseRefName: string): string {
   return `origin/${baseRefName}`;
 }
 
+function resolvePullRequestHeadRemoteRef(headRefName: string): string {
+  return `origin/${headRefName}`;
+}
+
 function getBaseSyncTip(
   repoRoot: string,
   workspace: PullRequestPrepareReviewWorkspace,
@@ -261,6 +265,102 @@ function listUnmergedPaths(
     .split(/\r?\n/)
     .map((value) => value.trim())
     .filter((value) => value.length > 0);
+}
+
+function getAheadBehindCounts(
+  repoRoot: string,
+  workspace: PullRequestPrepareReviewWorkspace,
+  remoteRef: string
+): { ahead: number; behind: number } {
+  const counts = runTrackedCommand(
+    repoRoot,
+    workspace,
+    "git",
+    ["rev-list", "--left-right", "--count", `${remoteRef}...HEAD`],
+    `Failed to compare HEAD with "${remoteRef}".`,
+    { echoOutput: false }
+  ).trim();
+
+  const [behindRaw, aheadRaw] = counts.split(/\s+/);
+  const behind = Number.parseInt(behindRaw ?? "", 10);
+  const ahead = Number.parseInt(aheadRaw ?? "", 10);
+
+  if (!Number.isInteger(behind) || !Number.isInteger(ahead)) {
+    throw new Error(`Failed to compare HEAD with "${remoteRef}".`);
+  }
+
+  return {
+    ahead,
+    behind,
+  };
+}
+
+function pushReviewedPullRequestUpdates(
+  repoRoot: string,
+  workspace: PullRequestPrepareReviewWorkspace,
+  pullRequest: PullRequestDetails
+): void {
+  const remoteRef = resolvePullRequestHeadRemoteRef(pullRequest.headRefName);
+
+  console.log(`Fetching latest ${remoteRef} before checking push status...`);
+  const fetchResult = runTrackedCommandAndCapture(
+    repoRoot,
+    workspace,
+    "git",
+    ["fetch", "origin", pullRequest.headRefName]
+  );
+
+  if (fetchResult.error) {
+    throw new Error(
+      `Failed to fetch PR head branch "${pullRequest.headRefName}" from origin before pushing reviewed updates. ${fetchResult.error.message}`
+    );
+  }
+
+  if (fetchResult.status !== 0) {
+    throw new Error(
+      `Failed to fetch PR head branch "${pullRequest.headRefName}" from origin before pushing reviewed updates. This workflow currently only pushes PR branches that are available as ${remoteRef}.`
+    );
+  }
+
+  runTrackedCommand(
+    repoRoot,
+    workspace,
+    "git",
+    ["rev-parse", remoteRef],
+    `Failed to resolve "${remoteRef}" after fetching the PR head branch.`,
+    { echoOutput: false }
+  );
+
+  const { ahead, behind } = getAheadBehindCounts(repoRoot, workspace, remoteRef);
+  if (ahead === 0) {
+    return;
+  }
+
+  if (behind > 0) {
+    throw new Error(
+      `Cannot push reviewed updates to "${pullRequest.headRefName}" because HEAD diverged from ${remoteRef} (${ahead} ahead, ${behind} behind). Local commits were kept.`
+    );
+  }
+
+  console.log(`Pushing reviewed updates to origin/${pullRequest.headRefName}...`);
+  const pushResult = runTrackedCommandAndCapture(
+    repoRoot,
+    workspace,
+    "git",
+    ["push", "origin", `HEAD:${pullRequest.headRefName}`]
+  );
+
+  if (pushResult.error) {
+    throw new Error(
+      `Failed to push reviewed updates to origin/${pullRequest.headRefName}. ${pushResult.error.message}`
+    );
+  }
+
+  if (pushResult.status !== 0) {
+    throw new Error(
+      `Failed to push reviewed updates to origin/${pullRequest.headRefName}.`
+    );
+  }
 }
 
 function synchronizePullRequestBaseBranch(
@@ -805,12 +905,23 @@ export async function runPrPrepareReviewCommand(
     interactiveRuntime.launch(options.repoRoot, interactiveWorkspace);
   }
 
+  const maybePushReviewedUpdates = (
+    workflowCreatedLocalCommits: boolean
+  ): void => {
+    if (!workflowCreatedLocalCommits) {
+      return;
+    }
+
+    pushReviewedPullRequestUpdates(options.repoRoot, workspace, pullRequest);
+  };
+
   if (!options.hasChanges(options.repoRoot)) {
     console.log("Codex exited without producing any file changes to review or commit.");
+    maybePushReviewedUpdates(baseSync.status === "merged");
     return;
   }
 
-  await finalizeRuntimeChanges({
+  const finalizeResult = await finalizeRuntimeChanges({
     repoRoot: options.repoRoot,
     runDir: workspace.runDir,
     commitPrompt: "Commit generated changes with this message? [Y/n/m]: ",
@@ -835,4 +946,8 @@ export async function runPrPrepareReviewCommand(
     },
     checkForChangesBeforeBuild: true,
   });
+
+  maybePushReviewedUpdates(
+    baseSync.status === "merged" || finalizeResult.committed
+  );
 }


### PR DESCRIPTION
## Summary
This update extends the `git-ai pr prepare-review <pr-number>` command to automatically push any new local commits back to the corresponding pull request's remote head branch after the review process. This ensures that the state of the local review branch is consistent with the remote PR branch, addressing issues where local changes were not reflected on GitHub.

## Changes
- Added logic to detect if the local branch is ahead of the remote PR branch and push changes accordingly.
- Implemented fetching of the latest PR head branch before attempting to push.
- Enhanced error handling for push failures, providing clear feedback to the user.
- Updated documentation to reflect the new behavior of the `prepare-review` command.

## Testing
Reviewers can validate the change by running the `git-ai pr prepare-review <pr-number>` command and ensuring that any new commits created during the review process are pushed to the PR branch on GitHub. Automated tests have been added to cover various scenarios, including successful pushes and handling of push failures.

## Risk
There is a risk of push failures if the local branch has diverged from the remote branch. The implementation includes checks to prevent pushing in such cases, ensuring that local commits are preserved and not lost.

Closes #111

<!-- git-ai:pr-assistant:start -->
## PR Assistant

### Summary
This pull request enhances the `git-ai pr prepare-review` command to automatically push any new local commits back to the corresponding pull request's remote head branch after the review process. This change ensures that local modifications are consistently reflected in the remote PR branch, improving the workflow for developers during code reviews.

### Key changes
- Added logic to detect if the local branch is ahead of the remote PR branch and push changes accordingly.
- Implemented fetching of the latest PR head branch before attempting to push, ensuring the local state is up-to-date.
- Enhanced error handling for push failures, providing clear feedback to the user if the push cannot be completed.
- Updated documentation to reflect the new behavior of the `prepare-review` command.

### Risk areas
- Potential push failures if the local branch has diverged from the remote branch, though checks are in place to prevent data loss.

### Reviewer focus
- Verify the logic for detecting local commits that need to be pushed to the remote branch.
- Check the error handling mechanisms for push failures to ensure they provide adequate feedback.
- Ensure that the documentation accurately describes the new functionality and any potential caveats.
<!-- git-ai:pr-assistant:end -->