### PR TITLE
Add managed Codex skill refresh command

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ cd /path/to/your-repo
 prs setup
 ```
 
+After upgrading the CLI, refresh the managed Codex `/prs` skills without rerunning repository setup:
+
+```bash
+prs update skills
+```
+
 For the recommended OpenAI provider path, create a `.env` file in the target repository with `OPENAI_API_KEY`. `OPENAI_MODEL` and `OPENAI_BASE_URL` are optional.
 
 Then try the safest local CLI workflows:
@@ -124,6 +130,8 @@ Beta commands:
 Supporting commands:
 
 - `prs setup`
+- `prs setup --update-skills`
+- `prs update skills`
 - `prs audit publish (--issue <number>|--pr <number>) --file <path> --section <name> [--local-run <path>]`
 - `prs codex issue <number>`
 - `prs codex issue batch <number> <number> [...number] [--mode unattended]`

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -30,6 +30,8 @@ Beta commands:
 Supporting commands:
 
 - `prs setup`: guided repository onboarding for `prs`
+- `prs setup --update-skills`: refresh only managed Codex `/prs` skills
+- `prs update skills`: refresh managed Codex `/prs` skills after upgrading the CLI
 - `prs tool issue create (--draft-file <path>|--issue-set <path>) --json`: deterministically create GitHub issues from approved local issue draft artifacts
 - `prs codex pr prepare-review <pr-number>`: explicit legacy launcher for reviewer workspace preparation and live Codex follow-up
 - `prs tool pr prepare-review <pr-number> --json`: deterministic Codex-safe review preparation
@@ -71,9 +73,12 @@ Requirements:
 
 ```bash
 prs setup
+prs setup --update-skills
 ```
 
 Runs a guided repository setup flow for the current Git repository. The command inspects the repo, suggests defaults for `baseBranch`, `forge.type`, `ai.runtime.type`, `ai.issue.useCodexSuperpowers`, `buildCommand`, and extra `aiContext.excludePaths`, prints the detection source for each suggestion, warns when it had to fall back because signals were missing or conflicting, and first offers a one-confirmation "use the recommended setup" path before dropping into per-field prompts when you want to customize values. It writes `.prs/config.json`, preserves any existing `ai.provider` settings already present in that file, preserves an existing explicit `ai.issue.useCodexSuperpowers` value on reruns, treats legacy `ai.issueDraft.useCodexSuperpowers` as a backward-compatible input, ensures `.prs/` is gitignored, and only touches `AGENTS.md` when you explicitly opt in to a minimal scaffold for non-obvious repository guidance.
+
+`prs setup --update-skills` skips repository setup prompts and only refreshes managed Codex skills. It is equivalent to `prs update skills`.
 
 When Codex is available locally, setup also checks whether the Superpowers plugin is present under the active `CODEX_HOME` and reports whether Codex Superpowers-backed issue workflows were enabled or disabled. Setup does not install Codex plugins for you.
 
@@ -88,6 +93,14 @@ Those installed workflows reference `DevwareUK/prs/actions/...@main` and require
 When you opt into the `AGENTS.md` scaffold, setup adds only placeholder prompts such as protected paths, generated files, deployment caveats, and domain rules. It intentionally does not copy repository config values like branch names or build commands into `AGENTS.md`.
 
 The setup flow still expects you to create `.env` yourself because it cannot safely write secrets like `OPENAI_API_KEY`. It also calls out the recommended GitHub/OpenAI/Codex launch path and points advanced users to `bedrock-claude` and `claude-code` as customization paths rather than parity guarantees.
+
+### `prs update skills`
+
+```bash
+prs update skills
+```
+
+Refreshes the managed Codex `/prs` skills under the active Codex skills directory. Generated skill files include a prs-managed marker and content hash so the CLI can detect stale skills after upgrades. The command updates missing or stale managed skills, leaves current skills unchanged, and skips files at managed paths that do not look like prs-managed skill files.
 
 ### `prs issue`
 

--- a/docs/setup-configuration.md
+++ b/docs/setup-configuration.md
@@ -45,6 +45,8 @@ prs setup
 
 `prs setup` detects the repository root, suggests repo-aware defaults for the base branch, verification command, forge, Codex-first runtime, the Codex-only `ai.issue.useCodexSuperpowers` flag, and extra AI exclusions, then offers a fast "use the recommended setup" confirmation path. It writes `.prs/config.json`, ensures `.prs/` is gitignored, can optionally add a minimal `AGENTS.md` scaffold for repo-specific agent guidance, and for GitHub repositories can also install the recommended PR-focused workflows under `.github/workflows/prs-*.yml`. When setup finds managed legacy `git-ai-*.yml` workflow files, it migrates them to the new `prs-*.yml` filenames instead of leaving duplicate managed files behind. When setup cannot determine a value confidently, it prints an explicit warning before asking you to confirm or replace the suggestion.
 
+`prs setup` also installs or refreshes managed Codex `/prs` skills. After upgrading the CLI, run `prs update skills` or `prs setup --update-skills` to refresh only those managed skills without changing repository setup.
+
 The setup flow also makes the recommended launch path explicit: GitHub forge, OpenAI provider, and Codex runtime first. `bedrock-claude` and `claude-code` stay available as advanced customization paths after the default GitHub/OpenAI/Codex path is working.
 
 ### First successful CLI runs

--- a/packages/cli/src/codex-skills.test.ts
+++ b/packages/cli/src/codex-skills.test.ts
@@ -1,4 +1,11 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -8,6 +15,7 @@ import {
   renderCodexSkillMarkdown,
   resolveCodexSkillsRoot,
 } from "./codex-skills";
+import { parsePrsToolCommandArgs } from "./prs-tool-command";
 
 const cleanupTargets = new Set<string>();
 
@@ -39,6 +47,7 @@ describe("managed prs Codex skills", () => {
     const markdown = renderCodexSkillMarkdown(PRS_CODEX_SKILLS[1]);
 
     expect(markdown).toContain("name: prs:start-issue-work");
+    expect(markdown).toContain('<!-- prs:managed-skill name="prs:start-issue-work"');
     expect(markdown).toContain("Use Superpowers for brainstorming, planning, worktrees, agents, and verification.");
     expect(markdown).toContain("Publish specs, plans, decisions, and completion notes to GitHub through `prs audit publish`.");
     expect(markdown).toContain("Never commit generated Superpowers specs or plans to `docs/superpowers`.");
@@ -171,6 +180,22 @@ describe("managed prs Codex skills", () => {
     );
   });
 
+  it("keeps documented prs tool commands parseable by the bundled CLI", () => {
+    const markdown = PRS_CODEX_SKILLS.map((skill) =>
+      renderCodexSkillMarkdown(skill)
+    ).join("\n");
+    const documentedToolCommands = [
+      ...markdown.matchAll(/prs tool ([^`.\n]+)/g),
+    ].map((match) => match[1]?.trim().replace("<number>", "123"));
+
+    expect(documentedToolCommands).toContain("issue list --actionable --json");
+    for (const documentedCommand of documentedToolCommands) {
+      expect(() =>
+        parsePrsToolCommandArgs(documentedCommand.split(/\s+/))
+      ).not.toThrow();
+    }
+  });
+
   it("renders setup-captured fallback guidance in finish and audit skills", () => {
     const options = {
       cliFallbackCommand: [
@@ -213,6 +238,9 @@ describe("managed prs Codex skills", () => {
     });
 
     expect(result.installed).toBe(11);
+    expect(result.updated).toBe(0);
+    expect(result.unchanged).toBe(0);
+    expect(result.skipped).toEqual([]);
     const unifiedSkillPath = resolve(codexHome, "skills", "prs", "SKILL.md");
     expect(existsSync(unifiedSkillPath)).toBe(true);
     expect(readFileSync(unifiedSkillPath, "utf8")).toContain("name: prs");
@@ -238,5 +266,70 @@ describe("managed prs Codex skills", () => {
 
     expect(result.installed).toBe(11);
     expect(result.skillFiles.some((file) => file.endsWith("/prs/SKILL.md"))).toBe(true);
+  });
+
+  it("is idempotent for current managed skills", () => {
+    const codexHome = mkdtempSync(resolve(tmpdir(), "prs-codex-home-"));
+    cleanupTargets.add(codexHome);
+
+    installManagedCodexSkills({ CODEX_HOME: codexHome }, "/Users/tester");
+    const result = installManagedCodexSkills({ CODEX_HOME: codexHome }, "/Users/tester");
+
+    expect(result.installed).toBe(0);
+    expect(result.updated).toBe(0);
+    expect(result.unchanged).toBe(11);
+    expect(result.skipped).toEqual([]);
+  });
+
+  it("refreshes legacy managed skills that do not have a marker yet", () => {
+    const codexHome = mkdtempSync(resolve(tmpdir(), "prs-codex-home-"));
+    cleanupTargets.add(codexHome);
+    const skillDir = resolve(codexHome, "skills", "prs");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      resolve(skillDir, "SKILL.md"),
+      [
+        "---",
+        "name: prs",
+        'description: "old managed skill"',
+        "---",
+        "",
+        "## prs Workflow Contract",
+        "",
+        "Use `prs audit publish`.",
+        "",
+      ].join("\n"),
+      "utf8"
+    );
+
+    const result = installManagedCodexSkills({ CODEX_HOME: codexHome }, "/Users/tester");
+
+    expect(result.installed).toBe(10);
+    expect(result.updated).toBe(1);
+    expect(readFileSync(resolve(skillDir, "SKILL.md"), "utf8")).toContain(
+      '<!-- prs:managed-skill name="prs"'
+    );
+  });
+
+  it("skips custom files at managed skill paths", () => {
+    const codexHome = mkdtempSync(resolve(tmpdir(), "prs-codex-home-"));
+    cleanupTargets.add(codexHome);
+    const skillDir = resolve(codexHome, "skills", "prs");
+    const skillPath = resolve(skillDir, "SKILL.md");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(skillPath, "# My local prs helper\n", "utf8");
+
+    const result = installManagedCodexSkills({ CODEX_HOME: codexHome }, "/Users/tester");
+
+    expect(result.installed).toBe(10);
+    expect(result.updated).toBe(0);
+    expect(result.skipped).toEqual([
+      {
+        filePath: skillPath,
+        skillName: "prs",
+        reason: "custom-file",
+      },
+    ]);
+    expect(readFileSync(skillPath, "utf8")).toBe("# My local prs helper\n");
   });
 });

--- a/packages/cli/src/codex-skills.ts
+++ b/packages/cli/src/codex-skills.ts
@@ -1,4 +1,5 @@
-import { mkdirSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
 import {
@@ -16,12 +17,31 @@ export type ManagedCodexSkill = {
 export type InstalledCodexSkillsResult = {
   root: string;
   installed: number;
+  updated: number;
+  unchanged: number;
+  skipped: {
+    filePath: string;
+    skillName: string;
+    reason: "custom-file";
+  }[];
   skillFiles: string[];
 };
 
 export type CodexSkillRenderOptions = {
   cliFallbackCommand?: string[];
 };
+
+export type ManagedCodexSkillStatus = {
+  filePath: string;
+  skillName: string;
+  status: "missing" | "current" | "stale" | "custom";
+  expectedHash: string;
+  installedHash?: string;
+};
+
+const MANAGED_SKILL_MARKER_VERSION = "1";
+const MANAGED_SKILL_MARKER_PATTERN =
+  /<!-- prs:managed-skill name="([^"]+)" version="([^"]+)" hash="([a-f0-9]+)" -->/;
 
 const SHARED_WORKFLOW_CONTRACT = [
   "## prs Workflow Contract",
@@ -94,6 +114,62 @@ function formatCliFallbackCommand(command: string[]): string | undefined {
   }
 
   return normalized.map(formatShellCommandSegment).join(" ");
+}
+
+function normalizeCliFallbackCommand(command: string[] | undefined): string[] {
+  return (command ?? []).map((segment) => segment.trim()).filter(Boolean);
+}
+
+function computeManagedSkillHash(
+  skill: ManagedCodexSkill,
+  options: CodexSkillRenderOptions
+): string {
+  const payload = JSON.stringify({
+    markerVersion: MANAGED_SKILL_MARKER_VERSION,
+    name: skill.name,
+    description: skill.description,
+    body: skill.body,
+    cliFallbackCommand: normalizeCliFallbackCommand(options.cliFallbackCommand),
+  });
+
+  return createHash("sha256").update(payload).digest("hex").slice(0, 16);
+}
+
+function renderManagedSkillMarker(
+  skill: ManagedCodexSkill,
+  options: CodexSkillRenderOptions
+): string {
+  return `<!-- prs:managed-skill name="${skill.name}" version="${MANAGED_SKILL_MARKER_VERSION}" hash="${computeManagedSkillHash(
+    skill,
+    options
+  )}" -->`;
+}
+
+function readManagedSkillMarker(content: string):
+  | {
+      name: string;
+      version: string;
+      hash: string;
+    }
+  | undefined {
+  const match = content.match(MANAGED_SKILL_MARKER_PATTERN);
+  if (!match?.[1] || !match[2] || !match[3]) {
+    return undefined;
+  }
+
+  return {
+    name: match[1],
+    version: match[2],
+    hash: match[3],
+  };
+}
+
+function isLegacyManagedSkillContent(content: string, skill: ManagedCodexSkill): boolean {
+  return (
+    content.includes(`name: ${skill.name}`) &&
+    content.includes("## prs Workflow Contract") &&
+    content.includes("prs audit publish")
+  );
 }
 
 function renderSetupCapturedCliGuidance(options: CodexSkillRenderOptions): string[] {
@@ -399,9 +475,64 @@ export function renderCodexSkillMarkdown(
     `description: ${JSON.stringify(skill.description)}`,
     "---",
     "",
+    renderManagedSkillMarker(skill, options),
+    "",
     body.trim(),
     "",
   ].join("\n");
+}
+
+export function inspectManagedCodexSkills(
+  env: { CODEX_HOME?: string } = process.env,
+  home = homedir(),
+  options: CodexSkillRenderOptions = {}
+): ManagedCodexSkillStatus[] {
+  const root = resolveCodexSkillsRoot(env, home);
+
+  return PRS_CODEX_SKILLS.map((skill) => {
+    const skillFile = resolve(root, skill.folderName, "SKILL.md");
+    const expectedHash = computeManagedSkillHash(skill, options);
+
+    if (!existsSync(skillFile)) {
+      return {
+        filePath: skillFile,
+        skillName: skill.name,
+        status: "missing",
+        expectedHash,
+      };
+    }
+
+    const content = readFileSync(skillFile, "utf8");
+    const marker = readManagedSkillMarker(content);
+    if (marker?.name === skill.name) {
+      return {
+        filePath: skillFile,
+        skillName: skill.name,
+        status:
+          marker.version === MANAGED_SKILL_MARKER_VERSION && marker.hash === expectedHash
+            ? "current"
+            : "stale",
+        expectedHash,
+        installedHash: marker.hash,
+      };
+    }
+
+    if (isLegacyManagedSkillContent(content, skill)) {
+      return {
+        filePath: skillFile,
+        skillName: skill.name,
+        status: "stale",
+        expectedHash,
+      };
+    }
+
+    return {
+      filePath: skillFile,
+      skillName: skill.name,
+      status: "custom",
+      expectedHash,
+    };
+  });
 }
 
 export function installManagedCodexSkills(
@@ -411,18 +542,48 @@ export function installManagedCodexSkills(
 ): InstalledCodexSkillsResult {
   const root = resolveCodexSkillsRoot(env, home);
   const skillFiles: string[] = [];
+  const skipped: InstalledCodexSkillsResult["skipped"] = [];
+  let installed = 0;
+  let updated = 0;
+  let unchanged = 0;
+  const statuses = inspectManagedCodexSkills(env, home, options);
 
-  for (const skill of PRS_CODEX_SKILLS) {
+  for (const [index, skill] of PRS_CODEX_SKILLS.entries()) {
     const skillDir = resolve(root, skill.folderName);
     const skillFile = resolve(skillDir, "SKILL.md");
+    const status = statuses[index];
+
+    if (status?.status === "custom") {
+      skipped.push({
+        filePath: skillFile,
+        skillName: skill.name,
+        reason: "custom-file",
+      });
+      continue;
+    }
+
+    if (status?.status === "current") {
+      unchanged += 1;
+      skillFiles.push(skillFile);
+      continue;
+    }
+
     mkdirSync(skillDir, { recursive: true });
     writeFileSync(skillFile, renderCodexSkillMarkdown(skill, options), "utf8");
+    if (status?.status === "stale") {
+      updated += 1;
+    } else {
+      installed += 1;
+    }
     skillFiles.push(skillFile);
   }
 
   return {
     root,
-    installed: skillFiles.length,
+    installed,
+    updated,
+    unchanged,
+    skipped,
     skillFiles,
   };
 }

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1555,6 +1555,7 @@ async function loadCli(options: {
     parsePrCommandArgs: module.parsePrCommandArgs,
     parseReviewCommandArgs: module.parseReviewCommandArgs,
     parseSetupCommandArgs: module.parseSetupCommandArgs,
+    parseUpdateCommandArgs: module.parseUpdateCommandArgs,
     analyzeFeatureBacklog,
     analyzeTestBacklog,
     generateCommitMessage,
@@ -4702,8 +4703,16 @@ describe("CLI integration", () => {
     const { parseSetupCommandArgs } = await loadCli();
 
     expect(() => parseSetupCommandArgs(["setup", "--force"])).toThrow(
-      'Unknown setup option "--force". Usage:\n  prs setup'
+      'Unknown setup option "--force". Usage:\n  prs setup\n  prs setup --update-skills'
     );
+  });
+
+  it("parses update skills command", async () => {
+    process.env.GIT_AI_DISABLE_AUTO_RUN = "1";
+    const { parseUpdateCommandArgs } = await loadCli();
+
+    expect(parseUpdateCommandArgs(["update", "skills"])).toEqual({ action: "skills" });
+    expect(() => parseUpdateCommandArgs(["update"])).toThrow("Usage:\n  prs update skills");
   });
 
   it("filters excluded paths from commit diffs", async () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -45,6 +45,7 @@ import {
   loadResolvedRepositoryConfig,
 } from "./config";
 import { publishAuditArtifact } from "./audit-artifacts";
+import { inspectManagedCodexSkills } from "./codex-skills";
 import { buildDoneStateInstructions } from "./done-state";
 import { listIssuesTool } from "./issue-list-tool";
 import { readyIssueTool } from "./issue-ready-tool";
@@ -111,7 +112,13 @@ import {
   toRepoRelativePath,
   writeIssueRefineSessionState,
 } from "./run-artifacts";
-import { parseSetupCommandArgs, runSetupCommand } from "./setup";
+import {
+  logManagedCodexSkillsRefreshResult,
+  parseSetupCommandArgs,
+  refreshManagedCodexSkills,
+  resolveCurrentCliFallbackCommand,
+  runSetupCommand,
+} from "./setup";
 import {
   branchContainsCommit,
   ensureVerificationCommandAvailable,
@@ -472,6 +479,8 @@ const TOP_LEVEL_HELP = [
   "",
   "Supporting commands:",
   "  prs setup",
+  "  prs setup --update-skills",
+  "  prs update skills",
   "  prs tool issue list [--actionable] --json",
   "  prs tool issue ready <issue-number> [--all] --json",
   "  prs tool issue create (--draft-file <path>|--issue-set <path>) --json",
@@ -487,6 +496,8 @@ const TOP_LEVEL_HELP = [
   "GitHub-only by design: forge-backed issue and pull request workflows currently target GitHub repositories.",
 ].join("\n");
 
+const UPDATE_USAGE = ["Usage:", "  prs update skills"].join("\n");
+
 function getCliArgs(): string[] {
   return process.argv.slice(2).filter((arg) => arg !== "--");
 }
@@ -498,6 +509,33 @@ function getInvokedCommandName(): string {
 
 function getDefaultRepoRoot(): string {
   return resolveRuntimeRepoRoot();
+}
+
+function warnIfManagedCodexSkillsAreStale(command: string): void {
+  if (command === "setup" || command === "update") {
+    return;
+  }
+
+  try {
+    const staleSkills = inspectManagedCodexSkills(undefined, undefined, {
+      cliFallbackCommand: resolveCurrentCliFallbackCommand(),
+    }).filter((status) => status.status === "stale");
+
+    if (staleSkills.length === 0) {
+      return;
+    }
+
+    const names = staleSkills
+      .slice(0, 3)
+      .map((status) => status.skillName)
+      .join(", ");
+    const suffix = staleSkills.length > 3 ? `, and ${staleSkills.length - 3} more` : "";
+    console.error(
+      `prs Codex skills look stale (${names}${suffix}). Run \`prs update skills\` to refresh them.`
+    );
+  } catch {
+    // Skill freshness should never block the requested command.
+  }
 }
 
 function loadRepoEnv(repoRoot: string): void {
@@ -1264,6 +1302,15 @@ export function parseAuditCommandArgs(args: string[]): AuditCommandOptions {
     sectionName,
     localRun,
   };
+}
+
+export function parseUpdateCommandArgs(args: string[]): { action: "skills" } {
+  const updateArgs = args[0] === "update" ? args.slice(1) : args;
+  if (updateArgs.length === 1 && updateArgs[0] === "skills") {
+    return { action: "skills" };
+  }
+
+  throw new Error(UPDATE_USAGE);
 }
 
 function parsePositiveInteger(value: string | undefined, flagName: string): number {
@@ -4579,6 +4626,13 @@ async function runAuditCommand(): Promise<void> {
   console.log(`Audit artifact ${result.status}: ${result.comment.url}`);
 }
 
+async function runUpdateCommand(): Promise<void> {
+  const command = parseUpdateCommandArgs(getCliArgs());
+  if (command.action === "skills") {
+    logManagedCodexSkillsRefreshResult(refreshManagedCodexSkills());
+  }
+}
+
 async function runPrCommand(): Promise<void> {
   const repoRoot = getDefaultRepoRoot();
   const prCommand = parsePrCommandArgs(getCliArgs());
@@ -7522,6 +7576,7 @@ export async function run(): Promise<void> {
     command !== "commit" &&
     command !== "diff" &&
     command !== "setup" &&
+    command !== "update" &&
     command !== "audit" &&
     command !== "issue" &&
     command !== "pr" &&
@@ -7534,6 +7589,7 @@ export async function run(): Promise<void> {
     throw new Error(`Unknown command: ${command}.\n\n${TOP_LEVEL_HELP}`);
   }
 
+  warnIfManagedCodexSkillsAreStale(command);
   emitLaunchStageNotice(args);
 
   if (command === "commit") {
@@ -7550,11 +7606,21 @@ export async function run(): Promise<void> {
   }
 
   if (command === "setup") {
-    parseSetupCommandArgs(args);
+    const setupCommand = parseSetupCommandArgs(args);
+    if (setupCommand.updateSkills) {
+      logManagedCodexSkillsRefreshResult(refreshManagedCodexSkills());
+      return;
+    }
+
     await runSetupCommand({
       repoRoot: getDefaultRepoRoot(),
       promptForLine,
     });
+    return;
+  }
+
+  if (command === "update") {
+    await runUpdateCommand();
     return;
   }
 

--- a/packages/cli/src/setup.test.ts
+++ b/packages/cli/src/setup.test.ts
@@ -221,7 +221,9 @@ describe("setup command", () => {
     expect(testSuggestionsWorkflow).toContain("github-script");
     expect(testSuggestionsWorkflow).toContain("updateComment");
     expect(testSuggestionsWorkflow).toContain("createComment");
-    expect(messages.join("\n")).toContain("Installed prs Codex skills: 11");
+    expect(messages.join("\n")).toContain(
+      "Installed prs Codex skills: 11; updated: 0; unchanged: 0; skipped: 0"
+    );
     expect(messages.join("\n")).toContain(
       "Codex fallback CLI: /usr/local/bin/node /Users/tester/Projects/prs/packages/cli/dist/index.js"
     );
@@ -357,8 +359,12 @@ describe("setup command", () => {
   });
 
   it("rejects unexpected setup arguments", () => {
+    expect(parseSetupCommandArgs(["setup"])).toEqual({ updateSkills: false });
+    expect(parseSetupCommandArgs(["setup", "--update-skills"])).toEqual({
+      updateSkills: true,
+    });
     expect(() => parseSetupCommandArgs(["setup", "--force"])).toThrow(
-      'Unknown setup option "--force". Usage:\n  prs setup'
+      'Unknown setup option "--force". Usage:\n  prs setup\n  prs setup --update-skills'
     );
   });
 

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -31,10 +31,13 @@ import {
   getRepositoryConfigPath,
   loadRepositoryConfig,
 } from "./config";
-import { installManagedCodexSkills } from "./codex-skills";
+import {
+  installManagedCodexSkills,
+  type InstalledCodexSkillsResult,
+} from "./codex-skills";
 import { getInteractiveRuntimeByType, isCodexSuperpowersAvailable } from "./runtime";
 
-const SETUP_USAGE = ["Usage:", "  prs setup"].join("\n");
+const SETUP_USAGE = ["Usage:", "  prs setup", "  prs setup --update-skills"].join("\n");
 const AGENTS_SECTION_START = SETUP_SECTION_START;
 const AGENTS_SECTION_END = SETUP_SECTION_END;
 const GIT_AI_WORKFLOW_MARKER = GENERATED_BY_SETUP_HEADER;
@@ -1866,13 +1869,24 @@ async function collectSetupAnswers(
   };
 }
 
-export function parseSetupCommandArgs(args: string[]): void {
-  if (args.length > 1) {
-    throw new Error(`Unknown setup option "${args[1]}". ${SETUP_USAGE}`);
+export type SetupCommandOptions = {
+  updateSkills: boolean;
+};
+
+export function parseSetupCommandArgs(args: string[]): SetupCommandOptions {
+  const optionArgs = args[0] === "setup" ? args.slice(1) : args;
+  if (optionArgs.length === 0) {
+    return { updateSkills: false };
   }
+
+  if (optionArgs.length === 1 && optionArgs[0] === "--update-skills") {
+    return { updateSkills: true };
+  }
+
+  throw new Error(`Unknown setup option "${optionArgs[0] ?? ""}". ${SETUP_USAGE}`);
 }
 
-function resolveCurrentCliFallbackCommand(): string[] | undefined {
+export function resolveCurrentCliFallbackCommand(): string[] | undefined {
   const rawEntrypoint = process.argv[1]?.trim();
   if (!rawEntrypoint) {
     return undefined;
@@ -1890,6 +1904,29 @@ function resolveCurrentCliFallbackCommand(): string[] | undefined {
   }
 
   return [process.execPath, entrypoint];
+}
+
+export function refreshManagedCodexSkills(options: {
+  cliFallbackCommand?: string[];
+} = {}): InstalledCodexSkillsResult {
+  return installManagedCodexSkills(undefined, undefined, {
+    cliFallbackCommand: options.cliFallbackCommand ?? resolveCurrentCliFallbackCommand(),
+  });
+}
+
+export function logManagedCodexSkillsRefreshResult(
+  result: InstalledCodexSkillsResult
+): void {
+  console.log(
+    `Refreshed prs Codex skills: ${result.installed} installed, ${result.updated} updated, ${result.unchanged} unchanged, ${result.skipped.length} skipped.`
+  );
+  console.log(`Codex skills root: ${result.root}`);
+
+  for (const skipped of result.skipped) {
+    console.log(
+      `Skipped ${skipped.filePath} because it does not look like a prs-managed skill.`
+    );
+  }
 }
 
 export async function runSetupCommand(options: {
@@ -1939,9 +1976,7 @@ export async function runSetupCommand(options: {
   }
 
   const cliFallbackCommand = options.cliFallbackCommand ?? resolveCurrentCliFallbackCommand();
-  const installedSkills = installManagedCodexSkills(undefined, undefined, {
-    cliFallbackCommand,
-  });
+  const installedSkills = refreshManagedCodexSkills({ cliFallbackCommand });
 
   console.log("");
   console.log(`Wrote ${getRepositoryConfigPath(options.repoRoot)}.`);
@@ -1983,7 +2018,9 @@ export async function runSetupCommand(options: {
     console.log(`Updated ${resolve(options.repoRoot, "AGENTS.md")}.`);
   }
 
-  console.log(`Installed prs Codex skills: ${installedSkills.installed}`);
+  console.log(
+    `Installed prs Codex skills: ${installedSkills.installed}; updated: ${installedSkills.updated}; unchanged: ${installedSkills.unchanged}; skipped: ${installedSkills.skipped.length}`
+  );
   if (cliFallbackCommand && cliFallbackCommand.length > 0) {
     console.log(`Codex fallback CLI: ${formatCommandForDisplay(cliFallbackCommand)}`);
   }


### PR DESCRIPTION
## Summary
- add managed Codex skill markers and hash-based stale detection
- add prs update skills and prs setup --update-skills refresh paths
- document the new skill refresh flow and extend CLI tests

## Verification
- pnpm build
- pnpm exec vitest run packages/cli/src/codex-skills.test.ts packages/cli/src/setup.test.ts packages/cli/src/index.test.ts
- CODEX_HOME=/tmp/prs-update-skills-check node packages/cli/dist/index.js update skills

Closes #190

<!-- prs:pr-assistant:start -->
## PR Assistant

### Summary
This pull request introduces a managed Codex skill refresh command, allowing users to update their Codex skills without re-running the entire repository setup. It includes new commands for refreshing skills and updates documentation accordingly.

### Risk areas
None noted.

### Files changed
- README.md
- docs/cli-reference.md
- docs/setup-configuration.md
- packages/cli/src/codex-skills.test.ts
- packages/cli/src/codex-skills.ts
- packages/cli/src/index.test.ts
- packages/cli/src/index.ts
- packages/cli/src/setup.test.ts
- packages/cli/src/setup.ts

### Testing notes
- The changes were verified by running the build and executing the CLI tests, which include tests for the new skill refresh functionality.
- The command `prs update skills` was tested to ensure it correctly refreshes managed Codex skills.

### Rollout concerns
None noted.

### Reviewer checklist
- Verify that the new commands `prs setup --update-skills` and `prs update skills` function as intended.
- Check that the documentation accurately reflects the new functionality.
- Ensure that existing functionality remains unaffected by the new changes.
<!-- prs:pr-assistant:end -->