### PR TITLE
Update Default Selection Behavior for PR Fix Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,8 +459,8 @@ Important behavior:
 - if you decline the reviewed commit message, `prs pr fix-comments <pr-number>` and `prs pr fix-tests <pr-number>` leave the changes uncommitted and do not attempt a push
 - local interactive runtime prompts end with an explicit done-state summary, a short note about how to see the result or what was verified, and plain-language next steps
 - the command expects the relevant PR branch to already be checked out locally before the runtime starts editing
-- the interactive selector accepts numbered thread choices and, when available, grouped task choices like `g1`; `all` still selects every individual thread
-- `prs pr fix-tests <pr-number>` accepts `all`, `none`, or a comma-separated suggestion list like `1,2`
+- the interactive comment selector accepts numbered thread choices, grouped task choices like `g1` when available, `all`, `none`, and blank input; pressing Enter selects every individual thread
+- `prs pr fix-tests <pr-number>` accepts `all`, `none`, blank input, or a comma-separated suggestion list like `1,2`; pressing Enter selects every suggestion
 - managed AI test suggestions now carry behavior covered, regression risk, suggested test type, protected paths, suggestion-level edge cases, and a short implementation note so the selected snapshot can be used directly as implementation guidance
 - when `forge.type` is `github`, PR fetching uses `gh pr view` when available, otherwise the GitHub API
 - when `forge.type` is `github`, GitHub API access for PR metadata, review comments, and PR issue comments uses `GH_TOKEN` or `GITHUB_TOKEN` when present

--- a/packages/cli/src/workflows/pr-fix-comments/run.test.ts
+++ b/packages/cli/src/workflows/pr-fix-comments/run.test.ts
@@ -224,7 +224,7 @@ describe("runPrFixCommentsCommand", () => {
     );
     expect(promptForLine).toHaveBeenNthCalledWith(
       1,
-      "Select tasks to address [all|none|1,2,...]: "
+      "Select tasks to address [All|none|1,2,...] (default: All): "
     );
     expect(promptForLine).toHaveBeenNthCalledWith(
       2,

--- a/packages/cli/src/workflows/pr-fix-comments/run.ts
+++ b/packages/cli/src/workflows/pr-fix-comments/run.ts
@@ -123,8 +123,8 @@ async function selectPullRequestReviewComments(
 
   const selectionPrompt =
     groupTasks.length > 0
-      ? "Select tasks to address [all|none|g1,2,...] (`all` selects every individual thread): "
-      : "Select tasks to address [all|none|1,2,...]: ";
+      ? "Select tasks to address [All|none|g1,2,...] (default: All; `all` selects every individual thread): "
+      : "Select tasks to address [All|none|1,2,...] (default: All): ";
   const selection = await promptForLine(selectionPrompt);
   const selectedEntries = parsePullRequestReviewSelection(
     selection,

--- a/packages/cli/src/workflows/pr-fix-comments/selection.test.ts
+++ b/packages/cli/src/workflows/pr-fix-comments/selection.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { parsePullRequestReviewSelection } from "./selection";
+
+describe("pr-fix-comments selection helpers", () => {
+  it("defaults blank review selection to every individual thread", () => {
+    expect(parsePullRequestReviewSelection("", 3, 2)).toEqual([
+      { kind: "thread", index: 0 },
+      { kind: "thread", index: 1 },
+      { kind: "thread", index: 2 },
+    ]);
+    expect(parsePullRequestReviewSelection("   ", 2, 0)).toEqual([
+      { kind: "thread", index: 0 },
+      { kind: "thread", index: 1 },
+    ]);
+  });
+
+  it("keeps explicit review skip and selection inputs unchanged", () => {
+    expect(parsePullRequestReviewSelection("none", 3, 1)).toEqual([]);
+    expect(parsePullRequestReviewSelection("n", 3, 1)).toEqual([]);
+    expect(parsePullRequestReviewSelection("all", 2, 1)).toEqual([
+      { kind: "thread", index: 0 },
+      { kind: "thread", index: 1 },
+    ]);
+    expect(parsePullRequestReviewSelection("g1,2", 3, 1)).toEqual([
+      { kind: "group", index: 0 },
+      { kind: "thread", index: 1 },
+    ]);
+  });
+});

--- a/packages/cli/src/workflows/pr-fix-comments/selection.ts
+++ b/packages/cli/src/workflows/pr-fix-comments/selection.ts
@@ -351,15 +351,15 @@ export function parsePullRequestReviewSelection(
   groupCount: number
 ): Array<{ kind: "group" | "thread"; index: number }> {
   const normalized = response.trim().toLowerCase();
-  if (!normalized || normalized === "none" || normalized === "n") {
-    return [];
-  }
-
-  if (normalized === "all") {
+  if (!normalized || normalized === "all") {
     return Array.from({ length: threadCount }, (_, index) => ({
       kind: "thread" as const,
       index,
     }));
+  }
+
+  if (normalized === "none" || normalized === "n") {
+    return [];
   }
 
   const selectedEntries: Array<{ kind: "group" | "thread"; index: number }> = [];

--- a/packages/cli/src/workflows/pr-fix-tests/run.test.ts
+++ b/packages/cli/src/workflows/pr-fix-tests/run.test.ts
@@ -318,7 +318,7 @@ describe("runPrFixTestsCommand", () => {
     );
     expect(promptForLine).toHaveBeenNthCalledWith(
       1,
-      "Select test suggestions to implement [all|none|1,2,...]: "
+      "Select test suggestions to implement [All|none|1,2,...] (default: All): "
     );
     expect(promptForLine).toHaveBeenNthCalledWith(
       2,

--- a/packages/cli/src/workflows/pr-fix-tests/run.ts
+++ b/packages/cli/src/workflows/pr-fix-tests/run.ts
@@ -54,7 +54,7 @@ async function selectPullRequestTestSuggestions(
   printPullRequestTestSuggestions(suggestions);
 
   const selection = await promptForLine(
-    "Select test suggestions to implement [all|none|1,2,...]: "
+    "Select test suggestions to implement [All|none|1,2,...] (default: All): "
   );
   const selectedIndexes = parsePullRequestTestSuggestionSelection(
     selection,

--- a/packages/cli/src/workflows/pr-fix-tests/selection.test.ts
+++ b/packages/cli/src/workflows/pr-fix-tests/selection.test.ts
@@ -281,6 +281,8 @@ describe("pr-fix-tests selection helpers", () => {
   });
 
   it("parses interactive suggestion selection and rejects invalid entries", () => {
+    expect(parsePullRequestTestSuggestionSelection("", 3)).toEqual([0, 1, 2]);
+    expect(parsePullRequestTestSuggestionSelection("   ", 3)).toEqual([0, 1, 2]);
     expect(parsePullRequestTestSuggestionSelection("all", 3)).toEqual([0, 1, 2]);
     expect(parsePullRequestTestSuggestionSelection("2, 1, 2", 3)).toEqual([1, 0]);
     expect(parsePullRequestTestSuggestionSelection("none", 3)).toEqual([]);

--- a/packages/cli/src/workflows/pr-fix-tests/selection.ts
+++ b/packages/cli/src/workflows/pr-fix-tests/selection.ts
@@ -343,12 +343,12 @@ export function parsePullRequestTestSuggestionSelection(
   suggestionCount: number
 ): number[] {
   const normalized = selection.trim().toLowerCase();
-  if (!normalized || normalized === "none") {
-    return [];
+  if (!normalized || normalized === "all") {
+    return Array.from({ length: suggestionCount }, (_, index) => index);
   }
 
-  if (normalized === "all") {
-    return Array.from({ length: suggestionCount }, (_, index) => index);
+  if (normalized === "none") {
+    return [];
   }
 
   const entries = normalized


### PR DESCRIPTION
This pull request modifies the default behavior of the `prs pr fix-comments` and `prs pr fix-tests` commands to select all available tasks or suggestions when the user presses Enter without providing input. 

### Key Changes:
- Blank or whitespace-only input now defaults to selecting all individual review threads for comments and all suggestions for tests, aligning with the explicit `all` option.
- Updated prompt messages to clearly indicate that pressing Enter selects all, enhancing user experience and discoverability.
- Adjusted related unit tests to ensure that the new default behavior is correctly validated.

### Documentation:
- The README has been updated to reflect these changes, ensuring that users are aware of the new default selection behavior.

Closes #160

<!-- prs:pr-assistant:start -->
## PR Assistant

### Summary
This pull request updates the default selection behavior for the `prs pr fix-comments` and `prs pr fix-tests` commands. When users press Enter without input, all tasks or suggestions are now selected by default. This change enhances user experience by making the selection process more intuitive and consistent.

### Risk areas
None noted.

### Files changed
- README.md
- packages/cli/src/workflows/pr-fix-comments/run.test.ts
- packages/cli/src/workflows/pr-fix-comments/run.ts
- packages/cli/src/workflows/pr-fix-comments/selection.test.ts
- packages/cli/src/workflows/pr-fix-comments/selection.ts
- packages/cli/src/workflows/pr-fix-tests/run.test.ts
- packages/cli/src/workflows/pr-fix-tests/run.ts
- packages/cli/src/workflows/pr-fix-tests/selection.test.ts
- packages/cli/src/workflows/pr-fix-tests/selection.ts

### Testing notes
- Unit tests have been adjusted to validate the new default behavior for both comments and tests.
- New tests ensure that blank input correctly selects all available threads or suggestions.

### Rollout concerns
None noted.

### Reviewer checklist
- Verify that pressing Enter without input selects all tasks for comments.
- Verify that pressing Enter without input selects all suggestions for tests.
- Check that updated prompt messages reflect the new default behavior.
- Ensure that unit tests cover the new selection logic.
<!-- prs:pr-assistant:end -->