### PR TITLE
Fix unattended Superpowers plan preflight

### DIFF
--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -13492,6 +13492,191 @@ describe("CLI integration", () => {
     });
   });
 
+  it("uses unattended Codex for Superpowers plan preflight during unattended issue runs", async () => {
+    const beforeRuns = listRunDirectories();
+    const issueNumber = 1516;
+    const branchName = "feat/issue-1516-superpowers-plan-preflight";
+    const sessionStateDir = resolve(REPO_ROOT, ".prs", "issues", String(issueNumber));
+    const issueWorkspaceDir = resolve(
+      REPO_ROOT,
+      ".prs",
+      "issues",
+      "1516-superpowers-plan-preflight"
+    );
+    rmSync(sessionStateDir, { recursive: true, force: true });
+    rmSync(issueWorkspaceDir, { recursive: true, force: true });
+    cleanupTargets.add(sessionStateDir);
+    cleanupTargets.add(issueWorkspaceDir);
+    createMockCodexSuperpowersHome();
+
+    const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.endsWith(`/issues/${issueNumber}`)) {
+        return createFetchResponse({
+          title: "Superpowers plan preflight",
+          body: "The unattended issue workflow should generate plans without a terminal.",
+          html_url: `https://github.com/DevwareUK/prs/issues/${issueNumber}`,
+        });
+      }
+
+      if (url.includes(`/issues/${issueNumber}/comments?`)) {
+        return createFetchResponse([]);
+      }
+
+      if (url.endsWith(`/issues/${issueNumber}/comments`) && init?.method === "POST") {
+        return createFetchResponse({
+          id: 1516,
+          body: JSON.parse(String(init.body)).body,
+          html_url:
+            `https://github.com/DevwareUK/prs/issues/${issueNumber}#issuecomment-1516`,
+          updated_at: "2026-05-12T15:10:00Z",
+        });
+      }
+
+      throw new Error(`Unexpected fetch call: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    process.env.OPENAI_API_KEY = "test-key";
+    process.env.GITHUB_TOKEN = "test-token";
+    const codexExecArgs: string[][] = [];
+
+    await withRepositoryConfig(
+      JSON.stringify({
+        ai: {
+          issue: {
+            useCodexSuperpowers: true,
+          },
+          runtime: {
+            type: "codex",
+          },
+          provider: {
+            type: "openai",
+          },
+        },
+        baseBranch: "main",
+        buildCommand: ["pnpm", "build"],
+        forge: {
+          type: "github",
+        },
+      }),
+      async () => {
+        const { run, generateCommitMessage, spawnSync } = await loadCli({
+          execFileSyncImpl: (command, args) => {
+            if (command === "git" && args[0] === "status") {
+              return "";
+            }
+
+            if (command === "git" && args[0] === "diff") {
+              return "";
+            }
+
+            if (
+              command === "git" &&
+              args[0] === "ls-files" &&
+              args[1] === "--others" &&
+              args[2] === "--exclude-standard"
+            ) {
+              return "";
+            }
+
+            if (command === "git" && args[0] === "remote") {
+              return "git@github.com:DevwareUK/prs.git\n";
+            }
+
+            throw new Error(`Unexpected execFileSync call: ${command} ${args.join(" ")}`);
+          },
+          spawnSyncImpl: (command, args) => {
+            if (command === "gh" && args[0] === "--version") {
+              return { status: 0 };
+            }
+
+            if (command === "gh" && args[0] === "auth" && args[1] === "status") {
+              return { status: 0 };
+            }
+
+            if (command === "gh" && args[0] === "issue" && args[1] === "view") {
+              return {
+                status: 1,
+                error: new Error("force API fallback"),
+              };
+            }
+
+            if (command === "git" && args[0] === "rev-parse") {
+              return { status: 1 };
+            }
+
+            if (command === "git" && args[0] === "checkout" && args[1] === "main") {
+              return { status: 0 };
+            }
+
+            if (command === "git" && args[0] === "pull") {
+              return { status: 0 };
+            }
+
+            if (command === "git" && args[0] === "checkout" && args[1] === "-b") {
+              return { status: 0 };
+            }
+
+            if (command === "codex" && args[0] === "--version") {
+              return { status: 0 };
+            }
+
+            if (command === "codex" && args[0] === "exec") {
+              codexExecArgs.push([...args]);
+              const { metadata, runDir } = readLatestRunMetadata();
+              if (String(metadata.runDir).includes(`issue-plan-${issueNumber}`)) {
+                writeFileSync(
+                  resolve(REPO_ROOT, metadata.runDir as string, "superpowers-plan.md"),
+                  "# Superpowers Plan\n\n- Use the unattended plan preflight.\n",
+                  "utf8"
+                );
+                cleanupTargets.add(resolve(REPO_ROOT, ".prs", "runs", runDir));
+              }
+              return { status: 0 };
+            }
+
+            if (command === "pnpm" && args[0] === "--version") {
+              return { status: 0 };
+            }
+
+            if (command === "pnpm" && args[0] === "build") {
+              return { status: 0, stdout: "built\n", stderr: "" };
+            }
+
+            throw new Error(`Unexpected spawnSync call: ${command} ${args.join(" ")}`);
+          },
+        });
+
+        process.argv = ["node", "prs", "issue", String(issueNumber), "--mode", "unattended"];
+        await run();
+
+        expect(codexExecArgs[0]).toContain("--full-auto");
+        expect(codexExecArgs[0]).toContain("--cd");
+        expect(codexExecArgs[0]).toContain(REPO_ROOT);
+        expect(
+          spawnSync.mock.calls.some(
+            ([command, args]) =>
+              command === "codex" &&
+              Array.isArray(args) &&
+              args[0] === "--sandbox"
+          )
+        ).toBe(false);
+        expect(generateCommitMessage).not.toHaveBeenCalled();
+      }
+    );
+
+    for (const runDir of listRunDirectories().filter((entry) => !beforeRuns.includes(entry))) {
+      cleanupTargets.add(resolve(REPO_ROOT, ".prs", "runs", runDir));
+    }
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining(`/issues/${issueNumber}/comments`),
+      expect.objectContaining({
+        method: "POST",
+      })
+    );
+  });
+
   it("summarizes manual pull request creation when GitHub authentication is unavailable", async () => {
     const beforeRuns = listRunDirectories();
     const issueNumber = 1511;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5187,6 +5187,7 @@ async function createSuperpowersIssuePlanComment(options: {
   issueNumber: number;
   issue: IssueDetails;
   existingPlanComment?: IssuePlanComment;
+  mode: IssuePlanResolutionMode;
 }): Promise<IssuePlanComment | undefined> {
   const workspace = createIssuePlanWorkspace(options.repoRoot, options.issueNumber);
   writeIssuePlanWorkspaceFiles(
@@ -5198,8 +5199,12 @@ async function createSuperpowersIssuePlanComment(options: {
   );
 
   console.log("Creating issue resolution plan with Codex Superpowers...");
-  const runtime = getInteractiveRuntimeByType("codex");
-  runtime.launch(options.repoRoot, workspace);
+  if (options.mode === "execution-preflight") {
+    launchUnattendedRuntime("codex", options.repoRoot, workspace);
+  } else {
+    const runtime = getInteractiveRuntimeByType("codex");
+    runtime.launch(options.repoRoot, workspace);
+  }
 
   const comment = await publishSuperpowersPlanArtifact({
     repoRoot: options.repoRoot,
@@ -5260,6 +5265,7 @@ async function resolveIssuePlanComment(options: {
       issueNumber: options.issueNumber,
       issue,
       existingPlanComment: existingPlanComment,
+      mode: options.mode,
     });
     if (comment) {
       return comment;
@@ -5919,7 +5925,7 @@ function summarizeIssueBatchChildFailure(result: IssueBatchChildResult): string 
     return result.error.message;
   }
 
-  const output = [result.stderr, result.stdout]
+  const output = [result.stdout, result.stderr]
     .join("\n")
     .split(/\r?\n/)
     .map((line) => line.trim())


### PR DESCRIPTION
## Summary
- run Superpowers issue-plan preflight through unattended Codex during unattended issue execution
- keep explicit `prs issue plan <number>` on the interactive planner path
- surface child stderr after stdout so multi-issue failures report the actionable error line

## Verification
- `PATH=/Users/james/.nvm/versions/node/v20.19.6/bin:$PATH pnpm build`
- `PATH=/Users/james/.nvm/versions/node/v20.19.6/bin:$PATH pnpm exec vitest run packages/cli/src/index.test.ts -t "unattended Codex for Superpowers plan preflight|Superpowers issue plans|multi-issue child worktree|issue batch|multiple issue numbers" --testTimeout 20000`

<!-- prs:pr-assistant:start -->
## PR Assistant

### Summary
This pull request modifies the Superpowers plan preflight process to run unattended during issue execution. It ensures that the `prs issue plan <number>` command remains available in the interactive planner path and improves error reporting by surfacing child stderr after stdout for multi-issue failures.

### Risk areas
None noted.

### Files changed
- packages/cli/src/index.test.ts
- packages/cli/src/index.ts

### Testing notes
- The changes have been verified by running tests that include the new unattended Codex functionality for Superpowers plan preflight.
- Specific tests were executed to ensure that the unattended mode correctly generates plans and handles errors.

### Rollout concerns
None noted.

### Reviewer checklist
- Verify that the unattended Codex functionality is correctly integrated into the Superpowers plan preflight.
- Check that the interactive planner retains the `prs issue plan <number>` command.
- Ensure that error reporting for multi-issue failures is functioning as expected.
<!-- prs:pr-assistant:end -->