### PR TITLE
Fix GitHub CLI auth path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ After upgrading the CLI, refresh the managed Codex `/prs` skills without rerunni
 prs update skills
 ```
 
-For the recommended OpenAI provider path, create a `.env` file in the target repository with `OPENAI_API_KEY`. `OPENAI_MODEL` and `OPENAI_BASE_URL` are optional.
+For the recommended OpenAI provider path, create a `.env` file in the target repository with `OPENAI_API_KEY`. `OPENAI_MODEL` and `OPENAI_BASE_URL` are optional. GitHub-backed local workflows can use `GH_TOKEN`/`GITHUB_TOKEN`, but normal developer and Codex shells can also use an authenticated `gh`; if that binary is outside PATH, set `forge.githubCliPath` in `.prs/config.json` or `PRS_GH_PATH` in the shell.
 
 Then try the safest local CLI workflows:
 

--- a/actions/pr-assistant/dist/index.js
+++ b/actions/pr-assistant/dist/index.js
@@ -16509,7 +16509,8 @@ var require_dist = __commonJS({
     var import_zod9 = require_zod();
     var RepositoryForgeType = import_zod9.z.enum(["github", "none"]);
     var RepositoryForgeConfig = import_zod9.z.object({
-      type: RepositoryForgeType.optional()
+      type: RepositoryForgeType.optional(),
+      githubCliPath: import_zod9.z.string().trim().min(1, "forge githubCliPath must be non-empty").optional()
     });
     var RepositoryAiContextConfig = import_zod9.z.object({
       excludePaths: import_zod9.z.array(import_zod9.z.string().trim().min(1, "excludePaths entries must be non-empty")).optional()
@@ -16582,7 +16583,8 @@ var require_dist = __commonJS({
       baseBranch: import_zod9.z.string().trim().min(1),
       buildCommand: RepositoryConfigCommand,
       forge: import_zod9.z.object({
-        type: RepositoryForgeType
+        type: RepositoryForgeType,
+        githubCliPath: import_zod9.z.string().trim().min(1).optional()
       }),
       localRuntime: RepositoryLocalRuntimeConfig.optional()
     });
@@ -17119,7 +17121,8 @@ ${formatValidationIssues(validationIssues)}`,
         baseBranch: parsedConfig.baseBranch ?? DEFAULT_REPOSITORY_BASE_BRANCH,
         buildCommand: parsedConfig.buildCommand ?? [...DEFAULT_REPOSITORY_BUILD_COMMAND],
         forge: {
-          type: parsedConfig.forge?.type ?? DEFAULT_REPOSITORY_FORGE_TYPE
+          type: parsedConfig.forge?.type ?? DEFAULT_REPOSITORY_FORGE_TYPE,
+          ...parsedConfig.forge?.githubCliPath ? { githubCliPath: parsedConfig.forge.githubCliPath } : {}
         },
         localRuntime: parsedConfig.localRuntime
       });

--- a/actions/pr-review/dist/index.js
+++ b/actions/pr-review/dist/index.js
@@ -16509,7 +16509,8 @@ var require_dist = __commonJS({
     var import_zod9 = require_zod();
     var RepositoryForgeType = import_zod9.z.enum(["github", "none"]);
     var RepositoryForgeConfig = import_zod9.z.object({
-      type: RepositoryForgeType.optional()
+      type: RepositoryForgeType.optional(),
+      githubCliPath: import_zod9.z.string().trim().min(1, "forge githubCliPath must be non-empty").optional()
     });
     var RepositoryAiContextConfig = import_zod9.z.object({
       excludePaths: import_zod9.z.array(import_zod9.z.string().trim().min(1, "excludePaths entries must be non-empty")).optional()
@@ -16582,7 +16583,8 @@ var require_dist = __commonJS({
       baseBranch: import_zod9.z.string().trim().min(1),
       buildCommand: RepositoryConfigCommand,
       forge: import_zod9.z.object({
-        type: RepositoryForgeType
+        type: RepositoryForgeType,
+        githubCliPath: import_zod9.z.string().trim().min(1).optional()
       }),
       localRuntime: RepositoryLocalRuntimeConfig.optional()
     });
@@ -17119,7 +17121,8 @@ ${formatValidationIssues(validationIssues)}`,
         baseBranch: parsedConfig.baseBranch ?? DEFAULT_REPOSITORY_BASE_BRANCH,
         buildCommand: parsedConfig.buildCommand ?? [...DEFAULT_REPOSITORY_BUILD_COMMAND],
         forge: {
-          type: parsedConfig.forge?.type ?? DEFAULT_REPOSITORY_FORGE_TYPE
+          type: parsedConfig.forge?.type ?? DEFAULT_REPOSITORY_FORGE_TYPE,
+          ...parsedConfig.forge?.githubCliPath ? { githubCliPath: parsedConfig.forge.githubCliPath } : {}
         },
         localRuntime: parsedConfig.localRuntime
       });

--- a/actions/test-suggestions/dist/index.js
+++ b/actions/test-suggestions/dist/index.js
@@ -16509,7 +16509,8 @@ var require_dist = __commonJS({
     var import_zod9 = require_zod();
     var RepositoryForgeType = import_zod9.z.enum(["github", "none"]);
     var RepositoryForgeConfig = import_zod9.z.object({
-      type: RepositoryForgeType.optional()
+      type: RepositoryForgeType.optional(),
+      githubCliPath: import_zod9.z.string().trim().min(1, "forge githubCliPath must be non-empty").optional()
     });
     var RepositoryAiContextConfig = import_zod9.z.object({
       excludePaths: import_zod9.z.array(import_zod9.z.string().trim().min(1, "excludePaths entries must be non-empty")).optional()
@@ -16582,7 +16583,8 @@ var require_dist = __commonJS({
       baseBranch: import_zod9.z.string().trim().min(1),
       buildCommand: RepositoryConfigCommand,
       forge: import_zod9.z.object({
-        type: RepositoryForgeType
+        type: RepositoryForgeType,
+        githubCliPath: import_zod9.z.string().trim().min(1).optional()
       }),
       localRuntime: RepositoryLocalRuntimeConfig.optional()
     });
@@ -17119,7 +17121,8 @@ ${formatValidationIssues(validationIssues)}`,
         baseBranch: parsedConfig.baseBranch ?? DEFAULT_REPOSITORY_BASE_BRANCH,
         buildCommand: parsedConfig.buildCommand ?? [...DEFAULT_REPOSITORY_BUILD_COMMAND],
         forge: {
-          type: parsedConfig.forge?.type ?? DEFAULT_REPOSITORY_FORGE_TYPE
+          type: parsedConfig.forge?.type ?? DEFAULT_REPOSITORY_FORGE_TYPE,
+          ...parsedConfig.forge?.githubCliPath ? { githubCliPath: parsedConfig.forge.githubCliPath } : {}
         },
         localRuntime: parsedConfig.localRuntime
       });

--- a/docs/setup-configuration.md
+++ b/docs/setup-configuration.md
@@ -77,7 +77,7 @@ You only need extra tooling for advanced or deeper local workflows:
 - `codex` on `PATH` for `prs codex pr prepare-review <pr-number>`, which checks out a reviewer workspace, syncs it with the latest PR base branch, resolves merge conflicts in Codex when needed, generates the review brief, leaves you in an interactive Codex session for follow-up questions or fixes, offers the same reviewed commit-message flow as other local fix workflows when that session makes changes, and pushes any new reviewed commits back to the PR head branch before exiting
 - `codex` on `PATH` for `prs pr resolve-conflicts <pr-number>`, which checks out the PR head branch, syncs it with the latest PR base branch, opens a focused Codex session only when merge conflicts need local resolution, verifies the completed merge with the configured build command, writes `.prs/` run artifacts, and pushes the synced branch back to the PR head branch through the guarded push flow
 - `codex` plus authenticated GitHub access for `prs issue <number> --mode unattended`, `prs issue <number> <number> ...`, and `prs issue batch ...`
-- `gh`, `GH_TOKEN`, or `GITHUB_TOKEN` for GitHub-backed issue and pull request flows
+- authenticated `gh`, `GH_TOKEN`, or `GITHUB_TOKEN` for GitHub-backed issue and pull request flows
 
 `prs` resolves the active repository from your current Git working tree at runtime. It loads `.env` and `.prs/config.json` from that repository root, not from the CLI build location. If a repository has not been migrated yet, `prs` falls back to legacy `.git-ai/` config and workflow state when no `.prs/` equivalent exists.
 
@@ -136,12 +136,13 @@ Optional repository-specific defaults live in `.prs/config.json`. `prs setup` ca
   "baseBranch": "main",
   "buildCommand": ["pnpm", "build"],
   "forge": {
-    "type": "github"
+    "type": "github",
+    "githubCliPath": "/opt/homebrew/bin/gh"
   }
 }
 ```
 
-Recommended first configuration: leave `ai.provider.type` unset so it defaults to `openai`, leave `ai.runtime.type` unset so it defaults to `codex`, and use `forge.type: "github"` for GitHub-backed issue and PR flows. Change provider or runtime settings only when you need a deeper customization path.
+Recommended first configuration: leave `ai.provider.type` unset so it defaults to `openai`, leave `ai.runtime.type` unset so it defaults to `codex`, and use `forge.type: "github"` for GitHub-backed issue and PR flows. Change provider or runtime settings only when you need a deeper customization path. `forge.githubCliPath` is optional; use it only when the authenticated GitHub CLI lives outside the PATH used by `prs`.
 
 Supported fields:
 
@@ -156,6 +157,7 @@ Supported fields:
 - `baseBranch`: base branch used by `prs issue <number>` and `prs issue prepare <number>` when switching, syncing from `origin`, and opening pull requests. If unset, the resolved default is `main`, but `prs setup` first tries the remote default branch and then prints an explicit fallback warning when it has to guess.
 - `buildCommand`: command run after the interactive runtime exits during full local `prs issue <number>`, `prs pr fix-comments <pr-number>`, and `prs pr fix-tests <pr-number>` flows, and after a clean or Codex-resolved merge during `prs pr resolve-conflicts <pr-number>`. `prs pr fix-failing-tests <pr-number>` runs it once before launching the runtime and exits without a run directory if it already passes, then reruns it after the runtime when a failure was captured. If unset, the resolved default is `["pnpm", "build"]`, but `prs setup` first tries repository-local `verify`, `build`, or `test` commands from `package.json`, `composer.json`, or PHPUnit signals and warns before falling back.
 - `forge.type`: forge integration. Use `"github"` for GitHub-backed issue and PR flows or `"none"` to disable forge-backed issue and PR features for the repository.
+- `forge.githubCliPath`: optional path to the authenticated `gh` executable that prs should use for local GitHub operations when environment tokens are not set. PRS resolves auth in this order: `GH_TOKEN`, `GITHUB_TOKEN`, `PRS_GH_PATH` or `PRS_GITHUB_CLI_PATH`, `forge.githubCliPath`, `gh` on PATH, then common local install paths such as `/opt/homebrew/bin/gh` and `/usr/local/bin/gh`. CI and headless environments can keep using `GH_TOKEN` or `GITHUB_TOKEN`; normal local Codex shells can rely on authenticated `gh` without adding project-specific token values to `.env`.
 
 Runtime and provider fallback behavior:
 

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -196,6 +196,24 @@ describe("config helpers", () => {
     });
   });
 
+  it("resolves a configured GitHub CLI path from repository config", () => {
+    const repoRoot = createRepoRoot();
+    writeRepositoryConfig(
+      repoRoot,
+      JSON.stringify({
+        forge: {
+          type: "github",
+          githubCliPath: "/opt/homebrew/bin/gh",
+        },
+      })
+    );
+
+    expect(loadResolvedRepositoryConfig(repoRoot).forge).toEqual({
+      type: "github",
+      githubCliPath: "/opt/homebrew/bin/gh",
+    });
+  });
+
   it("loads local runtime readiness config from disk", () => {
     const repoRoot = createRepoRoot();
     writeRepositoryConfig(

--- a/packages/cli/src/github-auth.test.ts
+++ b/packages/cli/src/github-auth.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  formatGitHubAuthDiagnostics,
+  resolveGitHubCli,
+  resolveGitHubToken,
+} from "./github-auth";
+
+describe("GitHub auth resolution", () => {
+  it("uses an env token without requiring gh", () => {
+    const spawnSync = vi.fn();
+    const runCommand = vi.fn();
+
+    const result = resolveGitHubToken({
+      env: {
+        GH_TOKEN: "  env-token  ",
+      },
+      runCommand,
+      spawnSync,
+    });
+
+    expect(result.token).toBe("env-token");
+    expect(result.diagnostics.tokenSource).toBe("GH_TOKEN");
+    expect(spawnSync).not.toHaveBeenCalled();
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it("finds an authenticated gh executable outside PATH", () => {
+    const spawnSync = vi.fn((command: string) => ({
+      status: command === "/opt/homebrew/bin/gh" ? 0 : 1,
+    }));
+    const runCommand = vi.fn((command: string, args: string[]) => {
+      if (command === "/opt/homebrew/bin/gh" && args.join(" ") === "auth token") {
+        return "gh-token";
+      }
+      throw new Error(`unexpected command: ${command} ${args.join(" ")}`);
+    });
+
+    const cli = resolveGitHubCli({
+      env: {
+        PATH: "/usr/bin:/bin",
+      },
+      spawnSync,
+    });
+
+    expect(cli.path).toBe("/opt/homebrew/bin/gh");
+    expect(cli.source).toBe("common-path");
+
+    const token = resolveGitHubToken({
+      env: {
+        PATH: "/usr/bin:/bin",
+      },
+      runCommand,
+      spawnSync,
+    });
+
+    expect(token.token).toBe("gh-token");
+    expect(token.diagnostics.tokenSource).toBe("gh");
+    expect(runCommand).toHaveBeenCalledWith("/opt/homebrew/bin/gh", ["auth", "token"]);
+  });
+
+  it("prefers a configured gh executable before PATH and common locations", () => {
+    const spawnSync = vi.fn((command: string) => ({
+      status: command === "/custom/bin/gh" ? 0 : 1,
+    }));
+
+    const result = resolveGitHubCli({
+      configuredPath: "/custom/bin/gh",
+      env: {
+        PATH: "/usr/bin:/bin",
+      },
+      spawnSync,
+    });
+
+    expect(result.path).toBe("/custom/bin/gh");
+    expect(result.source).toBe("config");
+  });
+
+  it("reports attempted auth paths when no env token or gh token is available", () => {
+    const spawnSync = vi.fn(() => ({
+      status: 1,
+      error: new Error("not found"),
+    }));
+
+    const result = resolveGitHubToken({
+      env: {
+        PATH: "/usr/bin:/bin",
+      },
+      runCommand: vi.fn(),
+      spawnSync,
+    });
+
+    expect(result.token).toBeUndefined();
+    expect(formatGitHubAuthDiagnostics(result.diagnostics)).toContain("GH_TOKEN present: no");
+    expect(formatGitHubAuthDiagnostics(result.diagnostics)).toContain(
+      "GITHUB_TOKEN present: no"
+    );
+    expect(formatGitHubAuthDiagnostics(result.diagnostics)).toContain(
+      "gh candidates tried:"
+    );
+    expect(formatGitHubAuthDiagnostics(result.diagnostics)).toContain(
+      "/opt/homebrew/bin/gh"
+    );
+  });
+});

--- a/packages/cli/src/github-auth.ts
+++ b/packages/cli/src/github-auth.ts
@@ -1,0 +1,262 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { loadRepositoryConfig } from "./config";
+
+export const COMMON_GH_EXECUTABLE_PATHS = [
+  "/opt/homebrew/bin/gh",
+  "/usr/local/bin/gh",
+] as const;
+
+type SpawnResult = {
+  error?: Error;
+  status?: number | null;
+};
+
+type SpawnCommand = (command: string, args: string[]) => SpawnResult;
+type RunCommand = (command: string, args: string[]) => string;
+
+export type GitHubCliResolutionSource =
+  | "env"
+  | "config"
+  | "path"
+  | "common-path";
+
+export type GitHubCliAttempt = {
+  path: string;
+  source: GitHubCliResolutionSource;
+  available: boolean;
+  error?: string;
+};
+
+export type GitHubAuthDiagnostics = {
+  ghTokenPresent: boolean;
+  githubTokenPresent: boolean;
+  ghCandidates: GitHubCliAttempt[];
+  selectedGhPath?: string;
+  selectedGhSource?: GitHubCliResolutionSource;
+  tokenSource?: "GH_TOKEN" | "GITHUB_TOKEN" | "gh";
+  ghTokenError?: string;
+};
+
+export type GitHubCliResolution = {
+  path?: string;
+  source?: GitHubCliResolutionSource;
+  diagnostics: GitHubAuthDiagnostics;
+};
+
+function defaultSpawnCommand(command: string, args: string[]): SpawnResult {
+  return spawnSync(command, args, { stdio: "ignore" });
+}
+
+function defaultRunCommand(command: string, args: string[]): string {
+  return execFileSync(command, args, {
+    encoding: "utf8",
+    maxBuffer: 10 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function normalizeToken(value: string | undefined): string | undefined {
+  const token = value?.trim();
+  return token ? token : undefined;
+}
+
+function loadConfiguredGitHubCliPath(repoRoot: string | undefined): string | undefined {
+  if (!repoRoot) {
+    return undefined;
+  }
+
+  try {
+    return loadRepositoryConfig(repoRoot)?.forge?.githubCliPath?.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function uniqueCandidates(
+  candidates: Array<{ path: string | undefined; source: GitHubCliResolutionSource }>
+): Array<{ path: string; source: GitHubCliResolutionSource }> {
+  const seen = new Set<string>();
+  const unique: Array<{ path: string; source: GitHubCliResolutionSource }> = [];
+  for (const candidate of candidates) {
+    const path = candidate.path?.trim();
+    if (!path || seen.has(path)) {
+      continue;
+    }
+
+    seen.add(path);
+    unique.push({ path, source: candidate.source });
+  }
+
+  return unique;
+}
+
+function renderSpawnError(result: SpawnResult): string | undefined {
+  if (result.error?.message) {
+    return result.error.message;
+  }
+
+  if (typeof result.status === "number") {
+    return `exit ${result.status}`;
+  }
+
+  return undefined;
+}
+
+export function resolveGitHubCli(options: {
+  configuredPath?: string;
+  env?: Record<string, string | undefined>;
+  repoRoot?: string;
+  spawnSync?: SpawnCommand;
+} = {}): GitHubCliResolution {
+  const env = options.env ?? process.env;
+  const spawn = options.spawnSync ?? defaultSpawnCommand;
+  const configuredPath =
+    options.configuredPath ?? loadConfiguredGitHubCliPath(options.repoRoot);
+  const diagnostics: GitHubAuthDiagnostics = {
+    ghTokenPresent: Boolean(normalizeToken(env.GH_TOKEN)),
+    githubTokenPresent: Boolean(normalizeToken(env.GITHUB_TOKEN)),
+    ghCandidates: [],
+  };
+
+  const candidates = uniqueCandidates([
+    { path: env.PRS_GH_PATH ?? env.PRS_GITHUB_CLI_PATH, source: "env" },
+    { path: configuredPath, source: "config" },
+    { path: "gh", source: "path" },
+    ...COMMON_GH_EXECUTABLE_PATHS.map((path) => ({
+      path,
+      source: "common-path" as const,
+    })),
+  ]);
+
+  for (const candidate of candidates) {
+    let result: SpawnResult;
+    try {
+      result = spawn(candidate.path, ["--version"]);
+    } catch (error: unknown) {
+      result = {
+        error: error instanceof Error ? error : new Error(String(error)),
+      };
+    }
+    const available = !result.error && result.status === 0;
+    diagnostics.ghCandidates.push({
+      ...candidate,
+      available,
+      error: available ? undefined : renderSpawnError(result),
+    });
+
+    if (available) {
+      diagnostics.selectedGhPath = candidate.path;
+      diagnostics.selectedGhSource = candidate.source;
+      return {
+        path: candidate.path,
+        source: candidate.source,
+        diagnostics,
+      };
+    }
+  }
+
+  return { diagnostics };
+}
+
+export function resolveGitHubToken(options: {
+  configuredPath?: string;
+  env?: Record<string, string | undefined>;
+  repoRoot?: string;
+  runCommand?: RunCommand;
+  spawnSync?: SpawnCommand;
+} = {}): { token?: string; diagnostics: GitHubAuthDiagnostics } {
+  const env = options.env ?? process.env;
+  const ghToken = normalizeToken(env.GH_TOKEN);
+  const githubToken = normalizeToken(env.GITHUB_TOKEN);
+
+  if (ghToken) {
+    return {
+      token: ghToken,
+      diagnostics: {
+        ghTokenPresent: true,
+        githubTokenPresent: Boolean(githubToken),
+        ghCandidates: [],
+        tokenSource: "GH_TOKEN",
+      },
+    };
+  }
+
+  if (githubToken) {
+    return {
+      token: githubToken,
+      diagnostics: {
+        ghTokenPresent: false,
+        githubTokenPresent: true,
+        ghCandidates: [],
+        tokenSource: "GITHUB_TOKEN",
+      },
+    };
+  }
+
+  const cli = resolveGitHubCli({
+    configuredPath: options.configuredPath,
+    env,
+    repoRoot: options.repoRoot,
+    spawnSync: options.spawnSync,
+  });
+  if (!cli.path) {
+    return { diagnostics: cli.diagnostics };
+  }
+
+  try {
+    const token = normalizeToken(
+      (options.runCommand ?? defaultRunCommand)(cli.path, ["auth", "token"])
+    );
+    return {
+      token,
+      diagnostics: {
+        ...cli.diagnostics,
+        tokenSource: token ? "gh" : undefined,
+      },
+    };
+  } catch (error: unknown) {
+    return {
+      diagnostics: {
+        ...cli.diagnostics,
+        ghTokenError: error instanceof Error ? error.message : String(error),
+      },
+    };
+  }
+}
+
+export function formatGitHubAuthDiagnostics(
+  diagnostics: GitHubAuthDiagnostics
+): string {
+  const lines = [
+    "GitHub auth diagnostics:",
+    `- GH_TOKEN present: ${diagnostics.ghTokenPresent ? "yes" : "no"}`,
+    `- GITHUB_TOKEN present: ${diagnostics.githubTokenPresent ? "yes" : "no"}`,
+  ];
+
+  if (diagnostics.tokenSource) {
+    lines.push(`- token source: ${diagnostics.tokenSource}`);
+  }
+
+  if (diagnostics.selectedGhPath) {
+    lines.push(
+      `- selected gh: ${diagnostics.selectedGhPath} (${diagnostics.selectedGhSource})`
+    );
+  }
+
+  if (diagnostics.ghCandidates.length > 0) {
+    lines.push("- gh candidates tried:");
+    for (const candidate of diagnostics.ghCandidates) {
+      lines.push(
+        `  - ${candidate.path} (${candidate.source}): ${
+          candidate.available ? "available" : `unavailable${candidate.error ? `, ${candidate.error}` : ""}`
+        }`
+      );
+    }
+  }
+
+  if (diagnostics.ghTokenError) {
+    lines.push(`- gh auth token failed: ${diagnostics.ghTokenError}`);
+  }
+
+  return lines.join("\n");
+}

--- a/packages/cli/src/github.ts
+++ b/packages/cli/src/github.ts
@@ -15,6 +15,11 @@ import type {
   RepositoryForge,
 } from "./forge";
 import { AUDIT_COMMENT_MARKER } from "./audit-artifacts";
+import {
+  formatGitHubAuthDiagnostics,
+  resolveGitHubCli,
+  resolveGitHubToken,
+} from "./github-auth";
 
 function runCommand(
   command: string,
@@ -40,14 +45,6 @@ function runCommand(
   }
 }
 
-function canRunCommand(command: string, args: string[] = ["--version"]): boolean {
-  const result = spawnSync(command, args, {
-    stdio: "ignore",
-  });
-
-  return !result.error && result.status === 0;
-}
-
 function hasGitHubApiToken(): boolean {
   return Boolean(process.env.GH_TOKEN?.trim() || process.env.GITHUB_TOKEN?.trim());
 }
@@ -70,43 +67,47 @@ function parseGitHubRepoFromRemote(repoRoot: string): { owner: string; repo: str
   };
 }
 
-function isGhAuthenticated(): boolean {
-  if (!canRunCommand("gh")) {
+function resolveGhCommand(repoRoot?: string): string | undefined {
+  return resolveGitHubCli({ repoRoot }).path;
+}
+
+function isGhAuthenticated(repoRoot?: string): boolean {
+  const ghCommand = resolveGhCommand(repoRoot);
+  if (!ghCommand) {
     return false;
   }
 
-  const result = spawnSync("gh", ["auth", "status"], {
-    stdio: "ignore",
-  });
+  let result: ReturnType<typeof spawnSync>;
+  try {
+    result = spawnSync(ghCommand, ["auth", "status"], {
+      stdio: "ignore",
+    });
+  } catch {
+    return false;
+  }
 
   return !result.error && result.status === 0;
 }
 
-function canUseGitHub(): boolean {
-  return isGhAuthenticated() || hasGitHubApiToken();
+function canUseGitHub(repoRoot?: string): boolean {
+  return (
+    hasGitHubApiToken() ||
+    isGhAuthenticated(repoRoot) ||
+    Boolean(tryResolveGitHubApiToken(repoRoot))
+  );
 }
 
-function tryResolveGitHubApiToken(): string | undefined {
-  const envToken = process.env.GH_TOKEN?.trim() || process.env.GITHUB_TOKEN?.trim();
-  if (envToken) {
-    return envToken;
-  }
-
-  if (!isGhAuthenticated()) {
-    return undefined;
-  }
-
-  try {
-    return runCommand("gh", ["auth", "token"], "Failed to read the GitHub token from gh.");
-  } catch {
-    return undefined;
-  }
+function tryResolveGitHubApiToken(repoRoot?: string): string | undefined {
+  return resolveGitHubToken({ repoRoot }).token;
 }
 
-function getGitHubApiToken(requiredMessage: string): string {
-  const token = tryResolveGitHubApiToken();
+function getGitHubApiToken(requiredMessage: string, repoRoot?: string): string {
+  const resolution = resolveGitHubToken({ repoRoot });
+  const token = resolution.token;
   if (!token) {
-    throw new Error(requiredMessage);
+    throw new Error(
+      `${requiredMessage}\n${formatGitHubAuthDiagnostics(resolution.diagnostics)}`
+    );
   }
 
   return token;
@@ -234,9 +235,10 @@ function runTrackedCommand(
 async function listIssueComments(
   owner: string,
   repo: string,
-  issueNumber: number
+  issueNumber: number,
+  repoRoot?: string
 ): Promise<RepositoryComment[]> {
-  const token = tryResolveGitHubApiToken();
+  const token = tryResolveGitHubApiToken(repoRoot);
   const headers: Record<string, string> = {
     Accept: "application/vnd.github+json",
     "User-Agent": "prs-cli",
@@ -296,9 +298,10 @@ async function listIssueComments(
 async function assertAuditTargetMatchesType(
   owner: string,
   repo: string,
-  target: AuditTarget
+  target: AuditTarget,
+  repoRoot?: string
 ): Promise<void> {
-  const token = tryResolveGitHubApiToken();
+  const token = tryResolveGitHubApiToken(repoRoot);
   const headers: Record<string, string> = {
     Accept: "application/vnd.github+json",
     "User-Agent": "prs-cli",
@@ -342,15 +345,17 @@ async function assertAuditTargetMatchesType(
 function tryFetchPullRequestWithGh(
   owner: string,
   repo: string,
-  prNumber: number
+  prNumber: number,
+  repoRoot?: string
 ): PullRequestDetails | undefined {
-  if (!canRunCommand("gh")) {
+  const ghCommand = resolveGhCommand(repoRoot);
+  if (!ghCommand) {
     return undefined;
   }
 
   try {
     const payload = runCommand(
-      "gh",
+      ghCommand,
       [
         "pr",
         "view",
@@ -399,15 +404,17 @@ function tryFetchPullRequestWithGh(
 function tryFetchIssueWithGh(
   owner: string,
   repo: string,
-  issueNumber: number
+  issueNumber: number,
+  repoRoot?: string
 ): IssueDetails | undefined {
-  if (!canRunCommand("gh")) {
+  const ghCommand = resolveGhCommand(repoRoot);
+  if (!ghCommand) {
     return undefined;
   }
 
   try {
     const payload = runCommand(
-      "gh",
+      ghCommand,
       ["issue", "view", String(issueNumber), "--repo", `${owner}/${repo}`, "--json", "title,body,url"],
       `Failed to fetch GitHub issue #${issueNumber} with gh.`
     );
@@ -430,9 +437,10 @@ function tryFetchIssueWithGh(
 async function fetchIssueWithApi(
   owner: string,
   repo: string,
-  issueNumber: number
+  issueNumber: number,
+  repoRoot?: string
 ): Promise<IssueDetails> {
-  const token = tryResolveGitHubApiToken();
+  const token = tryResolveGitHubApiToken(repoRoot);
   const headers: Record<string, string> = {
     Accept: "application/vnd.github+json",
     "User-Agent": "prs-cli",
@@ -473,9 +481,10 @@ async function fetchIssueWithApi(
 async function fetchPullRequestWithApi(
   owner: string,
   repo: string,
-  prNumber: number
+  prNumber: number,
+  repoRoot?: string
 ): Promise<PullRequestDetails> {
-  const token = tryResolveGitHubApiToken();
+  const token = tryResolveGitHubApiToken(repoRoot);
   const headers: Record<string, string> = {
     Accept: "application/vnd.github+json",
     "User-Agent": "prs-cli",
@@ -535,14 +544,15 @@ async function fetchPullRequestWithApi(
 async function listPullRequestChecks(
   owner: string,
   repo: string,
-  prNumber: number
+  prNumber: number,
+  repoRoot?: string
 ): Promise<PullRequestCheckSignal[]> {
-  const pullRequest = await fetchPullRequestWithApi(owner, repo, prNumber);
+  const pullRequest = await fetchPullRequestWithApi(owner, repo, prNumber, repoRoot);
   if (!pullRequest.headSha) {
     return [];
   }
 
-  const token = tryResolveGitHubApiToken();
+  const token = tryResolveGitHubApiToken(repoRoot);
   const headers: Record<string, string> = {
     Accept: "application/vnd.github+json",
     "User-Agent": "prs-cli",
@@ -672,9 +682,10 @@ function normalizeStatusConclusion(
 
 async function listOpenPullRequests(
   owner: string,
-  repo: string
+  repo: string,
+  repoRoot?: string
 ): Promise<Array<Omit<OpenPullRequestChange, "files">>> {
-  const token = tryResolveGitHubApiToken();
+  const token = tryResolveGitHubApiToken(repoRoot);
   const headers: Record<string, string> = {
     Accept: "application/vnd.github+json",
     "User-Agent": "prs-cli",
@@ -724,9 +735,10 @@ async function listOpenPullRequests(
 async function listPullRequestFiles(
   owner: string,
   repo: string,
-  prNumber: number
+  prNumber: number,
+  repoRoot?: string
 ): Promise<string[]> {
-  const token = tryResolveGitHubApiToken();
+  const token = tryResolveGitHubApiToken(repoRoot);
   const headers: Record<string, string> = {
     Accept: "application/vnd.github+json",
     "User-Agent": "prs-cli",
@@ -756,9 +768,10 @@ async function listPullRequestFiles(
 async function listPullRequestReviewComments(
   owner: string,
   repo: string,
-  prNumber: number
+  prNumber: number,
+  repoRoot?: string
 ): Promise<PullRequestReviewComment[]> {
-  const token = tryResolveGitHubApiToken();
+  const token = tryResolveGitHubApiToken(repoRoot);
   const headers: Record<string, string> = {
     Accept: "application/vnd.github+json",
     "User-Agent": "prs-cli",
@@ -916,22 +929,22 @@ class GitHubRepositoryForge implements RepositoryForge {
   constructor(private readonly repoRoot: string) {}
 
   isAuthenticated(): boolean {
-    return canUseGitHub();
+    return canUseGitHub(this.repoRoot);
   }
 
   async fetchIssueDetails(issueNumber: number): Promise<IssueDetails> {
     const { owner, repo } = parseGitHubRepoFromRemote(this.repoRoot);
-    const ghIssue = tryFetchIssueWithGh(owner, repo, issueNumber);
+    const ghIssue = tryFetchIssueWithGh(owner, repo, issueNumber, this.repoRoot);
     if (ghIssue) {
       return ghIssue;
     }
 
-    return fetchIssueWithApi(owner, repo, issueNumber);
+    return fetchIssueWithApi(owner, repo, issueNumber, this.repoRoot);
   }
 
   async fetchIssuePlanComment(issueNumber: number): Promise<IssuePlanComment | undefined> {
     const { owner, repo } = parseGitHubRepoFromRemote(this.repoRoot);
-    const comments = await listIssueComments(owner, repo, issueNumber);
+    const comments = await listIssueComments(owner, repo, issueNumber, this.repoRoot);
 
     return comments
       .filter((comment) => includesManagedMarker(comment.body, ALL_ISSUE_PLAN_COMMENT_MARKERS))
@@ -940,8 +953,8 @@ class GitHubRepositoryForge implements RepositoryForge {
 
   async fetchAuditComment(target: AuditTarget): Promise<RepositoryComment | undefined> {
     const { owner, repo } = parseGitHubRepoFromRemote(this.repoRoot);
-    await assertAuditTargetMatchesType(owner, repo, target);
-    const comments = await listIssueComments(owner, repo, target.number);
+    await assertAuditTargetMatchesType(owner, repo, target, this.repoRoot);
+    const comments = await listIssueComments(owner, repo, target.number, this.repoRoot);
 
     return comments
       .filter((comment) => comment.body.includes(AUDIT_COMMENT_MARKER))
@@ -950,44 +963,44 @@ class GitHubRepositoryForge implements RepositoryForge {
 
   async fetchIssueComments(issueNumber: number): Promise<RepositoryComment[]> {
     const { owner, repo } = parseGitHubRepoFromRemote(this.repoRoot);
-    return listIssueComments(owner, repo, issueNumber);
+    return listIssueComments(owner, repo, issueNumber, this.repoRoot);
   }
 
   async fetchPullRequestDetails(prNumber: number): Promise<PullRequestDetails> {
     const { owner, repo } = parseGitHubRepoFromRemote(this.repoRoot);
-    const ghPullRequest = tryFetchPullRequestWithGh(owner, repo, prNumber);
+    const ghPullRequest = tryFetchPullRequestWithGh(owner, repo, prNumber, this.repoRoot);
     if (ghPullRequest) {
       return ghPullRequest;
     }
 
-    return fetchPullRequestWithApi(owner, repo, prNumber);
+    return fetchPullRequestWithApi(owner, repo, prNumber, this.repoRoot);
   }
 
   async fetchPullRequestChecks(prNumber: number): Promise<PullRequestCheckSignal[]> {
     const { owner, repo } = parseGitHubRepoFromRemote(this.repoRoot);
-    return listPullRequestChecks(owner, repo, prNumber);
+    return listPullRequestChecks(owner, repo, prNumber, this.repoRoot);
   }
 
   async listOpenPullRequestChanges(): Promise<OpenPullRequestChange[]> {
     const { owner, repo } = parseGitHubRepoFromRemote(this.repoRoot);
-    const pullRequests = await listOpenPullRequests(owner, repo);
+    const pullRequests = await listOpenPullRequests(owner, repo, this.repoRoot);
 
     return Promise.all(
       pullRequests.map(async (pullRequest) => ({
         ...pullRequest,
-        files: await listPullRequestFiles(owner, repo, pullRequest.number),
+        files: await listPullRequestFiles(owner, repo, pullRequest.number, this.repoRoot),
       }))
     );
   }
 
   async fetchPullRequestIssueComments(prNumber: number): Promise<RepositoryComment[]> {
     const { owner, repo } = parseGitHubRepoFromRemote(this.repoRoot);
-    return listIssueComments(owner, repo, prNumber);
+    return listIssueComments(owner, repo, prNumber, this.repoRoot);
   }
 
   async fetchPullRequestReviewComments(prNumber: number): Promise<PullRequestReviewComment[]> {
     const { owner, repo } = parseGitHubRepoFromRemote(this.repoRoot);
-    return listPullRequestReviewComments(owner, repo, prNumber);
+    return listPullRequestReviewComments(owner, repo, prNumber, this.repoRoot);
   }
 
   async createIssuePlanComment(
@@ -996,7 +1009,8 @@ class GitHubRepositoryForge implements RepositoryForge {
   ): Promise<IssuePlanComment> {
     const { owner, repo } = parseGitHubRepoFromRemote(this.repoRoot);
     const token = getGitHubApiToken(
-      "Posting issue resolution plans requires GH_TOKEN or GITHUB_TOKEN to be set, or gh to be installed and authenticated."
+      "Posting issue resolution plans requires GH_TOKEN or GITHUB_TOKEN to be set, or gh to be installed and authenticated.",
+      this.repoRoot
     );
     const response = await fetch(
       `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}/comments`,
@@ -1036,9 +1050,10 @@ class GitHubRepositoryForge implements RepositoryForge {
     body: string
   ): Promise<RepositoryComment> {
     const { owner, repo } = parseGitHubRepoFromRemote(this.repoRoot);
-    await assertAuditTargetMatchesType(owner, repo, target);
+    await assertAuditTargetMatchesType(owner, repo, target, this.repoRoot);
     const token = getGitHubApiToken(
-      "Publishing audit comments requires GH_TOKEN or GITHUB_TOKEN to be set, or gh to be installed and authenticated."
+      "Publishing audit comments requires GH_TOKEN or GITHUB_TOKEN to be set, or gh to be installed and authenticated.",
+      this.repoRoot
     );
     const response = await fetch(
       `https://api.github.com/repos/${owner}/${repo}/issues/${target.number}/comments`,
@@ -1079,7 +1094,8 @@ class GitHubRepositoryForge implements RepositoryForge {
   ): Promise<IssuePlanComment> {
     const { owner, repo } = parseGitHubRepoFromRemote(this.repoRoot);
     const token = getGitHubApiToken(
-      "Refreshing issue resolution plans requires GH_TOKEN or GITHUB_TOKEN to be set, or gh to be installed and authenticated."
+      "Refreshing issue resolution plans requires GH_TOKEN or GITHUB_TOKEN to be set, or gh to be installed and authenticated.",
+      this.repoRoot
     );
     const response = await fetch(
       `https://api.github.com/repos/${owner}/${repo}/issues/comments/${commentId}`,
@@ -1117,7 +1133,8 @@ class GitHubRepositoryForge implements RepositoryForge {
   async updateIssueComment(commentId: number, body: string): Promise<RepositoryComment> {
     const { owner, repo } = parseGitHubRepoFromRemote(this.repoRoot);
     const token = getGitHubApiToken(
-      "Updating issue comments requires GH_TOKEN or GITHUB_TOKEN to be set, or gh to be installed and authenticated."
+      "Updating issue comments requires GH_TOKEN or GITHUB_TOKEN to be set, or gh to be installed and authenticated.",
+      this.repoRoot
     );
     const response = await fetch(
       `https://api.github.com/repos/${owner}/${repo}/issues/comments/${commentId}`,
@@ -1155,9 +1172,12 @@ class GitHubRepositoryForge implements RepositoryForge {
   async createDraftIssue(title: string, body: string): Promise<string> {
     const { owner, repo } = parseGitHubRepoFromRemote(this.repoRoot);
 
-    if (isGhAuthenticated()) {
+    const ghCommand = hasGitHubApiToken()
+      ? undefined
+      : resolveGhCommand(this.repoRoot);
+    if (ghCommand && isGhAuthenticated(this.repoRoot)) {
       const output = runCommand(
-        "gh",
+        ghCommand,
         ["issue", "create", "--repo", `${owner}/${repo}`, "--title", title, "--body", body],
         `Failed to create GitHub issue "${title}" with gh.`
       );
@@ -1170,7 +1190,8 @@ class GitHubRepositoryForge implements RepositoryForge {
     }
 
     const token = getGitHubApiToken(
-      "Creating issues requires GH_TOKEN or GITHUB_TOKEN to be set, or gh to be installed and authenticated."
+      "Creating issues requires GH_TOKEN or GITHUB_TOKEN to be set, or gh to be installed and authenticated.",
+      this.repoRoot
     );
     const createdIssue = await createGitHubIssue(owner, repo, token, title, body, []);
     return createdIssue.url;
@@ -1183,7 +1204,8 @@ class GitHubRepositoryForge implements RepositoryForge {
   ): Promise<CreatedIssueRecord> {
     const { owner, repo } = parseGitHubRepoFromRemote(this.repoRoot);
     const token = getGitHubApiToken(
-      "Updating GitHub issues requires GH_TOKEN or GITHUB_TOKEN to be set, or gh to be installed and authenticated."
+      "Updating GitHub issues requires GH_TOKEN or GITHUB_TOKEN to be set, or gh to be installed and authenticated.",
+      this.repoRoot
     );
     const response = await fetch(
       `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}`,
@@ -1222,7 +1244,8 @@ class GitHubRepositoryForge implements RepositoryForge {
     labels: string[]
   ): Promise<CreatedIssueRecord> {
     const token = getGitHubApiToken(
-      "Creating GitHub issues requires GH_TOKEN or GITHUB_TOKEN to be set."
+      "Creating GitHub issues requires GH_TOKEN or GITHUB_TOKEN to be set.",
+      this.repoRoot
     );
     const { owner, repo } = parseGitHubRepoFromRemote(this.repoRoot);
     if (!this.openIssuesByTitle) {
@@ -1259,7 +1282,7 @@ class GitHubRepositoryForge implements RepositoryForge {
       this.repoRoot
     );
     const stdout = runTrackedCommand(
-      "gh",
+      resolveGhCommand(this.repoRoot) ?? "gh",
       [
         "pr",
         "create",

--- a/packages/cli/src/index-test-support.ts
+++ b/packages/cli/src/index-test-support.ts
@@ -1204,6 +1204,31 @@ async function loadCli(options: {
       options.spawnSyncImpl?.(command, normalizedArgs, rawSecondArg);
 
     if (
+      (command === "/opt/homebrew/bin/gh" || command === "/usr/local/bin/gh") &&
+      normalizedArgs[0] === "--version"
+    ) {
+      try {
+        return invokeCustomSpawnSync() ?? {
+          status: 1,
+          error: new Error(`${command} unavailable`),
+          stdout: "",
+          stderr: "",
+        };
+      } catch (error: unknown) {
+        if (!isUnexpectedSpawnSyncCall(error)) {
+          throw error;
+        }
+
+        return {
+          status: 1,
+          error: new Error(`${command} unavailable`),
+          stdout: "",
+          stderr: "",
+        };
+      }
+    }
+
+    if (
       command !== "git" &&
       command !== "gh" &&
       command !== "codex" &&

--- a/packages/cli/src/issue-list-tool.test.ts
+++ b/packages/cli/src/issue-list-tool.test.ts
@@ -18,12 +18,14 @@ describe("issue list tool", () => {
 
           return "git@github.com:DevwareUK/prs.git";
         },
+        spawnSyncImpl: () => ({ status: 1, error: new Error("gh unavailable") }),
       })
-    ).resolves.toEqual({
+    ).resolves.toMatchObject({
       status: "blocked",
       reason: "github-auth-required",
-      message:
-        "GitHub authentication is required for `prs tool issue list --actionable --json`.",
+      message: expect.stringContaining(
+        "GitHub authentication is required for `prs tool issue list --actionable --json`."
+      ),
       nextAction:
         "Set GH_TOKEN or GITHUB_TOKEN in the repository environment, or authenticate gh in the shell that runs prs.",
     });

--- a/packages/cli/src/issue-list-tool.ts
+++ b/packages/cli/src/issue-list-tool.ts
@@ -1,8 +1,9 @@
-import { execFileSync, spawnSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import {
   filterActionableIssuesForUser,
   type ActionableIssue,
 } from "./actionable-github";
+import { formatGitHubAuthDiagnostics, resolveGitHubToken } from "./github-auth";
 
 const ISSUE_PLAN_MARKERS = ["<!-- prs:issue-plan -->", "<!-- git-ai:issue-plan -->"];
 
@@ -34,6 +35,7 @@ type ListIssuesToolOptions = {
   fetchImpl?: FetchLike;
   repoRoot: string;
   runCommand?: (command: string, args: string[]) => string;
+  spawnSyncImpl?: (command: string, args: string[]) => { status?: number | null; error?: Error };
 };
 
 function runCommand(command: string, args: string[]): string {
@@ -54,31 +56,6 @@ function parseGitHubRepoFromRemote(remoteUrl: string): { owner: string; repo: st
     owner: match[1],
     repo: match[2],
   };
-}
-
-function canRunGh(): boolean {
-  const result = spawnSync("gh", ["--version"], { stdio: "ignore" });
-  return !result.error && result.status === 0;
-}
-
-function resolveGitHubToken(
-  env: Record<string, string | undefined>,
-  commandRunner: (command: string, args: string[]) => string
-): string | undefined {
-  const envToken = env.GH_TOKEN?.trim() || env.GITHUB_TOKEN?.trim();
-  if (envToken) {
-    return envToken;
-  }
-
-  if (!canRunGh()) {
-    return undefined;
-  }
-
-  try {
-    return commandRunner("gh", ["auth", "token"]).trim() || undefined;
-  } catch {
-    return undefined;
-  }
 }
 
 function createGitHubHeaders(token: string): Record<string, string> {
@@ -178,13 +155,19 @@ export async function listIssuesTool(
 ): Promise<IssueListToolResult> {
   const env = options.env ?? process.env;
   const commandRunner = options.runCommand ?? runCommand;
-  const token = resolveGitHubToken(env, commandRunner);
+  const tokenResolution = resolveGitHubToken({
+    env,
+    repoRoot: options.repoRoot,
+    runCommand: commandRunner,
+    spawnSync: options.spawnSyncImpl,
+  });
+  const token = tokenResolution.token;
   if (!token) {
     return {
       status: "blocked",
       reason: "github-auth-required",
       message:
-        "GitHub authentication is required for `prs tool issue list --actionable --json`.",
+        `GitHub authentication is required for \`prs tool issue list --actionable --json\`.\n${formatGitHubAuthDiagnostics(tokenResolution.diagnostics)}`,
       nextAction:
         "Set GH_TOKEN or GITHUB_TOKEN in the repository environment, or authenticate gh in the shell that runs prs.",
     };

--- a/packages/cli/src/issue-plan-forge.test.ts
+++ b/packages/cli/src/issue-plan-forge.test.ts
@@ -666,6 +666,84 @@ describe("Issue plan and GitHub forge workflows", () => {
     });
   });
 
+  it("creates audit comments with a resolved gh token when gh is outside PATH", async () => {
+    const issueNumber = 199;
+    const body = "<!-- prs:audit -->\n# Issue #199 audit\n";
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(createFetchResponse({ number: issueNumber }))
+      .mockResolvedValueOnce(
+        createFetchResponse({
+          id: 3202,
+          body,
+          html_url: `https://github.com/DevwareUK/prs/issues/${issueNumber}#issuecomment-3202`,
+          created_at: "2026-05-13T12:00:00Z",
+          updated_at: "2026-05-13T12:00:00Z",
+          user: {
+            login: "prs-bot",
+            type: "Bot",
+          },
+        })
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    process.env.GH_TOKEN = "";
+    process.env.GITHUB_TOKEN = "";
+    process.env.PATH = "/usr/bin:/bin";
+
+    const { createGitHubRepositoryForge, execFileSync } = await loadGitHubForge({
+      execFileSyncImpl: (command, args) => {
+        if (command === "git" && args[0] === "remote") {
+          return "git@github.com:DevwareUK/prs.git\n";
+        }
+
+        if (command === "/opt/homebrew/bin/gh" && args.join(" ") === "auth token") {
+          return "resolved-gh-token\n";
+        }
+
+        throw new Error(`Unexpected execFileSync call: ${command} ${args.join(" ")}`);
+      },
+      spawnSyncImpl: (command, args) => {
+        if (command === "gh" && args[0] === "--version") {
+          return { status: 1, error: new Error("gh is unavailable on PATH") };
+        }
+
+        if (command === "/usr/bin/gh" && args[0] === "--version") {
+          return { status: 1, error: new Error("gh is unavailable on PATH") };
+        }
+
+        if (command === "/bin/gh" && args[0] === "--version") {
+          return { status: 1, error: new Error("gh is unavailable on PATH") };
+        }
+
+        if (command === "/opt/homebrew/bin/gh" && args[0] === "--version") {
+          return { status: 0 };
+        }
+
+        throw new Error(`Unexpected spawnSync call: ${command} ${args.join(" ")}`);
+      },
+    });
+    const forge = createGitHubRepositoryForge(REPO_ROOT);
+
+    await expect(
+      (forge as any).createAuditComment({ type: "issue", number: issueNumber }, body)
+    ).resolves.toMatchObject({
+      id: 3202,
+      body,
+    });
+
+    expect(execFileSync).toHaveBeenCalledWith(
+      "/opt/homebrew/bin/gh",
+      ["auth", "token"],
+      expect.any(Object)
+    );
+    expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({
+      headers: expect.objectContaining({
+        Authorization: "Bearer resolved-gh-token",
+      }),
+    });
+  });
+
   it("rejects issue audit targets that resolve to pull requests", async () => {
     const issueNumber = 88;
     const fetchMock = vi.fn().mockResolvedValueOnce(

--- a/packages/cli/src/pr-list-tool.test.ts
+++ b/packages/cli/src/pr-list-tool.test.ts
@@ -18,12 +18,14 @@ describe("PR list tool", () => {
 
           return "git@github.com:DevwareUK/prs.git";
         },
+        spawnSyncImpl: () => ({ status: 1, error: new Error("gh unavailable") }),
       })
-    ).resolves.toEqual({
+    ).resolves.toMatchObject({
       status: "blocked",
       reason: "github-auth-required",
-      message:
-        "GitHub authentication is required for `prs tool pr list --actionable --json`.",
+      message: expect.stringContaining(
+        "GitHub authentication is required for `prs tool pr list --actionable --json`."
+      ),
       nextAction:
         "Set GH_TOKEN or GITHUB_TOKEN in the repository environment, or authenticate gh in the shell that runs prs.",
     });

--- a/packages/cli/src/pr-list-tool.ts
+++ b/packages/cli/src/pr-list-tool.ts
@@ -1,8 +1,9 @@
-import { execFileSync, spawnSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import {
   filterActionablePullRequestsForUser,
   type ActionablePullRequest,
 } from "./actionable-github";
+import { formatGitHubAuthDiagnostics, resolveGitHubToken } from "./github-auth";
 
 export type PullRequestListToolResult =
   | {
@@ -32,6 +33,7 @@ type ListPullRequestsToolOptions = {
   fetchImpl?: FetchLike;
   repoRoot: string;
   runCommand?: (command: string, args: string[]) => string;
+  spawnSyncImpl?: (command: string, args: string[]) => { status?: number | null; error?: Error };
 };
 
 function runCommand(command: string, args: string[]): string {
@@ -52,31 +54,6 @@ function parseGitHubRepoFromRemote(remoteUrl: string): { owner: string; repo: st
     owner: match[1],
     repo: match[2],
   };
-}
-
-function canRunGh(): boolean {
-  const result = spawnSync("gh", ["--version"], { stdio: "ignore" });
-  return !result.error && result.status === 0;
-}
-
-function resolveGitHubToken(
-  env: Record<string, string | undefined>,
-  commandRunner: (command: string, args: string[]) => string
-): string | undefined {
-  const envToken = env.GH_TOKEN?.trim() || env.GITHUB_TOKEN?.trim();
-  if (envToken) {
-    return envToken;
-  }
-
-  if (!canRunGh()) {
-    return undefined;
-  }
-
-  try {
-    return commandRunner("gh", ["auth", "token"]).trim() || undefined;
-  } catch {
-    return undefined;
-  }
 }
 
 function createGitHubHeaders(token: string): Record<string, string> {
@@ -162,13 +139,19 @@ export async function listPullRequestsTool(
 ): Promise<PullRequestListToolResult> {
   const env = options.env ?? process.env;
   const commandRunner = options.runCommand ?? runCommand;
-  const token = resolveGitHubToken(env, commandRunner);
+  const tokenResolution = resolveGitHubToken({
+    env,
+    repoRoot: options.repoRoot,
+    runCommand: commandRunner,
+    spawnSync: options.spawnSyncImpl,
+  });
+  const token = tokenResolution.token;
   if (!token) {
     return {
       status: "blocked",
       reason: "github-auth-required",
       message:
-        "GitHub authentication is required for `prs tool pr list --actionable --json`.",
+        `GitHub authentication is required for \`prs tool pr list --actionable --json\`.\n${formatGitHubAuthDiagnostics(tokenResolution.diagnostics)}`,
       nextAction:
         "Set GH_TOKEN or GITHUB_TOKEN in the repository environment, or authenticate gh in the shell that runs prs.",
     };

--- a/packages/contracts/src/repository-config.test.ts
+++ b/packages/contracts/src/repository-config.test.ts
@@ -22,6 +22,22 @@ describe("repository config schema", () => {
     });
   });
 
+  it("accepts an optional GitHub CLI path in forge config", () => {
+    expect(
+      RepositoryConfig.parse({
+        forge: {
+          type: "github",
+          githubCliPath: "/opt/homebrew/bin/gh",
+        },
+      })
+    ).toEqual({
+      forge: {
+        type: "github",
+        githubCliPath: "/opt/homebrew/bin/gh",
+      },
+    });
+  });
+
   it("rejects empty local runtime command segments", () => {
     expect(() =>
       RepositoryConfig.parse({

--- a/packages/contracts/src/repository-config.ts
+++ b/packages/contracts/src/repository-config.ts
@@ -4,6 +4,11 @@ export const RepositoryForgeType = z.enum(["github", "none"]);
 
 export const RepositoryForgeConfig = z.object({
   type: RepositoryForgeType.optional(),
+  githubCliPath: z
+    .string()
+    .trim()
+    .min(1, "forge githubCliPath must be non-empty")
+    .optional(),
 });
 
 export type RepositoryForgeConfigType = z.infer<typeof RepositoryForgeConfig>;
@@ -132,6 +137,7 @@ export const ResolvedRepositoryConfig = z.object({
   buildCommand: RepositoryConfigCommand,
   forge: z.object({
     type: RepositoryForgeType,
+    githubCliPath: z.string().trim().min(1).optional(),
   }),
   localRuntime: RepositoryLocalRuntimeConfig.optional(),
 });

--- a/packages/core/src/repository-config.ts
+++ b/packages/core/src/repository-config.ts
@@ -57,6 +57,9 @@ export function resolveRepositoryConfig(
     buildCommand: parsedConfig.buildCommand ?? [...DEFAULT_REPOSITORY_BUILD_COMMAND],
     forge: {
       type: parsedConfig.forge?.type ?? DEFAULT_REPOSITORY_FORGE_TYPE,
+      ...(parsedConfig.forge?.githubCliPath
+        ? { githubCliPath: parsedConfig.forge.githubCliPath }
+        : {}),
     },
     localRuntime: parsedConfig.localRuntime,
   });


### PR DESCRIPTION
## Summary
- Add a shared GitHub auth resolver for GH_TOKEN/GITHUB_TOKEN, configured gh paths, PATH gh, and common local gh install paths.
- Route GitHub forge/list/audit flows through the resolver and include auth diagnostics when no token can be resolved.
- Add `forge.githubCliPath` config support plus README/setup docs for Codex shells where `/opt/homebrew/bin/gh` is authenticated but not on PATH.

Closes #199

## Verification
- `pnpm exec vitest run packages/contracts/src/repository-config.test.ts packages/cli/src/config.test.ts packages/cli/src/github-auth.test.ts packages/cli/src/issue-list-tool.test.ts packages/cli/src/pr-list-tool.test.ts packages/cli/src/issue-plan-forge.test.ts packages/cli/src/issue-draft-setup.test.ts`
- `pnpm exec vitest run packages/cli/src/issue-run.test.ts --testTimeout=60000`
- `pnpm exec vitest run packages/cli/src/pr-fix-workflows.test.ts packages/cli/src/pr-prepare-review.test.ts --testTimeout=60000`
- `pnpm build`
- `git diff --check`

## Notes
- A full `pnpm exec vitest run --coverage --testTimeout=60000` attempt reached 464/466 passing tests but two long workflow tests timed out at their 20s per-test ceiling under full-suite coverage concurrency. Those same two workflow files pass directly with the longer timeout above.

<!-- prs:pr-assistant:start -->
## PR Assistant

### Summary
This pull request introduces a shared GitHub authentication resolver that supports both environment tokens (GH_TOKEN/GITHUB_TOKEN) and a configurable GitHub CLI path (githubCliPath). It enhances the GitHub-related workflows by routing authentication through this resolver, providing diagnostics when no token can be resolved, and updating documentation accordingly.

### Risk areas
None noted.

### Files changed
- README.md
- actions/pr-assistant/dist/index.js
- actions/pr-review/dist/index.js
- actions/test-suggestions/dist/index.js
- docs/setup-configuration.md
- packages/cli/src/config.test.ts
- packages/cli/src/github-auth.test.ts
- packages/cli/src/github-auth.ts
- packages/cli/src/github.ts
- packages/cli/src/index-test-support.ts
- packages/cli/src/issue-list-tool.test.ts
- packages/cli/src/issue-list-tool.ts
- packages/cli/src/issue-plan-forge.test.ts
- packages/cli/src/pr-list-tool.test.ts
- packages/cli/src/pr-list-tool.ts
- packages/contracts/src/repository-config.test.ts
- packages/contracts/src/repository-config.ts
- packages/core/src/repository-config.ts

### Testing notes
- All relevant tests were executed successfully, with a near-complete pass rate. Two long-running tests timed out but passed when given extended time.

### Rollout concerns
None noted.

### Reviewer checklist
- Verify that the new GitHub CLI path configuration is correctly implemented in the repository config.
- Check that the authentication resolver correctly prioritizes tokens and CLI paths as intended.
- Ensure that the README and setup documentation accurately reflect the new configuration options.
<!-- prs:pr-assistant:end -->