### PR TITLE
Rework PR Assistant for Consistent Managed Review Sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Start here if you are evaluating `git-ai` for a team:
 | Surface | Why it is part of the primary offer |
 | --- | --- |
 | `actions/pr-review` | Adds AI pull request review summaries, higher-level findings, and line-linked review comments in GitHub. |
-| `actions/pr-assistant` | Maintains a managed PR assistant section in the pull request body without overwriting unrelated manual content. |
+| `actions/pr-assistant` | Maintains a managed PR assistant section in the pull request body without overwriting unrelated manual content, using stable summary, risk, file, testing, rollout, and checklist headings. |
 | `actions/test-suggestions` | Posts practical test suggestions for the current pull request diff in GitHub. |
 | `git-ai review` | Runs a local senior-style diff review before or during a pull request. |
 | `git-ai pr fix-comments <pr-number>` | Pulls selected GitHub review comments into a focused local fix flow. |
@@ -652,10 +652,12 @@ Inputs:
 Outputs:
 
 - `summary`
-- `section`
+- `section` with `Summary`, `Risk areas`, `Files changed`, `Testing notes`, `Rollout concerns`, and `Reviewer checklist`
 - `body`
 
 When `GITHUB_OUTPUT` is not set, outputs are printed to stdout.
+
+`Files changed` is derived from the diff headers in code so the managed section stays grounded in the actual patch.
 
 #### Test suggestions action
 

--- a/actions/pr-assistant/README.md
+++ b/actions/pr-assistant/README.md
@@ -1,6 +1,6 @@
 # pr-assistant action
 
-Generate a managed PR assistant section from a pull request diff via OpenAI and merge it into the existing PR body.
+Generate a managed PR assistant section from a pull request diff via OpenAI and merge it into the existing PR body. The section uses a stable shape: summary, risk areas, files changed, testing notes, rollout concerns, and reviewer checklist.
 
 ## Local test
 
@@ -29,3 +29,5 @@ node actions/pr-assistant/dist/index.js
 `INPUT_DIFF` and `INPUT_COMMIT_MESSAGES` are still supported for smaller local runs, but the `*_FILE` inputs avoid shell and GitHub Actions argument-length limits.
 
 When `GITHUB_OUTPUT` is not set, outputs are printed to stdout as `summary=...`, `section=...`, and `body=...`.
+
+`Files changed` is derived from the diff headers in code so the managed section does not rely on the model to invent file paths.

--- a/actions/pr-assistant/action.yml
+++ b/actions/pr-assistant/action.yml
@@ -1,5 +1,5 @@
 name: "AI PR Assistant"
-description: "Generate and merge a managed PR assistant section into the pull request body"
+description: "Generate and merge a managed PR assistant section with summary, risks, files, testing, rollout, and checklist notes"
 
 inputs:
   diff:
@@ -35,7 +35,7 @@ outputs:
   summary:
     description: "Generated PR assistant summary paragraph"
   section:
-    description: "Generated managed PR assistant section markdown"
+    description: "Generated managed PR assistant section markdown with stable reviewer headings"
   body:
     description: "Updated pull request body with the managed PR assistant section"
 

--- a/actions/pr-assistant/dist/index.js
+++ b/actions/pr-assistant/dist/index.js
@@ -73,21 +73,41 @@ function stripManagedPRAssistantSection(body) {
   const stripped = body.replace(PR_ASSISTANT_SECTION_PATTERN, "").replace(/\n{3,}/g, "\n\n").trim();
   return stripped ? stripped : void 0;
 }
-function buildPRAssistantSection(summary) {
-  const lines = ["## PR Assistant", "", "### Summary", summary.summary, ""];
-  lines.push(...renderBulletSection("Key changes", summary.keyChanges, "No key changes identified."));
+function buildPRAssistantSection(assistant) {
+  const lines = ["## PR Assistant", "", "### Summary", assistant.summary, ""];
   lines.push(
     ...renderBulletSection(
       "Risk areas",
-      summary.riskAreas,
-      "No additional diff-grounded risk areas identified."
+      assistant.riskAreas,
+      "None noted."
     )
   );
   lines.push(
     ...renderBulletSection(
-      "Reviewer focus",
-      summary.reviewerFocus,
-      "No additional reviewer focus areas identified."
+      "Files changed",
+      assistant.filesChanged,
+      "No changed files detected from the diff."
+    )
+  );
+  lines.push(
+    ...renderBulletSection(
+      "Testing notes",
+      assistant.testingNotes,
+      "None noted."
+    )
+  );
+  lines.push(
+    ...renderBulletSection(
+      "Rollout concerns",
+      assistant.rolloutConcerns,
+      "None noted."
+    )
+  );
+  lines.push(
+    ...renderBulletSection(
+      "Reviewer checklist",
+      assistant.reviewerChecklist,
+      "None noted."
     )
   );
   while (lines[lines.length - 1] === "") {

--- a/actions/pr-assistant/src/body.test.ts
+++ b/actions/pr-assistant/src/body.test.ts
@@ -8,17 +8,38 @@ import {
 } from "./body";
 
 describe("pr-assistant body helpers", () => {
-  it("renders the managed section with fallback risk text", () => {
+  it("renders the managed section with the stable reviewer headings", () => {
     const section = buildPRAssistantSection({
       summary: "Adds a single PR assistant action.",
-      keyChanges: ["Merges duplicate PR automation into one output."],
       riskAreas: [],
-      reviewerFocus: ["Verify the managed block updates without touching other text."],
+      filesChanged: ["actions/pr-assistant/src/index.ts"],
+      testingNotes: [],
+      rolloutConcerns: [],
+      reviewerChecklist: [
+        "Verify the managed block updates without touching other text.",
+      ],
     });
 
     expect(section).toContain("## PR Assistant");
     expect(section).toContain("### Risk areas");
-    expect(section).toContain("No additional diff-grounded risk areas identified.");
+    expect(section).toContain("### Files changed");
+    expect(section).toContain("### Testing notes");
+    expect(section).toContain("### Rollout concerns");
+    expect(section).toContain("### Reviewer checklist");
+    expect(section).toContain("None noted.");
+  });
+
+  it("renders an explicit empty files state", () => {
+    const section = buildPRAssistantSection({
+      summary: "Keeps the renderer calm when no file headers are available.",
+      riskAreas: [],
+      filesChanged: [],
+      testingNotes: [],
+      rolloutConcerns: [],
+      reviewerChecklist: [],
+    });
+
+    expect(section).toContain("No changed files detected from the diff.");
   });
 
   it("appends a managed section when the PR body has no markers", () => {

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -575,9 +575,11 @@ async function loadCli(options: {
   issueResolutionPlanResult?: ReturnType<typeof createIssueResolutionPlanResult>;
   prAssistantResult?: {
     summary: string;
-    keyChanges: string[];
     riskAreas: string[];
-    reviewerFocus: string[];
+    filesChanged: string[];
+    testingNotes: string[];
+    rolloutConcerns: string[];
+    reviewerChecklist: string[];
   };
   prDescriptionResult?: {
     title: string;
@@ -632,9 +634,13 @@ async function loadCli(options: {
   generatePRAssistant.mockResolvedValue(
     options.prAssistantResult ?? {
       summary: "Adds reviewer-ready PR assistant content to issue-created pull requests.",
-      keyChanges: ["Generates a managed PR assistant section from the completed diff."],
       riskAreas: [],
-      reviewerFocus: ["Confirm the generated PR body and assistant section match the diff."],
+      filesChanged: ["packages/cli/src/index.ts"],
+      testingNotes: ["pnpm build"],
+      rolloutConcerns: [],
+      reviewerChecklist: [
+        "Confirm the generated PR body and assistant section match the diff.",
+      ],
     }
   );
   const generatePRDescription = vi.fn();
@@ -6865,12 +6871,11 @@ describe("CLI integration", () => {
         },
         prAssistantResult: {
           summary: "Keeps issue-created pull requests aligned with repository configuration.",
-          keyChanges: [
-            "Uses the configured base branch for issue preparation and PR creation.",
-            "Uses the configured build command before commit and PR steps.",
-          ],
           riskAreas: [],
-          reviewerFocus: [
+          filesChanged: ["packages/cli/src/index.ts"],
+          testingNotes: ["npm run verify"],
+          rolloutConcerns: [],
+          reviewerChecklist: [
             "Verify the workflow honors the configured base branch and build command.",
           ],
         },
@@ -7058,7 +7063,7 @@ describe("CLI integration", () => {
         "<!-- git-ai:pr-assistant:start -->"
       );
       expect(prArgs[prArgs.indexOf("--body") + 1]).toContain(
-        "### Reviewer focus"
+        "### Reviewer checklist"
       );
     } finally {
       if (hadOriginalConfig && originalConfig !== undefined) {

--- a/packages/contracts/src/pr-assistant.test.ts
+++ b/packages/contracts/src/pr-assistant.test.ts
@@ -5,16 +5,24 @@ describe("PRAssistantOutput", () => {
   it("parses a valid PR assistant payload", () => {
     const parsed = PRAssistantOutput.parse({
       summary: "Adds a shared PR assistant section for generated review guidance.",
-      keyChanges: ["Introduces a unified action and workflow."],
       riskAreas: ["Managed section replacement logic in the PR body."],
-      reviewerFocus: ["Verify existing body content remains unchanged outside markers."],
+      filesChanged: ["actions/pr-assistant/src/index.ts"],
+      testingNotes: ["pnpm build"],
+      rolloutConcerns: ["Managed section replacement depends on stable markers."],
+      reviewerChecklist: [
+        "Verify existing body content remains unchanged outside markers.",
+      ],
     });
 
     expect(parsed).toEqual({
       summary: "Adds a shared PR assistant section for generated review guidance.",
-      keyChanges: ["Introduces a unified action and workflow."],
       riskAreas: ["Managed section replacement logic in the PR body."],
-      reviewerFocus: ["Verify existing body content remains unchanged outside markers."],
+      filesChanged: ["actions/pr-assistant/src/index.ts"],
+      testingNotes: ["pnpm build"],
+      rolloutConcerns: ["Managed section replacement depends on stable markers."],
+      reviewerChecklist: [
+        "Verify existing body content remains unchanged outside markers.",
+      ],
     });
   });
 
@@ -22,9 +30,11 @@ describe("PRAssistantOutput", () => {
     expect(() =>
       PRAssistantOutput.parse({
         summary: "   ",
-        keyChanges: ["Valid change"],
         riskAreas: [],
-        reviewerFocus: ["Valid focus"],
+        filesChanged: ["actions/pr-assistant/src/index.ts"],
+        testingNotes: [],
+        rolloutConcerns: [],
+        reviewerChecklist: ["Valid focus"],
       })
     ).toThrow();
   });

--- a/packages/contracts/src/pr-assistant.ts
+++ b/packages/contracts/src/pr-assistant.ts
@@ -13,9 +13,11 @@ export type PRAssistantInputType = z.infer<typeof PRAssistantInput>;
 
 export const PRAssistantOutput = z.object({
   summary: z.string().trim().min(1, "summary must be non-empty"),
-  keyChanges: z.array(PRAssistantItem).min(1, "keyChanges must be non-empty"),
   riskAreas: z.array(PRAssistantItem),
-  reviewerFocus: z.array(PRAssistantItem).min(1, "reviewerFocus must be non-empty"),
+  filesChanged: z.array(PRAssistantItem),
+  testingNotes: z.array(PRAssistantItem),
+  rolloutConcerns: z.array(PRAssistantItem),
+  reviewerChecklist: z.array(PRAssistantItem),
 });
 
 export type PRAssistantOutputType = z.infer<typeof PRAssistantOutput>;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "@git-ai/contracts": "workspace:*",
-    "@git-ai/providers": "workspace:*"
+    "@git-ai/providers": "workspace:*",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "tsup": "^8.5.1"

--- a/packages/core/src/pr-assistant-body.ts
+++ b/packages/core/src/pr-assistant-body.ts
@@ -39,23 +39,43 @@ export function stripManagedPRAssistantSection(
 }
 
 export function buildPRAssistantSection(
-  summary: PRAssistantOutputType
+  assistant: PRAssistantOutputType
 ): string {
-  const lines: string[] = ["## PR Assistant", "", "### Summary", summary.summary, ""];
+  const lines: string[] = ["## PR Assistant", "", "### Summary", assistant.summary, ""];
 
-  lines.push(...renderBulletSection("Key changes", summary.keyChanges, "No key changes identified."));
   lines.push(
     ...renderBulletSection(
       "Risk areas",
-      summary.riskAreas,
-      "No additional diff-grounded risk areas identified."
+      assistant.riskAreas,
+      "None noted."
     )
   );
   lines.push(
     ...renderBulletSection(
-      "Reviewer focus",
-      summary.reviewerFocus,
-      "No additional reviewer focus areas identified."
+      "Files changed",
+      assistant.filesChanged,
+      "No changed files detected from the diff."
+    )
+  );
+  lines.push(
+    ...renderBulletSection(
+      "Testing notes",
+      assistant.testingNotes,
+      "None noted."
+    )
+  );
+  lines.push(
+    ...renderBulletSection(
+      "Rollout concerns",
+      assistant.rolloutConcerns,
+      "None noted."
+    )
+  );
+  lines.push(
+    ...renderBulletSection(
+      "Reviewer checklist",
+      assistant.reviewerChecklist,
+      "None noted."
     )
   );
 

--- a/packages/core/src/pr-assistant.test.ts
+++ b/packages/core/src/pr-assistant.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AIProvider } from "@git-ai/providers";
+import { generatePRAssistant } from "./pr-assistant";
+
+describe("generatePRAssistant", () => {
+  it("derives the files changed list from the diff structure", async () => {
+    const provider: AIProvider = {
+      generateText: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          summary: "Reworks the managed PR assistant section into a stable reviewer format.",
+          riskAreas: ["Managed section replacement logic now renders more sections."],
+          testingNotes: ["Build coverage for the updated contract and renderer should be verified."],
+          rolloutConcerns: [],
+          reviewerChecklist: ["Confirm manual PR body content remains outside the managed markers."],
+        })
+      ),
+    };
+
+    const result = await generatePRAssistant(provider, {
+      diff: [
+        "diff --git a/packages/core/src/pr-assistant.ts b/packages/core/src/pr-assistant.ts",
+        "--- a/packages/core/src/pr-assistant.ts",
+        "+++ b/packages/core/src/pr-assistant.ts",
+        "@@ -1,1 +1,1 @@",
+        "-old",
+        "+new",
+        "diff --git a/actions/pr-assistant/README.md b/actions/pr-assistant/README.md",
+        "--- a/actions/pr-assistant/README.md",
+        "+++ b/actions/pr-assistant/README.md",
+        "@@ -1,1 +1,1 @@",
+        "-old",
+        "+new",
+      ].join("\n"),
+    });
+
+    expect(result.filesChanged).toEqual([
+      "packages/core/src/pr-assistant.ts",
+      "actions/pr-assistant/README.md",
+    ]);
+    expect(result.summary).toContain("stable reviewer format");
+  });
+});

--- a/packages/core/src/pr-assistant.ts
+++ b/packages/core/src/pr-assistant.ts
@@ -5,21 +5,62 @@ import {
   PRAssistantOutputType,
 } from "@git-ai/contracts";
 import { AIProvider } from "@git-ai/providers";
+import { z } from "zod";
 import {
   buildDiffTaskPrompt,
   DIFF_GROUNDED_SYSTEM_PROMPT_LINES,
 } from "./diff-task";
-import { generateStructuredOutput } from "./structured-generation";
+import {
+  generateStructuredOutput,
+  normalizeNullableFields,
+} from "./structured-generation";
 
 const PR_ASSISTANT_SYSTEM_PROMPT = [
   "You are a senior software engineer writing a GitHub pull request assistant section for human reviewers.",
-  "Be concise but informative.",
+  "Be concise, repetitive, and predictable.",
   ...DIFF_GROUNDED_SYSTEM_PROMPT_LINES,
-  "Focus on a reviewer-useful summary, key changes, risk areas, and reviewer guidance.",
+  "Focus on a reviewer-useful summary, risk areas, testing notes, rollout concerns, and reviewer checklist items.",
   "Use the PR title, PR body, and commit messages only as supporting context and prefer the diff when they conflict.",
   "Only identify risks when they are supported by the diff or supporting context.",
   "Do not suggest reviewer checks that are not grounded in the change.",
+  "Use calm empty states and avoid novelty or marketing language.",
 ].join(" ");
+
+const PRAssistantModelItem = z.string().trim().min(1);
+
+const PRAssistantModelOutput = z.object({
+  summary: z.string().trim().min(1, "summary must be non-empty"),
+  riskAreas: z.array(PRAssistantModelItem).default([]),
+  testingNotes: z.array(PRAssistantModelItem).default([]),
+  rolloutConcerns: z.array(PRAssistantModelItem).default([]),
+  reviewerChecklist: z.array(PRAssistantModelItem).default([]),
+});
+
+function collectChangedFiles(diff: string): string[] {
+  const files: string[] = [];
+  const seen = new Set<string>();
+
+  for (const line of diff.split("\n")) {
+    if (!line.startsWith("diff --git ")) {
+      continue;
+    }
+
+    const match = line.match(/^diff --git a\/(.+?) b\/(.+)$/);
+    if (!match) {
+      continue;
+    }
+
+    const [, fromPath, toPath] = match;
+    const resolvedPath =
+      toPath === "dev/null" ? fromPath : fromPath === "dev/null" ? toPath : toPath;
+    if (!seen.has(resolvedPath)) {
+      seen.add(resolvedPath);
+      files.push(resolvedPath);
+    }
+  }
+
+  return files;
+}
 
 function buildPrompt(input: PRAssistantInputType): string {
   const contextLines: string[] = [];
@@ -39,16 +80,19 @@ function buildPrompt(input: PRAssistantInputType): string {
       "Generate a structured GitHub pull request assistant section from the provided diff.",
     guidanceLines: [
       'The "summary" should be a short paragraph describing the overall change and intent.',
-      '"keyChanges" should list the most meaningful implementation changes for reviewers.',
       '"riskAreas" should list concrete review risks or be an empty array if none are clearly supported.',
-      '"reviewerFocus" should list the specific checks a reviewer should make based on the diff.',
+      '"testingNotes" should list testing evidence, gaps, or notable verification context grounded in the diff or supporting context.',
+      '"rolloutConcerns" should list rollout, migration, or deployment concerns grounded in the diff or be an empty array.',
+      '"reviewerChecklist" should list the specific checks a reviewer should make based on the diff.',
+      "Do not include a files list in the JSON. File paths are derived from the diff separately.",
       "Avoid repeating the same point across multiple fields.",
     ],
     schemaLines: [
       '  "summary": string,',
-      '  "keyChanges": string[],',
       '  "riskAreas": string[],',
-      '  "reviewerFocus": string[]',
+      '  "testingNotes": string[],',
+      '  "rolloutConcerns": string[],',
+      '  "reviewerChecklist": string[]',
     ],
     contextLines:
       contextLines.length > 0
@@ -64,12 +108,23 @@ export async function generatePRAssistant(
 ): Promise<PRAssistantOutputType> {
   const parsedInput = PRAssistantInput.parse(input);
   const prompt = buildPrompt(parsedInput);
-
-  return generateStructuredOutput({
+  const modelOutput = await generateStructuredOutput({
     provider,
     systemPrompt: PR_ASSISTANT_SYSTEM_PROMPT,
     prompt,
-    schema: PRAssistantOutput,
+    schema: PRAssistantModelOutput,
     validationErrorPrefix: "Model output failed PR assistant schema validation",
+    normalizeParsedJson: (value) =>
+      normalizeNullableFields(value, [
+        "riskAreas",
+        "testingNotes",
+        "rolloutConcerns",
+        "reviewerChecklist",
+      ]),
+  });
+
+  return PRAssistantOutput.parse({
+    ...modelOutput,
+    filesChanged: collectChangedFiles(parsedInput.diff),
   });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       '@git-ai/providers':
         specifier: workspace:*
         version: link:../providers
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       tsup:
         specifier: ^8.5.1


### PR DESCRIPTION
## Summary
This pull request reworks the PR assistant to generate a more structured and predictable managed section in pull request bodies. The new format includes stable headings for summary, risk areas, files changed, testing notes, rollout concerns, and a reviewer checklist, enhancing review hygiene and trustworthiness.

## Changes
- Updated the PR assistant output structure to include stable headings: Summary, Risk areas, Files changed, Testing notes, Rollout concerns, and Reviewer checklist.
- Derived the list of files changed directly from the diff, ensuring accuracy and reducing reliance on model-generated content.
- Preserved existing manual PR content outside the managed section to maintain context.
- Enhanced documentation to reflect the new output format and its implications.

## Testing
Reviewers can validate the changes by checking that the generated PR assistant section adheres to the new structure and that it accurately reflects the changes made in the diff.

## Risk
There is a potential risk of breaking existing workflows that depend on the previous output format. Care should be taken to ensure that all integrations with the PR assistant are updated to accommodate the new structure.

Closes #118

<!-- git-ai:pr-assistant:start -->
## PR Assistant

### Summary
This pull request reworks the PR assistant to provide a more structured and predictable output format. The new format includes stable headings for summary, risk areas, files changed, testing notes, rollout concerns, and a reviewer checklist, which enhances the clarity and usability of the PR assistant section.

### Risk areas
- Potential breaking changes to existing workflows that depend on the previous output format.

### Files changed
- README.md
- actions/pr-assistant/README.md
- actions/pr-assistant/action.yml
- actions/pr-assistant/src/body.test.ts
- packages/cli/src/index.test.ts
- packages/contracts/src/pr-assistant.test.ts
- packages/contracts/src/pr-assistant.ts
- packages/core/package.json
- packages/core/src/pr-assistant-body.ts
- packages/core/src/pr-assistant.test.ts
- packages/core/src/pr-assistant.ts
- pnpm-lock.yaml

### Testing notes
- Reviewers should validate that the generated PR assistant section adheres to the new structure and accurately reflects the changes made in the diff.

### Rollout concerns
None noted.

### Reviewer checklist
- Ensure the new structure is correctly implemented in the PR assistant output.
- Verify that the list of files changed is accurately derived from the diff.
- Check that existing manual PR content remains intact outside the managed section.
<!-- git-ai:pr-assistant:end -->