### PR TITLE
Enhance `git-ai issue plan` with Refresh Capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ These workflows remain supported and documented below, but they are separate fro
 Advanced workflows:
 
 - `git-ai issue draft`
-- `git-ai issue plan <number>`
+- `git-ai issue plan <number> [--refresh]`
 - `git-ai issue prepare <number>`
 - `git-ai issue finalize <number>`
 - `git-ai issue <number>`
@@ -149,7 +149,7 @@ Primary offer commands:
 Advanced commands:
 
 - `git-ai issue draft`: turn a rough idea into a structured issue draft
-- `git-ai issue plan <number>`: generate or refresh an issue-resolution plan comment
+- `git-ai issue plan <number> [--refresh]`: maintain an issue-resolution plan comment as secondary execution support
 - `git-ai issue <number>`: run the full local issue-to-PR workflow
 - `git-ai issue prepare <number>` and `git-ai issue finalize <number>`: split issue setup from local completion
 
@@ -215,7 +215,7 @@ Optional repository-specific defaults live in `.git-ai/config.json`. `git-ai set
 Supported fields:
 
 - `ai.runtime.type`: interactive runtime used by `git-ai issue draft`, local `git-ai issue <number>`, `git-ai pr fix-comments <pr-number>`, and `git-ai pr fix-tests <pr-number>`. Supported values: `"codex"` and `"claude-code"`. Default: `"codex"`.
-- `ai.provider.type`: structured text provider used by `git-ai commit`, `git-ai diff`, `git-ai review`, `git-ai issue plan <number>`, and commit/PR generation inside `git-ai issue <number>` and `git-ai issue finalize <number>`. Supported values: `"openai"` and `"bedrock-claude"`. Default: `"openai"`.
+- `ai.provider.type`: structured text provider used by `git-ai commit`, `git-ai diff`, `git-ai review`, `git-ai issue plan <number> [--refresh]`, and commit/PR generation inside `git-ai issue <number>` and `git-ai issue finalize <number>`. Supported values: `"openai"` and `"bedrock-claude"`. Default: `"openai"`.
 - `ai.provider.model`: optional for `"openai"`, required for `"bedrock-claude"`.
 - `ai.provider.baseUrl`: optional override for `"openai"`.
 - `ai.provider.region`: optional explicit AWS region for `"bedrock-claude"`. Falls back to `AWS_REGION` or `AWS_DEFAULT_REGION`.
@@ -293,7 +293,7 @@ Usage:
 git-ai issue <number> [--mode <interactive|unattended>]
 git-ai issue batch <number> <number> [...number] [--mode unattended]
 git-ai issue draft
-git-ai issue plan <number>
+git-ai issue plan <number> [--refresh]
 git-ai issue prepare <number> [--mode <local|github-action>]
 git-ai issue finalize <number>
 ```
@@ -306,14 +306,14 @@ Available subcommands:
 | `git-ai issue <number> --mode unattended` | Full local issue-to-PR flow in unattended mode. Requires `ai.runtime.type` to be `codex`, reuses the same per-issue branch and session state as interactive runs, launches Codex non-interactively, commits with the generated commit message automatically, pushes the issue branch through the pull-request creation path, and then opens the pull request without prompting. |
 | `git-ai issue batch <number> <number> [...number]` | Sequential unattended issue queue. Defaults to `--mode unattended`, requires at least two unique issue numbers, runs each issue as its own independent unattended issue execution, stores batch progress separately under `.git-ai/batches/`, and stops immediately at the first incomplete issue so reruns can resume from there. Each completed issue uses the same unattended issue-to-PR path, including pushing the branch before opening the pull request. |
 | `git-ai issue draft` | Interactive issue drafting flow. Prompts for a rough idea, creates `.git-ai/` draft-run artifacts, launches the configured runtime so it can inspect the repository and ask targeted follow-up questions itself, expects the runtime to write the Markdown draft under `.git-ai/issues/`, previews the draft in the terminal, and lets you create it as-is, modify it in `$VISUAL`, `$EDITOR`, or `vim`, or keep it on disk without creating the issue. |
-| `git-ai issue plan <number>` | Generates an issue resolution plan for the configured forge issue through the configured text provider and posts it as a managed comment. If an editable plan comment already exists, the command reuses it instead of overwriting collaborator edits. |
+| `git-ai issue plan <number> [--refresh]` | Secondary issue-execution support. By default it generates a managed issue resolution plan comment once and safely reuses the latest edited managed comment on later runs. Pass `--refresh` to regenerate the managed comment when the issue context has changed. Generated plans include acceptance criteria, likely files, implementation steps, test plan, risks, and a done definition. |
 | `git-ai issue prepare <number>` | Preflights the configured forge, verification command, and `baseBranch`, fast-forwards the configured base branch to `origin/<base-branch>`, prepares the issue branch and `.git-ai/` workspace artifacts, and then prints machine-readable JSON describing the run. |
 | `git-ai issue prepare <number> --mode github-action` | Same preparation flow, but writes prompt instructions tailored for non-interactive GitHub Actions runs. |
 | `git-ai issue finalize <number>` | Generates a proposed commit message from the current repository diff, lets you preview, edit, or skip it, and creates the commit only after confirmation. It does not push or open a pull request. |
 
 Important behavior:
 
-- `git-ai issue draft`, `git-ai issue plan <number>`, `git-ai issue prepare <number>`, `git-ai issue finalize <number>`, and full `git-ai issue <number>` runs print an advanced workflow notice before execution
+- `git-ai issue draft`, `git-ai issue plan <number> [--refresh]`, `git-ai issue prepare <number>`, `git-ai issue finalize <number>`, and full `git-ai issue <number>` runs print an advanced workflow notice before execution
 - `git-ai issue batch ...` prints a beta workflow notice before execution
 - `git-ai issue` requires a clean working tree before it starts
 - `git-ai issue <number>` and `git-ai issue prepare <number>` fail before checkout if the configured verification command cannot run from the repository root
@@ -321,7 +321,7 @@ Important behavior:
 - `git-ai issue batch ...` requires at least two unique issue numbers
 - `git-ai issue draft` previews the generated draft in the terminal and only opens `$VISUAL`, `$EDITOR`, or `vim` when you explicitly choose modify
 - `git-ai issue draft` requires an available interactive runtime CLI on `PATH`; if the configured non-default runtime is unavailable, `git-ai` falls back to `codex` when possible
-- `git-ai issue plan <number>` requires issue access through the configured forge, and creating a new managed plan comment also requires the configured provider plus GitHub authentication
+- `git-ai issue plan <number> [--refresh]` requires issue access through the configured forge; creating or refreshing a managed plan comment also requires the configured provider plus GitHub authentication
 - `git-ai issue finalize <number>` requires local file changes plus a usable configured provider so it can draft the proposed commit message
 - local full issue runs require an available interactive runtime CLI on `PATH`
 - local full issue runs require the configured provider for commit and PR text generation
@@ -336,7 +336,7 @@ Important behavior:
 - issue preparation checks out the configured `baseBranch` and fast-forwards it to `origin/<base-branch>`, defaulting to `main` only when no repository config is present
 - PR creation uses the configured `baseBranch`, defaulting to `main`
 - GitHub-backed PR creation requires `gh` to be installed and authenticated
-- GitHub-backed issue plan comments require `GH_TOKEN` or `GITHUB_TOKEN`, or an authenticated `gh` session, when they are created
+- GitHub-backed issue plan comments require `GH_TOKEN` or `GITHUB_TOKEN`, or an authenticated `gh` session, when they are created or refreshed
 - if an issue resolution plan comment exists, `git-ai issue prepare <number>` and full `git-ai issue <number>` runs copy the latest edited plan into the generated issue snapshot
 - when `forge.type` is `github`, issue fetching uses `gh issue view` when available, otherwise the GitHub API
 - when `forge.type` is `github`, GitHub API access for issue fetching, plan comments, or issue creation uses `GH_TOKEN` or `GITHUB_TOKEN` when present

--- a/packages/cli/src/forge.ts
+++ b/packages/cli/src/forge.ts
@@ -79,6 +79,7 @@ export interface RepositoryForge {
   fetchPullRequestIssueComments(prNumber: number): Promise<RepositoryComment[]>;
   fetchPullRequestReviewComments(prNumber: number): Promise<PullRequestReviewComment[]>;
   createIssuePlanComment(issueNumber: number, body: string): Promise<IssuePlanComment>;
+  updateIssuePlanComment(commentId: number, body: string): Promise<IssuePlanComment>;
   createDraftIssue(title: string, body: string): Promise<string>;
   createOrReuseIssue(
     title: string,
@@ -126,6 +127,12 @@ class NoopRepositoryForge implements RepositoryForge {
   }
 
   async createIssuePlanComment(): Promise<IssuePlanComment> {
+    throw new Error(
+      "Repository forge support is disabled by .git-ai/config.json. Configure `forge.type` to enable issue workflows."
+    );
+  }
+
+  async updateIssuePlanComment(): Promise<IssuePlanComment> {
     throw new Error(
       "Repository forge support is disabled by .git-ai/config.json. Configure `forge.type` to enable issue workflows."
     );

--- a/packages/cli/src/github.ts
+++ b/packages/cli/src/github.ts
@@ -108,6 +108,27 @@ function getGitHubApiToken(requiredMessage: string): string {
   return token;
 }
 
+function parseIssuePlanCommentPayload(
+  payload: {
+    id?: number;
+    body?: string | null;
+    html_url?: string;
+    updated_at?: string;
+  },
+  errorMessage: string
+): IssuePlanComment {
+  if (!payload.id || !payload.body || !payload.html_url || !payload.updated_at) {
+    throw new Error(errorMessage);
+  }
+
+  return {
+    id: payload.id,
+    body: payload.body,
+    url: payload.html_url,
+    updatedAt: payload.updated_at,
+  };
+}
+
 function appendRunLog(
   outputLogPath: string,
   command: string,
@@ -624,18 +645,51 @@ class GitHubRepositoryForge implements RepositoryForge {
       updated_at?: string;
     };
 
-    if (!payload.id || !payload.body || !payload.html_url || !payload.updated_at) {
+    return parseIssuePlanCommentPayload(
+      payload,
+      `GitHub issue plan comment creation for #${issueNumber} returned an incomplete payload.`
+    );
+  }
+
+  async updateIssuePlanComment(
+    commentId: number,
+    body: string
+  ): Promise<IssuePlanComment> {
+    const { owner, repo } = parseGitHubRepoFromRemote(this.repoRoot);
+    const token = getGitHubApiToken(
+      "Refreshing issue resolution plans requires GH_TOKEN or GITHUB_TOKEN to be set, or gh to be installed and authenticated."
+    );
+    const response = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}/issues/comments/${commentId}`,
+      {
+        method: "PATCH",
+        headers: {
+          Accept: "application/vnd.github+json",
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+          "User-Agent": "git-ai-cli",
+        },
+        body: JSON.stringify({ body }),
+      }
+    );
+
+    if (!response.ok) {
       throw new Error(
-        `GitHub issue plan comment creation for #${issueNumber} returned an incomplete payload.`
+        `Failed to refresh the issue resolution plan comment ${commentId} (${response.status} ${response.statusText}).`
       );
     }
 
-    return {
-      id: payload.id,
-      body: payload.body,
-      url: payload.html_url,
-      updatedAt: payload.updated_at,
+    const payload = (await response.json()) as {
+      id?: number;
+      body?: string | null;
+      html_url?: string;
+      updated_at?: string;
     };
+
+    return parseIssuePlanCommentPayload(
+      payload,
+      `GitHub issue plan comment refresh for comment ${commentId} returned an incomplete payload.`
+    );
   }
 
   async createDraftIssue(title: string, body: string): Promise<string> {

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -256,19 +256,30 @@ function createIssueDraftGuidanceClarifyResult() {
 function createIssueResolutionPlanResult() {
   return {
     summary: "Create an editable plan comment and reuse it during issue runs.",
+    acceptanceCriteria: [
+      "Users can explicitly refresh a managed issue plan comment when the issue changes.",
+    ],
+    likelyFiles: [
+      "packages/cli/src/index.ts",
+      "packages/cli/src/github.ts",
+      "README.md",
+    ],
     implementationSteps: [
       "Generate a structured plan from the GitHub issue title and body.",
       "Post the plan as a managed comment that collaborators can edit.",
     ],
-    validationSteps: [
+    testPlan: [
       "Verify the plan comment is created on the issue.",
       "Ensure later issue runs load the edited plan into the issue snapshot.",
     ],
     risks: [
       "Regenerating the plan should not overwrite a manually edited comment by default.",
     ],
+    doneDefinition: [
+      "The managed issue plan comment reflects the latest explicitly requested refresh.",
+    ],
     openQuestions: [
-      "Whether future flows should support explicit plan regeneration.",
+      "Whether future flows should diff the old and refreshed plan before applying it.",
     ],
   };
 }
@@ -1059,6 +1070,25 @@ describe("CLI integration", () => {
       action: "plan",
       issueNumber: 42,
       mode: "local",
+      refresh: false,
+    });
+  });
+
+  it("parses issue plan refresh aliases", async () => {
+    process.env.GIT_AI_DISABLE_AUTO_RUN = "1";
+    const { parseIssueCommandArgs } = await loadCli();
+
+    expect(parseIssueCommandArgs(["issue", "plan", "42", "--refresh"])).toEqual({
+      action: "plan",
+      issueNumber: 42,
+      mode: "local",
+      refresh: true,
+    });
+    expect(parseIssueCommandArgs(["issue", "plan", "42", "--update"])).toEqual({
+      action: "plan",
+      issueNumber: 42,
+      mode: "local",
+      refresh: true,
     });
   });
 
@@ -1252,7 +1282,7 @@ describe("CLI integration", () => {
 
         const output = stdout.output();
         expect(output).toContain("ADVANCED WORKFLOW NOTICE");
-        expect(output).toContain("`git-ai issue plan <number>`");
+        expect(output).toContain("`git-ai issue plan <number> [--refresh]`");
       }
     );
   });
@@ -5092,6 +5122,7 @@ describe("CLI integration", () => {
     const issueNumber = 42;
     const fetchMock = vi
       .fn()
+      .mockResolvedValueOnce(createFetchResponse([]))
       .mockResolvedValueOnce(
         createFetchResponse({
           title: "Add Command to Generate and Modify Issue Resolution Plan",
@@ -5099,7 +5130,6 @@ describe("CLI integration", () => {
           html_url: `https://github.com/DevwareUK/git-ai/issues/${issueNumber}`,
         })
       )
-      .mockResolvedValueOnce(createFetchResponse([]))
       .mockResolvedValueOnce(
         createFetchResponse({
           id: 501,
@@ -5159,19 +5189,24 @@ describe("CLI integration", () => {
     expect(JSON.parse(String(fetchMock.mock.calls[2]?.[1]?.body))).toMatchObject({
       body: expect.stringContaining(issuePlan.summary),
     });
+    expect(JSON.parse(String(fetchMock.mock.calls[2]?.[1]?.body))).toMatchObject({
+      body: expect.stringContaining("### Acceptance criteria"),
+    });
+    expect(JSON.parse(String(fetchMock.mock.calls[2]?.[1]?.body))).toMatchObject({
+      body: expect.stringContaining("### Likely files"),
+    });
+    expect(JSON.parse(String(fetchMock.mock.calls[2]?.[1]?.body))).toMatchObject({
+      body: expect.stringContaining("### Test plan"),
+    });
+    expect(JSON.parse(String(fetchMock.mock.calls[2]?.[1]?.body))).toMatchObject({
+      body: expect.stringContaining("### Done definition"),
+    });
   });
 
   it("reuses an existing edited issue resolution plan comment", async () => {
     const issueNumber = 42;
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce(
-        createFetchResponse({
-          title: "Add Command to Generate and Modify Issue Resolution Plan",
-          body: "Create a plan comment and reuse it in later issue runs.",
-          html_url: `https://github.com/DevwareUK/git-ai/issues/${issueNumber}`,
-        })
-      )
       .mockResolvedValueOnce(
         createFetchResponse([
           {
@@ -5212,7 +5247,92 @@ describe("CLI integration", () => {
     await run();
 
     expect(generateIssueResolutionPlan).not.toHaveBeenCalled();
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes an existing managed issue resolution plan comment when requested", async () => {
+    const issueNumber = 42;
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        createFetchResponse([
+          {
+            id: 777,
+            body: [
+              "<!-- git-ai:issue-plan -->",
+              "## Issue Resolution Plan",
+              "",
+              "Edited on GitHub by a collaborator.",
+            ].join("\n"),
+            html_url:
+              `https://github.com/DevwareUK/git-ai/issues/${issueNumber}#issuecomment-777`,
+            updated_at: "2026-03-18T12:00:00Z",
+          },
+        ])
+      )
+      .mockResolvedValueOnce(
+        createFetchResponse({
+          title: "Add Command to Generate and Modify Issue Resolution Plan",
+          body: "Create a plan comment and reuse it in later issue runs.",
+          html_url: `https://github.com/DevwareUK/git-ai/issues/${issueNumber}`,
+        })
+      )
+      .mockResolvedValueOnce(
+        createFetchResponse({
+          id: 777,
+          body: "<!-- git-ai:issue-plan -->\n## Issue Resolution Plan",
+          html_url:
+            `https://github.com/DevwareUK/git-ai/issues/${issueNumber}#issuecomment-777`,
+          updated_at: "2026-03-18T12:05:00Z",
+        })
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const issuePlan = createIssueResolutionPlanResult();
+    const { run, generateIssueResolutionPlan } = await loadCli({
+      issueResolutionPlanResult: issuePlan,
+      execFileSyncImpl: (command, args) => {
+        if (command === "git" && args[0] === "remote") {
+          return "git@github.com:DevwareUK/git-ai.git\n";
+        }
+
+        throw new Error(`Unexpected execFileSync call: ${command} ${args.join(" ")}`);
+      },
+      spawnSyncImpl: (command, args) => {
+        if (command === "gh" && args[0] === "--version") {
+          return { status: 1, error: new Error("gh is unavailable") };
+        }
+
+        throw new Error(`Unexpected spawnSync call: ${command} ${args.join(" ")}`);
+      },
+    });
+
+    process.env.OPENAI_API_KEY = "test-key";
+    process.env.GH_TOKEN = "";
+    process.env.GITHUB_TOKEN = "test-token";
+    process.argv = ["node", "git-ai", "issue", "plan", String(issueNumber), "--refresh"];
+
+    await run();
+
+    expect(generateIssueResolutionPlan).toHaveBeenCalledWith(expect.any(Object), {
+      issueNumber,
+      issueTitle: "Add Command to Generate and Modify Issue Resolution Plan",
+      issueBody: "Create a plan comment and reuse it in later issue runs.",
+      issueUrl: `https://github.com/DevwareUK/git-ai/issues/${issueNumber}`,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[2]?.[0]).toBe(
+      `https://api.github.com/repos/DevwareUK/git-ai/issues/comments/777`
+    );
+    expect(fetchMock.mock.calls[2]?.[1]).toMatchObject({
+      method: "PATCH",
+      headers: expect.objectContaining({
+        Authorization: expect.stringMatching(/^Bearer /),
+      }),
+    });
+    expect(JSON.parse(String(fetchMock.mock.calls[2]?.[1]?.body))).toMatchObject({
+      body: expect.stringContaining("### Done definition"),
+    });
   });
 
   it("prepares an issue run and writes automation artifacts", async () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -129,9 +129,15 @@ type IssueCommandOptions =
       mode: IssuePrepareMode;
     }
   | {
-      action: "finalize" | "plan";
+      action: "finalize";
       issueNumber: number;
       mode: "local";
+    }
+  | {
+      action: "plan";
+      issueNumber: number;
+      mode: "local";
+      refresh: boolean;
     }
   | {
       action: "draft";
@@ -270,7 +276,7 @@ const ISSUE_USAGE = [
   "  git-ai issue <number> [--mode <interactive|unattended>]",
   "  git-ai issue batch <number> <number> [...number] [--mode unattended]",
   "  git-ai issue draft",
-  "  git-ai issue plan <number>",
+  "  git-ai issue plan <number> [--refresh]",
   "  git-ai issue prepare <number> [--mode <local|github-action>]",
   "  git-ai issue finalize <number>",
 ].join("\n");
@@ -308,7 +314,7 @@ const TOP_LEVEL_HELP = [
   "",
   "Advanced:",
   "  git-ai issue draft",
-  "  git-ai issue plan <number>",
+  "  git-ai issue plan <number> [--refresh]",
   "  git-ai issue <number> [--mode <interactive|unattended>]",
   "  git-ai issue prepare <number> [--mode <local|github-action>]",
   "  git-ai issue finalize <number>",
@@ -682,6 +688,21 @@ function parseIssuePrepareMode(rawArgs: string[]): IssuePrepareMode {
   return mode;
 }
 
+function parseIssuePlanOptions(rawArgs: string[]): { refresh: boolean } {
+  let refresh = false;
+
+  for (const rawArg of rawArgs) {
+    if (rawArg === "--refresh" || rawArg === "--update") {
+      refresh = true;
+      continue;
+    }
+
+    throw new Error(`Unknown issue option "${rawArg}". ${ISSUE_USAGE}`);
+  }
+
+  return { refresh };
+}
+
 function parseIssueBatchArgs(rawArgs: string[]): {
   issueNumbers: number[];
   mode: "unattended";
@@ -781,15 +802,13 @@ export function parseIssueCommandArgs(args: string[]): IssueCommandOptions {
   }
 
   if (subcommand === "plan") {
-    const optionArgs = issueArgs.slice(2);
-    if (optionArgs.length > 0) {
-      throw new Error(`Unknown issue option "${optionArgs[0]}". ${ISSUE_USAGE}`);
-    }
+    const parsedOptions = parseIssuePlanOptions(issueArgs.slice(2));
 
     return {
       action: "plan",
       issueNumber: parseIssueNumber(issueArgs[1]),
       mode: "local",
+      refresh: parsedOptions.refresh,
     };
   }
 
@@ -1222,16 +1241,21 @@ function renderIssueResolutionPlanComment(
     "### Summary",
     plan.summary,
     "",
+    "### Acceptance criteria",
+    formatMarkdownList(plan.acceptanceCriteria),
+    "",
+    "### Likely files",
+    formatMarkdownList(plan.likelyFiles),
+    "",
     "### Implementation steps",
     formatNumberedMarkdownList(plan.implementationSteps),
     "",
-    "### Validation",
-    formatMarkdownList(plan.validationSteps),
+    "### Test plan",
+    formatMarkdownList(plan.testPlan),
   ];
 
-  if (plan.risks && plan.risks.length > 0) {
-    lines.push("", "### Risks", formatMarkdownList(plan.risks));
-  }
+  lines.push("", "### Risks", formatMarkdownList(plan.risks));
+  lines.push("", "### Done definition", formatMarkdownList(plan.doneDefinition));
 
   if (plan.openQuestions && plan.openQuestions.length > 0) {
     lines.push("", "### Open questions", formatMarkdownList(plan.openQuestions));
@@ -2866,20 +2890,24 @@ async function runIssueDraftCommand(): Promise<void> {
   console.log(`Created issue: ${issueUrl}`);
 }
 
-async function runIssuePlanCommand(issueNumber: number): Promise<void> {
+async function runIssuePlanCommand(
+  issueNumber: number,
+  options: { refresh: boolean }
+): Promise<void> {
   const repoRoot = getDefaultRepoRoot();
   const forge = getRepositoryForge(repoRoot);
-  console.log(`Fetching issue #${issueNumber}...`);
-  const issue = await forge.fetchIssueDetails(issueNumber);
   const existingPlanComment = await forge.fetchIssuePlanComment(issueNumber);
 
-  if (existingPlanComment) {
+  if (existingPlanComment && !options.refresh) {
     console.log(
       `Using existing issue resolution plan comment: ${existingPlanComment.url}`
     );
+    console.log("Re-run with `--refresh` to regenerate the managed plan comment.");
     return;
   }
 
+  console.log(`Fetching issue #${issueNumber}...`);
+  const issue = await forge.fetchIssueDetails(issueNumber);
   const { provider } = await createProvider(repoRoot);
   const plan = await generateIssueResolutionPlan(provider, {
     issueNumber,
@@ -2887,11 +2915,18 @@ async function runIssuePlanCommand(issueNumber: number): Promise<void> {
     issueBody: issue.body,
     issueUrl: issue.url,
   });
-  const comment = await forge.createIssuePlanComment(
-    issueNumber,
-    renderIssueResolutionPlanComment(issueNumber, plan)
-  );
+  const renderedPlan = renderIssueResolutionPlanComment(issueNumber, plan);
 
+  if (existingPlanComment) {
+    const comment = await forge.updateIssuePlanComment(
+      existingPlanComment.id,
+      renderedPlan
+    );
+    console.log(`Refreshed issue resolution plan comment: ${comment.url}`);
+    return;
+  }
+
+  const comment = await forge.createIssuePlanComment(issueNumber, renderedPlan);
   console.log(`Created issue resolution plan comment: ${comment.url}`);
 }
 
@@ -3391,7 +3426,9 @@ async function runIssueCommand(): Promise<void> {
   }
 
   if (issueCommand.action === "plan") {
-    await runIssuePlanCommand(issueCommand.issueNumber);
+    await runIssuePlanCommand(issueCommand.issueNumber, {
+      refresh: issueCommand.refresh,
+    });
     return;
   }
 

--- a/packages/cli/src/launch-stage.test.ts
+++ b/packages/cli/src/launch-stage.test.ts
@@ -16,7 +16,7 @@ describe("formatLaunchStageNotice", () => {
 
     expect(notice).toContain("Requires issue access through the configured forge");
     expect(notice).toContain(
-      "creating a new managed plan comment also needs a usable text provider and GitHub authentication"
+      "creating or refreshing a managed plan comment also needs a usable text provider and GitHub authentication"
     );
   });
 

--- a/packages/cli/src/launch-stage.ts
+++ b/packages/cli/src/launch-stage.ts
@@ -63,13 +63,13 @@ const LAUNCH_STAGE_NOTICE_DEFINITIONS: Record<
   },
   "issue-plan": {
     tier: "advanced",
-    command: "`git-ai issue plan <number>`",
+    command: "`git-ai issue plan <number> [--refresh]`",
     reason:
       "It prepares issue-plan comments for the wider issue-to-PR automation path rather than the primary review and fix loop.",
     recommendedFirst:
       "`git-ai review` first, then move into issue automation once the team trusts the narrower path.",
     constraints:
-      "Requires issue access through the configured forge; creating a new managed plan comment also needs a usable text provider and GitHub authentication.",
+      "Requires issue access through the configured forge; creating or refreshing a managed plan comment also needs a usable text provider and GitHub authentication.",
   },
   "issue-prepare": {
     tier: "advanced",

--- a/packages/cli/src/workflows/pr-fix-comments/run.test.ts
+++ b/packages/cli/src/workflows/pr-fix-comments/run.test.ts
@@ -76,6 +76,7 @@ function createForge(
       fetchPullRequestIssueComments: vi.fn(),
       fetchPullRequestReviewComments,
       createIssuePlanComment: vi.fn(),
+      updateIssuePlanComment: vi.fn(),
       createDraftIssue: vi.fn(),
       createOrReuseIssue: vi.fn(),
       createPullRequest: vi.fn(),

--- a/packages/cli/src/workflows/pr-fix-tests/run.test.ts
+++ b/packages/cli/src/workflows/pr-fix-tests/run.test.ts
@@ -124,6 +124,7 @@ function createForge(
       fetchPullRequestIssueComments,
       fetchPullRequestReviewComments: vi.fn(),
       createIssuePlanComment: vi.fn(),
+      updateIssuePlanComment: vi.fn(),
       createDraftIssue: vi.fn(),
       createOrReuseIssue: vi.fn(),
       createPullRequest: vi.fn(),

--- a/packages/cli/src/workflows/pr-prepare-review/run.test.ts
+++ b/packages/cli/src/workflows/pr-prepare-review/run.test.ts
@@ -82,6 +82,7 @@ function createForge(): {
       fetchPullRequestIssueComments: vi.fn(),
       fetchPullRequestReviewComments: vi.fn(),
       createIssuePlanComment: vi.fn(),
+      updateIssuePlanComment: vi.fn(),
       createDraftIssue: vi.fn(),
       createOrReuseIssue: vi.fn(),
       createPullRequest: vi.fn(),

--- a/packages/contracts/src/issue-resolution-plan.test.ts
+++ b/packages/contracts/src/issue-resolution-plan.test.ts
@@ -7,33 +7,45 @@ import {
 function createIssueResolutionPlanPayload() {
   return {
     summary: "Create an editable implementation plan before coding starts.",
+    acceptanceCriteria: [
+      "Users can explicitly regenerate a managed issue plan comment when issue scope changes.",
+    ],
+    likelyFiles: [
+      "packages/cli/src/index.ts",
+      "packages/cli/src/github.ts",
+      "README.md",
+    ],
     implementationSteps: [
       "Fetch the GitHub issue and derive a first-pass plan from its context.",
       "Post the plan as a managed comment collaborators can edit on GitHub.",
     ],
-    validationSteps: [
+    testPlan: [
       "Confirm the plan comment is created on the target issue.",
       "Ensure later issue runs load the edited plan into their workspace snapshot.",
+    ],
+    risks: [
+      "Refreshing the managed plan comment must stay opt-in so collaborator edits are not overwritten accidentally.",
+    ],
+    doneDefinition: [
+      "The managed issue plan comment reflects the latest requested regeneration.",
     ],
   };
 }
 
 describe("Issue resolution plan schemas", () => {
-  it("accepts model output when optional lists are omitted", () => {
+  it("accepts model output when open questions are omitted", () => {
     const parsed = IssueResolutionPlanModelOutput.parse(
       createIssueResolutionPlanPayload()
     );
 
-    expect(parsed.risks).toBeUndefined();
     expect(parsed.openQuestions).toBeUndefined();
   });
 
-  it("accepts normalized output when optional lists are omitted", () => {
+  it("accepts normalized output when open questions are omitted", () => {
     const parsed = IssueResolutionPlanOutput.parse(
       createIssueResolutionPlanPayload()
     );
 
-    expect(parsed.risks).toBeUndefined();
     expect(parsed.openQuestions).toBeUndefined();
   });
 });

--- a/packages/contracts/src/issue-resolution-plan.ts
+++ b/packages/contracts/src/issue-resolution-plan.ts
@@ -5,6 +5,11 @@ const OptionalStringList = z
   .nullable()
   .optional();
 
+const RequiredStringList = (fieldName: string) =>
+  z
+    .array(z.string().trim().min(1, `${fieldName} items must be non-empty`))
+    .min(1, `${fieldName} must contain at least one item`);
+
 export const IssueResolutionPlanInput = z.object({
   issueNumber: z.number().int().positive().optional(),
   issueTitle: z.string().trim().min(1, "issueTitle must be non-empty"),
@@ -16,13 +21,12 @@ export type IssueResolutionPlanInputType = z.infer<typeof IssueResolutionPlanInp
 
 export const IssueResolutionPlanModelOutput = z.object({
   summary: z.string().trim().min(1, "summary must be non-empty"),
-  implementationSteps: z
-    .array(z.string().trim().min(1, "implementationSteps items must be non-empty"))
-    .min(1, "implementationSteps must contain at least one item"),
-  validationSteps: z
-    .array(z.string().trim().min(1, "validationSteps items must be non-empty"))
-    .min(1, "validationSteps must contain at least one item"),
-  risks: OptionalStringList,
+  acceptanceCriteria: RequiredStringList("acceptanceCriteria"),
+  likelyFiles: RequiredStringList("likelyFiles"),
+  implementationSteps: RequiredStringList("implementationSteps"),
+  testPlan: RequiredStringList("testPlan"),
+  risks: RequiredStringList("risks"),
+  doneDefinition: RequiredStringList("doneDefinition"),
   openQuestions: OptionalStringList,
 });
 
@@ -32,15 +36,12 @@ export type IssueResolutionPlanModelOutputType = z.infer<
 
 export const IssueResolutionPlanOutput = z.object({
   summary: z.string().trim().min(1, "summary must be non-empty"),
-  implementationSteps: z
-    .array(z.string().trim().min(1, "implementationSteps items must be non-empty"))
-    .min(1, "implementationSteps must contain at least one item"),
-  validationSteps: z
-    .array(z.string().trim().min(1, "validationSteps items must be non-empty"))
-    .min(1, "validationSteps must contain at least one item"),
-  risks: z
-    .array(z.string().trim().min(1, "risks items must be non-empty"))
-    .optional(),
+  acceptanceCriteria: RequiredStringList("acceptanceCriteria"),
+  likelyFiles: RequiredStringList("likelyFiles"),
+  implementationSteps: RequiredStringList("implementationSteps"),
+  testPlan: RequiredStringList("testPlan"),
+  risks: RequiredStringList("risks"),
+  doneDefinition: RequiredStringList("doneDefinition"),
   openQuestions: z
     .array(z.string().trim().min(1, "openQuestions items must be non-empty"))
     .optional(),

--- a/packages/core/src/issue-resolution-plan.test.ts
+++ b/packages/core/src/issue-resolution-plan.test.ts
@@ -2,21 +2,33 @@ import { describe, expect, it } from "vitest";
 import { generateIssueResolutionPlan } from "./issue-resolution-plan";
 
 describe("generateIssueResolutionPlan", () => {
-  it("accepts model output when optional lists are null", async () => {
+  it("accepts model output when open questions are null", async () => {
     const result = await generateIssueResolutionPlan(
       {
         generateText: async () =>
           JSON.stringify({
             summary: "Create a reusable issue resolution plan comment.",
+            acceptanceCriteria: [
+              "Users can explicitly regenerate a managed issue plan comment.",
+            ],
+            likelyFiles: [
+              "packages/cli/src/index.ts",
+              "packages/cli/src/github.ts",
+            ],
             implementationSteps: [
               "Generate the plan from the issue description.",
               "Persist it in a GitHub comment users can edit.",
             ],
-            validationSteps: [
+            testPlan: [
               "Verify the comment is posted successfully.",
               "Ensure later issue runs load the edited comment.",
             ],
-            risks: null,
+            risks: [
+              "No concrete delivery risks were identified from the current issue context.",
+            ],
+            doneDefinition: [
+              "The refreshed plan is visible in the managed issue comment.",
+            ],
             openQuestions: null,
           }),
       },
@@ -27,23 +39,35 @@ describe("generateIssueResolutionPlan", () => {
       }
     );
 
-    expect(result.risks).toBeUndefined();
     expect(result.openQuestions).toBeUndefined();
   });
 
-  it("accepts model output when optional lists are omitted", async () => {
+  it("accepts model output when open questions are omitted", async () => {
     const result = await generateIssueResolutionPlan(
       {
         generateText: async () =>
           JSON.stringify({
             summary: "Create a reusable issue resolution plan comment.",
+            acceptanceCriteria: [
+              "Users can explicitly regenerate a managed issue plan comment.",
+            ],
+            likelyFiles: [
+              "packages/cli/src/index.ts",
+              "packages/cli/src/github.ts",
+            ],
             implementationSteps: [
               "Generate the plan from the issue description.",
               "Persist it in a GitHub comment users can edit.",
             ],
-            validationSteps: [
+            testPlan: [
               "Verify the comment is posted successfully.",
               "Ensure later issue runs load the edited comment.",
+            ],
+            risks: [
+              "No concrete delivery risks were identified from the current issue context.",
+            ],
+            doneDefinition: [
+              "The refreshed plan is visible in the managed issue comment.",
             ],
           }),
       },
@@ -53,7 +77,6 @@ describe("generateIssueResolutionPlan", () => {
       }
     );
 
-    expect(result.risks).toBeUndefined();
     expect(result.openQuestions).toBeUndefined();
   });
 });

--- a/packages/core/src/issue-resolution-plan.ts
+++ b/packages/core/src/issue-resolution-plan.ts
@@ -27,13 +27,20 @@ function buildPrompt(input: IssueResolutionPlanInputType): string {
     "Return strictly valid JSON in this exact shape:",
     "{",
     '  "summary": string,',
+    '  "acceptanceCriteria": string[],',
+    '  "likelyFiles": string[],',
     '  "implementationSteps": string[],',
-    '  "validationSteps": string[],',
-    '  "risks": string[] | null,',
+    '  "testPlan": string[],',
+    '  "risks": string[],',
+    '  "doneDefinition": string[],',
     '  "openQuestions": string[] | null',
     "}",
     "",
-    'Use "risks" only when there are concrete delivery risks or migration concerns; otherwise return null.',
+    'Make "acceptanceCriteria" concrete and checkable against the issue goal.',
+    'Make "likelyFiles" a list of likely repository-relative paths or code areas to inspect; use the most plausible targets from the issue context rather than placeholders.',
+    'Make "risks" explicit. If no major risk is evident, return a single item stating that no concrete delivery risks were identified from the current issue context.',
+    'Make "testPlan" the validation steps a contributor should run or perform before considering the work complete.',
+    'Make "doneDefinition" the conditions that should be true when the issue is actually finished.',
     'Use "openQuestions" only when the issue leaves important decisions unresolved; otherwise return null.',
     "Do not wrap JSON in markdown fences.",
     "",
@@ -52,6 +59,11 @@ function buildPrompt(input: IssueResolutionPlanInputType): string {
     "",
     "Issue body:",
     input.issueBody?.trim() || "(No issue body provided.)"
+  );
+
+  sections.push(
+    "",
+    "Every plan must cover acceptance criteria, likely files, test plan, risks, and a done definition."
   );
 
   return sections.join("\n");
@@ -77,7 +89,7 @@ export async function generateIssueResolutionPlan(
     validationErrorPrefix:
       "Model output failed issue resolution plan schema validation",
     normalizeParsedJson: (value) =>
-      normalizeNullableFields(value, ["risks", "openQuestions"]),
+      normalizeNullableFields(value, ["openQuestions"]),
   });
 
   return normalizeIssueResolutionPlanOutput(modelOutput);


### PR DESCRIPTION
## Summary
This update introduces a refresh capability for the `git-ai issue plan` command, allowing users to regenerate the managed issue resolution plan comment when the issue context changes. This change positions the command as a secondary execution support tool rather than a primary workflow feature.

## Changes
- Added `--refresh` option to `git-ai issue plan <number>` to regenerate the plan comment.
- Updated documentation to reflect the new command usage and its secondary nature.
- Modified the implementation to ensure that existing collaborator edits are preserved unless explicitly refreshed.
- Enhanced the generated plan to include acceptance criteria, likely files, test plan, risks, and done definition.

## Testing
Reviewers can validate the change by running the `git-ai issue plan <number> --refresh` command and confirming that the managed comment is regenerated correctly without overwriting existing edits. Additionally, ensure that the documentation accurately reflects the command's new usage.

## Risk
There is a risk of overwriting manually edited comments if the refresh functionality is misused. The implementation safeguards against this by preserving existing comments unless the user explicitly opts to refresh.

Closes #122

<!-- git-ai:pr-assistant:start -->
## PR Assistant

### Summary
This update enhances the `git-ai issue plan` command by introducing a `--refresh` option, allowing users to regenerate the issue resolution plan comment when the context changes. This positions the command as a secondary execution support tool, preserving existing collaborator edits unless explicitly refreshed. The generated plan now includes additional details such as acceptance criteria, likely files, test plan, risks, and done definition.

### Risk areas
- There is a risk of overwriting manually edited comments if the refresh functionality is misused, although safeguards are in place to prevent this.

### Files changed
- README.md
- packages/cli/src/forge.ts
- packages/cli/src/github.ts
- packages/cli/src/index.test.ts
- packages/cli/src/index.ts
- packages/cli/src/launch-stage.test.ts
- packages/cli/src/launch-stage.ts
- packages/cli/src/workflows/pr-fix-comments/run.test.ts
- packages/cli/src/workflows/pr-fix-tests/run.test.ts
- packages/cli/src/workflows/pr-prepare-review/run.test.ts
- packages/contracts/src/issue-resolution-plan.test.ts
- packages/contracts/src/issue-resolution-plan.ts
- packages/core/src/issue-resolution-plan.test.ts
- packages/core/src/issue-resolution-plan.ts

### Testing notes
- Reviewers can validate the change by running the `git-ai issue plan <number> --refresh` command and confirming that the managed comment is regenerated correctly without overwriting existing edits.
- Ensure that the documentation accurately reflects the command's new usage.

### Rollout concerns
None noted.

### Reviewer checklist
- Verify that the `--refresh` option is correctly implemented and documented.
- Check that existing collaborator edits are preserved unless explicitly refreshed.
- Confirm that the generated plan includes the new fields: acceptance criteria, likely files, test plan, risks, and done definition.
<!-- git-ai:pr-assistant:end -->