### PR TITLE
Estimate implementation token usage from issue plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Advanced commands:
 - `prs issue draft --draft-file <path> [--media-manifest <path>]`
 - `prs issue refine <number>`
 - `prs issue plan <number> [--refresh]`
+- `prs issue estimate <number>`
 - `prs issue <number>`
 - `prs issue prepare <number>`
 - `prs issue finalize <number>`
@@ -138,6 +139,7 @@ Supporting commands:
 - `prs audit publish (--issue <number>|--pr <number>) --file <path> --section <name> [--local-run <path>] [--media-manifest <path>]`
 - `prs tool issue list [--actionable] --json`
 - `prs tool issue ready <issue-number> [--unattended|--auto|--jdi] --json`
+- `prs tool issue estimate <issue-number> --json`
 - `prs tool issue create (--draft-file <path>|--issue-set <path>) --json [--media-manifest <path>]`
 - `prs tool pr list [--actionable] --json`
 - `prs tool pr ready <pr-number> [--unattended|--auto|--jdi] --json`
@@ -157,6 +159,8 @@ The old `prs codex ...` nested launcher group has been retired. To start an agen
 `prs issue draft --draft-file <path> --media-manifest <path>`, `prs tool issue create --draft-file <path> --media-manifest <path> --json`, and `prs audit publish ... --media-manifest <path>` attach visual evidence metadata to GitHub-facing Markdown. The manifest may be a JSON array or `{ "media": [...] }`; each item must provide exactly one of `url` or `path`, may set `kind` to `image` or `video`, and may include `caption` and `alt`. Supported local/URL extensions are `png`, `jpg`, `jpeg`, `gif`, `webp`, `mp4`, `mov`, and `webm`; local images are limited to 25 MB and local videos to 100 MB. URL images are embedded, URL videos are linked, and tracked repository image/video paths are rendered as raw GitHub URLs for the current branch. Local files that are not tracked in git are validated but omitted from GitHub-facing Markdown until a configured external storage backend exists.
 
 `prs tool issue ready <issue-number> [--unattended|--auto|--jdi] --json` reports the current managed issue-refinement artifact status without blocking implementation. It recognizes managed `<!-- prs:issue-spec -->` and `<!-- prs:issue-plan -->` markers whether they appear in direct managed comments or inside `prs audit publish` comments. If the specification or plan comment is missing, the JSON result is still `status: "ready"` and notes that missing managed refinement artifacts will be generated and published during issue preparation. When `prs issue <number>` or `prs issue prepare <number>` needs to create a missing managed plan before implementation, it also publishes a managed `<!-- prs:issue-spec -->` comment from the available issue context.
+
+`prs issue estimate <issue-number>` estimates the implementation token budget for working through the issue's managed `<!-- prs:issue-plan -->` comment. It reads the plan, scans bounded repository context such as likely files and configured verification commands, compares the configured AI profiles, and prints token ranges, confidence, drivers, warnings, and a recommendation. `prs tool issue estimate <issue-number> --json` returns the same estimate as structured JSON for Codex skills and automation. The estimate is a forecast, not exact usage accounting, and stops with lower confidence instead of expanding beyond its bounded scan.
 
 Codex-first issue completion never uses the configured text provider for finalization. `prs issue finalize <number>`, local `prs issue <number>`, and unattended `prs issue <number> --jdi` let Codex do the repository work, then use deterministic local commit and PR text for the CLI-owned final step.
 

--- a/actions/pr-assistant/dist/index.js
+++ b/actions/pr-assistant/dist/index.js
@@ -16782,6 +16782,8 @@ var require_dist2 = __commonJS({
       buildGitHubPRReviewComments: () => buildGitHubPRReviewComments,
       buildPRAssistantSection: () => buildPRAssistantSection2,
       createRepositoryPathMatcher: () => createRepositoryPathMatcher,
+      estimateIssueImplementationTokens: () => estimateIssueImplementationTokens,
+      extractIssueImplementationPlanFiles: () => extractIssueImplementationPlanFiles,
       filterRepositoryPaths: () => filterRepositoryPaths,
       formatPRImpactProfileMarkdown: () => formatPRImpactProfileMarkdown2,
       formatPRReviewInlineCommentBody: () => formatPRReviewInlineCommentBody,
@@ -17782,6 +17784,182 @@ ${formatValidationIssues(validationIssues)}`,
         normalizeParsedJson: (value) => normalizeNullableFields(value, ["openQuestions"])
       });
       return normalizeIssueResolutionPlanOutput(modelOutput);
+    }
+    var MANAGED_MARKER_PATTERN = /^<!--\s*prs:issue-plan\s*-->\s*$/i;
+    var RISK_TERMS = [
+      "auth",
+      "cache",
+      "command",
+      "concurrency",
+      "contract",
+      "generated",
+      "migration",
+      "network",
+      "runtime",
+      "schema",
+      "workflow"
+    ];
+    function normalizePlanPath(value) {
+      const trimmed = value.trim().replace(/^`|`$/g, "").replace(/^\.\//, "");
+      if (!trimmed || trimmed.includes("\n")) {
+        return void 0;
+      }
+      if (!/[/\\]/.test(trimmed) && !/\.[a-z0-9]+$/i.test(trimmed)) {
+        return void 0;
+      }
+      return trimmed.replace(/\\/g, "/");
+    }
+    function stripManagedMarker(planBody) {
+      return planBody.split(/\r?\n/).filter((line) => !MANAGED_MARKER_PATTERN.test(line.trim())).join("\n").trim();
+    }
+    function extractIssueImplementationPlanFiles(planBody) {
+      const lines = stripManagedMarker(planBody).split(/\r?\n/);
+      const start = lines.findIndex(
+        (line) => /^#{2,3}\s+Likely files\s*$/i.test(line.trim())
+      );
+      if (start === -1) {
+        return [];
+      }
+      const files = [];
+      for (const line of lines.slice(start + 1)) {
+        if (/^#{2,3}\s+/.test(line.trim())) {
+          break;
+        }
+        const match = line.match(/^\s*[-*]\s+(.+?)\s*$/);
+        if (!match) {
+          continue;
+        }
+        const path = normalizePlanPath(match[1] ?? "");
+        if (path) {
+          files.push(path);
+        }
+      }
+      return [...new Set(files)];
+    }
+    function countImplementationSteps(planBody) {
+      const lines = stripManagedMarker(planBody).split(/\r?\n/);
+      const numberedSteps = lines.filter((line) => /^\s*\d+\.\s+\S/.test(line)).length;
+      if (numberedSteps > 0) {
+        return numberedSteps;
+      }
+      const stepsStart = lines.findIndex(
+        (line) => /^#{2,3}\s+(Steps|Implementation steps|Plan)\s*$/i.test(line.trim())
+      );
+      if (stepsStart === -1) {
+        return 0;
+      }
+      return lines.slice(stepsStart + 1).filter((line) => /^\s*[-*]\s+\S/.test(line)).length;
+    }
+    function countRiskTerms(planBody) {
+      const normalized = planBody.toLowerCase();
+      return RISK_TERMS.filter((term) => normalized.includes(term)).length;
+    }
+    function roundToThousand(value) {
+      return Math.max(1e3, Math.round(value / 1e3) * 1e3);
+    }
+    function pluralize(count, singular, plural = `${singular}s`) {
+      return `${count} ${count === 1 ? singular : plural}`;
+    }
+    function profileMultiplier(profile) {
+      const model = profile.model.toLowerCase();
+      let multiplier = 1;
+      if (model.includes("mini")) {
+        multiplier += 0.35;
+      }
+      if (model.includes("spark")) {
+        multiplier += 0.45;
+      }
+      if (profile.thinking === "none" || profile.thinking === "minimal") {
+        multiplier -= 0.08;
+      }
+      if (profile.thinking === "high" || profile.thinking === "xhigh") {
+        multiplier += 0.08;
+      }
+      return Math.max(0.8, multiplier);
+    }
+    function confidenceFor(input) {
+      if (input.scanExhausted || input.stepCount === 0 || input.likelyFiles.length === 0 || input.missingFiles > 3) {
+        return "low";
+      }
+      if (input.riskTermCount > 4 || input.missingFiles > 0) {
+        return "medium";
+      }
+      return "high";
+    }
+    function estimateIssueImplementationTokens(input) {
+      const planBody = stripManagedMarker(input.planBody);
+      const likelyFilesFromPlan = extractIssueImplementationPlanFiles(input.planBody);
+      const fileContext = input.context?.likelyFiles ?? [];
+      const likelyFiles = fileContext.length > 0 ? fileContext.map((file) => file.path) : likelyFilesFromPlan;
+      const stepCount = countImplementationSteps(planBody);
+      const riskTermCount = countRiskTerms(planBody);
+      const missingFiles = fileContext.filter((file) => !file.exists).length;
+      const largeFiles = fileContext.filter((file) => file.lineCount > 1e3).length;
+      const verificationCommandCount = input.context?.verificationCommands?.length ?? 0;
+      const scanBudget = input.context?.scanBudget ?? {
+        filesConsidered: likelyFiles.length,
+        filesScanned: fileContext.filter((file) => file.exists).length,
+        maxFiles: Math.max(likelyFiles.length, fileContext.length),
+        exhausted: false
+      };
+      const confidence = confidenceFor({
+        likelyFiles,
+        missingFiles,
+        stepCount,
+        riskTermCount,
+        scanExhausted: scanBudget.exhausted
+      });
+      const planTokens = Math.ceil(planBody.length / 4);
+      const baseTokens = planTokens + Math.max(stepCount, 1) * 2500 + Math.max(likelyFiles.length, 1) * 900 + largeFiles * 2500 + missingFiles * 700 + riskTermCount * 1200 + Math.max(verificationCommandCount, 1) * 1800;
+      const profiles = input.profiles.map((profile) => {
+        const multiplier = profileMultiplier(profile);
+        const range2 = {
+          low: roundToThousand(baseTokens * multiplier * 0.75),
+          high: roundToThousand(baseTokens * multiplier * (confidence === "low" ? 1.75 : 1.35))
+        };
+        const notes = [
+          profile.name === input.implementerProfileName ? "Configured implementer profile." : "Comparison profile.",
+          profile.model.toLowerCase().includes("mini") ? "Mini-class models may spend more turns on implementation/debug loops." : "Premium-class model estimate assumes fewer implementation/debug loops."
+        ];
+        return {
+          ...profile,
+          range: range2,
+          confidence,
+          notes
+        };
+      });
+      const implementerProfile = profiles.find(
+        (profile) => profile.name === input.implementerProfileName
+      );
+      const recommendation = implementerProfile ? `Start with ${implementerProfile.name} (${implementerProfile.model}) unless the estimate drivers point to high-risk runtime, workflow, or command-surface work.` : "Use the configured implementer profile unless the estimate drivers point to high-risk runtime, workflow, or command-surface work.";
+      const drivers = [
+        `${stepCount || "No explicit"} implementation steps detected.`,
+        `${likelyFiles.length} likely files detected.`,
+        `${verificationCommandCount || 1} verification command group${(verificationCommandCount || 1) === 1 ? "" : "s"} considered.`,
+        ...largeFiles > 0 ? [`${pluralize(largeFiles, "large likely file")}.`] : [],
+        ...riskTermCount > 0 ? [`${pluralize(riskTermCount, "risk signal")} in the plan.`] : []
+      ];
+      const warnings = [
+        ...missingFiles > 0 ? [
+          `${pluralize(missingFiles, "likely file")} ${missingFiles === 1 ? "was" : "were"} not found locally.`
+        ] : [],
+        ...scanBudget.exhausted ? ["Repository context scan budget was exhausted; estimate confidence is reduced."] : [],
+        ...confidence === "low" ? ["Estimate confidence is low; refine or split the plan before relying on the range."] : []
+      ];
+      return {
+        status: "estimated",
+        profiles,
+        drivers,
+        warnings,
+        recommendation,
+        confidence,
+        scanBudget: {
+          status: scanBudget.exhausted ? "exhausted" : "complete",
+          filesConsidered: scanBudget.filesConsidered,
+          filesScanned: scanBudget.filesScanned,
+          maxFiles: scanBudget.maxFiles
+        }
+      };
     }
     var import_contracts8 = require_dist();
     var import_zod = require_zod();

--- a/actions/pr-review/dist/index.js
+++ b/actions/pr-review/dist/index.js
@@ -16782,6 +16782,8 @@ var require_dist2 = __commonJS({
       buildGitHubPRReviewComments: () => buildGitHubPRReviewComments,
       buildPRAssistantSection: () => buildPRAssistantSection,
       createRepositoryPathMatcher: () => createRepositoryPathMatcher,
+      estimateIssueImplementationTokens: () => estimateIssueImplementationTokens,
+      extractIssueImplementationPlanFiles: () => extractIssueImplementationPlanFiles,
       filterRepositoryPaths: () => filterRepositoryPaths,
       formatPRImpactProfileMarkdown: () => formatPRImpactProfileMarkdown,
       formatPRReviewInlineCommentBody: () => formatPRReviewInlineCommentBody,
@@ -17782,6 +17784,182 @@ ${formatValidationIssues(validationIssues)}`,
         normalizeParsedJson: (value) => normalizeNullableFields(value, ["openQuestions"])
       });
       return normalizeIssueResolutionPlanOutput(modelOutput);
+    }
+    var MANAGED_MARKER_PATTERN = /^<!--\s*prs:issue-plan\s*-->\s*$/i;
+    var RISK_TERMS = [
+      "auth",
+      "cache",
+      "command",
+      "concurrency",
+      "contract",
+      "generated",
+      "migration",
+      "network",
+      "runtime",
+      "schema",
+      "workflow"
+    ];
+    function normalizePlanPath(value) {
+      const trimmed = value.trim().replace(/^`|`$/g, "").replace(/^\.\//, "");
+      if (!trimmed || trimmed.includes("\n")) {
+        return void 0;
+      }
+      if (!/[/\\]/.test(trimmed) && !/\.[a-z0-9]+$/i.test(trimmed)) {
+        return void 0;
+      }
+      return trimmed.replace(/\\/g, "/");
+    }
+    function stripManagedMarker(planBody) {
+      return planBody.split(/\r?\n/).filter((line) => !MANAGED_MARKER_PATTERN.test(line.trim())).join("\n").trim();
+    }
+    function extractIssueImplementationPlanFiles(planBody) {
+      const lines = stripManagedMarker(planBody).split(/\r?\n/);
+      const start = lines.findIndex(
+        (line) => /^#{2,3}\s+Likely files\s*$/i.test(line.trim())
+      );
+      if (start === -1) {
+        return [];
+      }
+      const files = [];
+      for (const line of lines.slice(start + 1)) {
+        if (/^#{2,3}\s+/.test(line.trim())) {
+          break;
+        }
+        const match = line.match(/^\s*[-*]\s+(.+?)\s*$/);
+        if (!match) {
+          continue;
+        }
+        const path = normalizePlanPath(match[1] ?? "");
+        if (path) {
+          files.push(path);
+        }
+      }
+      return [...new Set(files)];
+    }
+    function countImplementationSteps(planBody) {
+      const lines = stripManagedMarker(planBody).split(/\r?\n/);
+      const numberedSteps = lines.filter((line) => /^\s*\d+\.\s+\S/.test(line)).length;
+      if (numberedSteps > 0) {
+        return numberedSteps;
+      }
+      const stepsStart = lines.findIndex(
+        (line) => /^#{2,3}\s+(Steps|Implementation steps|Plan)\s*$/i.test(line.trim())
+      );
+      if (stepsStart === -1) {
+        return 0;
+      }
+      return lines.slice(stepsStart + 1).filter((line) => /^\s*[-*]\s+\S/.test(line)).length;
+    }
+    function countRiskTerms(planBody) {
+      const normalized = planBody.toLowerCase();
+      return RISK_TERMS.filter((term) => normalized.includes(term)).length;
+    }
+    function roundToThousand(value) {
+      return Math.max(1e3, Math.round(value / 1e3) * 1e3);
+    }
+    function pluralize(count, singular, plural = `${singular}s`) {
+      return `${count} ${count === 1 ? singular : plural}`;
+    }
+    function profileMultiplier(profile) {
+      const model = profile.model.toLowerCase();
+      let multiplier = 1;
+      if (model.includes("mini")) {
+        multiplier += 0.35;
+      }
+      if (model.includes("spark")) {
+        multiplier += 0.45;
+      }
+      if (profile.thinking === "none" || profile.thinking === "minimal") {
+        multiplier -= 0.08;
+      }
+      if (profile.thinking === "high" || profile.thinking === "xhigh") {
+        multiplier += 0.08;
+      }
+      return Math.max(0.8, multiplier);
+    }
+    function confidenceFor(input) {
+      if (input.scanExhausted || input.stepCount === 0 || input.likelyFiles.length === 0 || input.missingFiles > 3) {
+        return "low";
+      }
+      if (input.riskTermCount > 4 || input.missingFiles > 0) {
+        return "medium";
+      }
+      return "high";
+    }
+    function estimateIssueImplementationTokens(input) {
+      const planBody = stripManagedMarker(input.planBody);
+      const likelyFilesFromPlan = extractIssueImplementationPlanFiles(input.planBody);
+      const fileContext = input.context?.likelyFiles ?? [];
+      const likelyFiles = fileContext.length > 0 ? fileContext.map((file) => file.path) : likelyFilesFromPlan;
+      const stepCount = countImplementationSteps(planBody);
+      const riskTermCount = countRiskTerms(planBody);
+      const missingFiles = fileContext.filter((file) => !file.exists).length;
+      const largeFiles = fileContext.filter((file) => file.lineCount > 1e3).length;
+      const verificationCommandCount = input.context?.verificationCommands?.length ?? 0;
+      const scanBudget = input.context?.scanBudget ?? {
+        filesConsidered: likelyFiles.length,
+        filesScanned: fileContext.filter((file) => file.exists).length,
+        maxFiles: Math.max(likelyFiles.length, fileContext.length),
+        exhausted: false
+      };
+      const confidence = confidenceFor({
+        likelyFiles,
+        missingFiles,
+        stepCount,
+        riskTermCount,
+        scanExhausted: scanBudget.exhausted
+      });
+      const planTokens = Math.ceil(planBody.length / 4);
+      const baseTokens = planTokens + Math.max(stepCount, 1) * 2500 + Math.max(likelyFiles.length, 1) * 900 + largeFiles * 2500 + missingFiles * 700 + riskTermCount * 1200 + Math.max(verificationCommandCount, 1) * 1800;
+      const profiles = input.profiles.map((profile) => {
+        const multiplier = profileMultiplier(profile);
+        const range2 = {
+          low: roundToThousand(baseTokens * multiplier * 0.75),
+          high: roundToThousand(baseTokens * multiplier * (confidence === "low" ? 1.75 : 1.35))
+        };
+        const notes = [
+          profile.name === input.implementerProfileName ? "Configured implementer profile." : "Comparison profile.",
+          profile.model.toLowerCase().includes("mini") ? "Mini-class models may spend more turns on implementation/debug loops." : "Premium-class model estimate assumes fewer implementation/debug loops."
+        ];
+        return {
+          ...profile,
+          range: range2,
+          confidence,
+          notes
+        };
+      });
+      const implementerProfile = profiles.find(
+        (profile) => profile.name === input.implementerProfileName
+      );
+      const recommendation = implementerProfile ? `Start with ${implementerProfile.name} (${implementerProfile.model}) unless the estimate drivers point to high-risk runtime, workflow, or command-surface work.` : "Use the configured implementer profile unless the estimate drivers point to high-risk runtime, workflow, or command-surface work.";
+      const drivers = [
+        `${stepCount || "No explicit"} implementation steps detected.`,
+        `${likelyFiles.length} likely files detected.`,
+        `${verificationCommandCount || 1} verification command group${(verificationCommandCount || 1) === 1 ? "" : "s"} considered.`,
+        ...largeFiles > 0 ? [`${pluralize(largeFiles, "large likely file")}.`] : [],
+        ...riskTermCount > 0 ? [`${pluralize(riskTermCount, "risk signal")} in the plan.`] : []
+      ];
+      const warnings = [
+        ...missingFiles > 0 ? [
+          `${pluralize(missingFiles, "likely file")} ${missingFiles === 1 ? "was" : "were"} not found locally.`
+        ] : [],
+        ...scanBudget.exhausted ? ["Repository context scan budget was exhausted; estimate confidence is reduced."] : [],
+        ...confidence === "low" ? ["Estimate confidence is low; refine or split the plan before relying on the range."] : []
+      ];
+      return {
+        status: "estimated",
+        profiles,
+        drivers,
+        warnings,
+        recommendation,
+        confidence,
+        scanBudget: {
+          status: scanBudget.exhausted ? "exhausted" : "complete",
+          filesConsidered: scanBudget.filesConsidered,
+          filesScanned: scanBudget.filesScanned,
+          maxFiles: scanBudget.maxFiles
+        }
+      };
     }
     var import_contracts8 = require_dist();
     var import_zod = require_zod();

--- a/actions/test-suggestions/dist/index.js
+++ b/actions/test-suggestions/dist/index.js
@@ -16782,6 +16782,8 @@ var require_dist2 = __commonJS({
       buildGitHubPRReviewComments: () => buildGitHubPRReviewComments,
       buildPRAssistantSection: () => buildPRAssistantSection,
       createRepositoryPathMatcher: () => createRepositoryPathMatcher,
+      estimateIssueImplementationTokens: () => estimateIssueImplementationTokens,
+      extractIssueImplementationPlanFiles: () => extractIssueImplementationPlanFiles,
       filterRepositoryPaths: () => filterRepositoryPaths,
       formatPRImpactProfileMarkdown: () => formatPRImpactProfileMarkdown,
       formatPRReviewInlineCommentBody: () => formatPRReviewInlineCommentBody,
@@ -17782,6 +17784,182 @@ ${formatValidationIssues(validationIssues)}`,
         normalizeParsedJson: (value) => normalizeNullableFields(value, ["openQuestions"])
       });
       return normalizeIssueResolutionPlanOutput(modelOutput);
+    }
+    var MANAGED_MARKER_PATTERN = /^<!--\s*prs:issue-plan\s*-->\s*$/i;
+    var RISK_TERMS = [
+      "auth",
+      "cache",
+      "command",
+      "concurrency",
+      "contract",
+      "generated",
+      "migration",
+      "network",
+      "runtime",
+      "schema",
+      "workflow"
+    ];
+    function normalizePlanPath(value) {
+      const trimmed = value.trim().replace(/^`|`$/g, "").replace(/^\.\//, "");
+      if (!trimmed || trimmed.includes("\n")) {
+        return void 0;
+      }
+      if (!/[/\\]/.test(trimmed) && !/\.[a-z0-9]+$/i.test(trimmed)) {
+        return void 0;
+      }
+      return trimmed.replace(/\\/g, "/");
+    }
+    function stripManagedMarker(planBody) {
+      return planBody.split(/\r?\n/).filter((line) => !MANAGED_MARKER_PATTERN.test(line.trim())).join("\n").trim();
+    }
+    function extractIssueImplementationPlanFiles(planBody) {
+      const lines = stripManagedMarker(planBody).split(/\r?\n/);
+      const start = lines.findIndex(
+        (line) => /^#{2,3}\s+Likely files\s*$/i.test(line.trim())
+      );
+      if (start === -1) {
+        return [];
+      }
+      const files = [];
+      for (const line of lines.slice(start + 1)) {
+        if (/^#{2,3}\s+/.test(line.trim())) {
+          break;
+        }
+        const match = line.match(/^\s*[-*]\s+(.+?)\s*$/);
+        if (!match) {
+          continue;
+        }
+        const path = normalizePlanPath(match[1] ?? "");
+        if (path) {
+          files.push(path);
+        }
+      }
+      return [...new Set(files)];
+    }
+    function countImplementationSteps(planBody) {
+      const lines = stripManagedMarker(planBody).split(/\r?\n/);
+      const numberedSteps = lines.filter((line) => /^\s*\d+\.\s+\S/.test(line)).length;
+      if (numberedSteps > 0) {
+        return numberedSteps;
+      }
+      const stepsStart = lines.findIndex(
+        (line) => /^#{2,3}\s+(Steps|Implementation steps|Plan)\s*$/i.test(line.trim())
+      );
+      if (stepsStart === -1) {
+        return 0;
+      }
+      return lines.slice(stepsStart + 1).filter((line) => /^\s*[-*]\s+\S/.test(line)).length;
+    }
+    function countRiskTerms(planBody) {
+      const normalized = planBody.toLowerCase();
+      return RISK_TERMS.filter((term) => normalized.includes(term)).length;
+    }
+    function roundToThousand(value) {
+      return Math.max(1e3, Math.round(value / 1e3) * 1e3);
+    }
+    function pluralize(count, singular, plural = `${singular}s`) {
+      return `${count} ${count === 1 ? singular : plural}`;
+    }
+    function profileMultiplier(profile) {
+      const model = profile.model.toLowerCase();
+      let multiplier = 1;
+      if (model.includes("mini")) {
+        multiplier += 0.35;
+      }
+      if (model.includes("spark")) {
+        multiplier += 0.45;
+      }
+      if (profile.thinking === "none" || profile.thinking === "minimal") {
+        multiplier -= 0.08;
+      }
+      if (profile.thinking === "high" || profile.thinking === "xhigh") {
+        multiplier += 0.08;
+      }
+      return Math.max(0.8, multiplier);
+    }
+    function confidenceFor(input) {
+      if (input.scanExhausted || input.stepCount === 0 || input.likelyFiles.length === 0 || input.missingFiles > 3) {
+        return "low";
+      }
+      if (input.riskTermCount > 4 || input.missingFiles > 0) {
+        return "medium";
+      }
+      return "high";
+    }
+    function estimateIssueImplementationTokens(input) {
+      const planBody = stripManagedMarker(input.planBody);
+      const likelyFilesFromPlan = extractIssueImplementationPlanFiles(input.planBody);
+      const fileContext = input.context?.likelyFiles ?? [];
+      const likelyFiles = fileContext.length > 0 ? fileContext.map((file) => file.path) : likelyFilesFromPlan;
+      const stepCount = countImplementationSteps(planBody);
+      const riskTermCount = countRiskTerms(planBody);
+      const missingFiles = fileContext.filter((file) => !file.exists).length;
+      const largeFiles = fileContext.filter((file) => file.lineCount > 1e3).length;
+      const verificationCommandCount = input.context?.verificationCommands?.length ?? 0;
+      const scanBudget = input.context?.scanBudget ?? {
+        filesConsidered: likelyFiles.length,
+        filesScanned: fileContext.filter((file) => file.exists).length,
+        maxFiles: Math.max(likelyFiles.length, fileContext.length),
+        exhausted: false
+      };
+      const confidence = confidenceFor({
+        likelyFiles,
+        missingFiles,
+        stepCount,
+        riskTermCount,
+        scanExhausted: scanBudget.exhausted
+      });
+      const planTokens = Math.ceil(planBody.length / 4);
+      const baseTokens = planTokens + Math.max(stepCount, 1) * 2500 + Math.max(likelyFiles.length, 1) * 900 + largeFiles * 2500 + missingFiles * 700 + riskTermCount * 1200 + Math.max(verificationCommandCount, 1) * 1800;
+      const profiles = input.profiles.map((profile) => {
+        const multiplier = profileMultiplier(profile);
+        const range2 = {
+          low: roundToThousand(baseTokens * multiplier * 0.75),
+          high: roundToThousand(baseTokens * multiplier * (confidence === "low" ? 1.75 : 1.35))
+        };
+        const notes = [
+          profile.name === input.implementerProfileName ? "Configured implementer profile." : "Comparison profile.",
+          profile.model.toLowerCase().includes("mini") ? "Mini-class models may spend more turns on implementation/debug loops." : "Premium-class model estimate assumes fewer implementation/debug loops."
+        ];
+        return {
+          ...profile,
+          range: range2,
+          confidence,
+          notes
+        };
+      });
+      const implementerProfile = profiles.find(
+        (profile) => profile.name === input.implementerProfileName
+      );
+      const recommendation = implementerProfile ? `Start with ${implementerProfile.name} (${implementerProfile.model}) unless the estimate drivers point to high-risk runtime, workflow, or command-surface work.` : "Use the configured implementer profile unless the estimate drivers point to high-risk runtime, workflow, or command-surface work.";
+      const drivers = [
+        `${stepCount || "No explicit"} implementation steps detected.`,
+        `${likelyFiles.length} likely files detected.`,
+        `${verificationCommandCount || 1} verification command group${(verificationCommandCount || 1) === 1 ? "" : "s"} considered.`,
+        ...largeFiles > 0 ? [`${pluralize(largeFiles, "large likely file")}.`] : [],
+        ...riskTermCount > 0 ? [`${pluralize(riskTermCount, "risk signal")} in the plan.`] : []
+      ];
+      const warnings = [
+        ...missingFiles > 0 ? [
+          `${pluralize(missingFiles, "likely file")} ${missingFiles === 1 ? "was" : "were"} not found locally.`
+        ] : [],
+        ...scanBudget.exhausted ? ["Repository context scan budget was exhausted; estimate confidence is reduced."] : [],
+        ...confidence === "low" ? ["Estimate confidence is low; refine or split the plan before relying on the range."] : []
+      ];
+      return {
+        status: "estimated",
+        profiles,
+        drivers,
+        warnings,
+        recommendation,
+        confidence,
+        scanBudget: {
+          status: scanBudget.exhausted ? "exhausted" : "complete",
+          filesConsidered: scanBudget.filesConsidered,
+          filesScanned: scanBudget.filesScanned,
+          maxFiles: scanBudget.maxFiles
+        }
+      };
     }
     var import_contracts8 = require_dist();
     var import_zod = require_zod();

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -18,6 +18,7 @@ Advanced commands:
 - `prs issue draft --draft-file <path> [--media-manifest <path>]`: ingest a skill-produced issue draft without launching another runtime
 - `prs issue refine <number>`: refine an existing GitHub issue into an implementation-ready specification
 - `prs issue plan <number> [--refresh]`: maintain an issue-resolution plan comment as secondary execution support
+- `prs issue estimate <number>`: estimate the implementation token budget for executing an issue plan
 - `prs issue <number>`: run the full local issue-to-PR workflow
 - `prs issue prepare <number>` and `prs issue finalize <number>`: split issue setup from local completion
 
@@ -34,6 +35,7 @@ Supporting commands:
 - `prs setup --update-skills`: refresh only managed Codex `/prs` skills
 - `prs update skills`: refresh managed Codex `/prs` skills after upgrading the CLI
 - `prs tool issue list [--actionable] --json`: list open GitHub issues, optionally filtered to actionable-for-me issues; returned items include number, title, URL, ownership, labels, update time, linked-PR status, and PRS plan status; PRS plan status recognizes direct managed plan comments and audit comments containing `<!-- prs:issue-plan -->`
+- `prs tool issue estimate <issue-number> --json`: return a structured implementation token estimate for the issue's managed plan comment
 - `prs tool issue create (--draft-file <path>|--issue-set <path>) --json [--media-manifest <path>]`: deterministically create GitHub issues from approved local issue draft artifacts
 - `prs tool pr list [--actionable] --json`: list open GitHub pull requests, optionally filtered to actionable-for-me PRs; returned items include number, title, URL, ownership, branch, labels, update time, and action signals such as conflicts
 - `prs tool pr ready <pr-number> [--unattended|--auto|--jdi] --json`: local PR readiness for `/prs:pr`; checks out the actual PR head branch, fetches and merges the latest PR base branch, runs configured `prReadiness.commands`, reports local step results in `localReadiness`, reports GitHub-hosted review signals in `prContext`, includes grouped PR comment summaries with source links when comments are available, reports actionable/handled/duplicate/resolved/outdated review-thread counts, and skips broad local verification beyond explicit readiness commands
@@ -128,6 +130,7 @@ prs issue draft --issue-set-file <path> [--rough-idea <text>|--rough-idea-file <
 prs issue draft --runtime
 prs issue refine <number>
 prs issue plan <number> [--refresh]
+prs issue estimate <number>
 prs issue prepare <number> [--mode <local|github-action>]
 prs issue finalize <number>
 ```
@@ -145,6 +148,7 @@ Available subcommands:
 | `prs issue draft --runtime` | Explicit legacy interactive issue drafting flow. Prompts for a rough idea, creates `.prs/` draft-run artifacts, prints that a separate AI session is being opened with only prompt-file context, launches the configured runtime, and then follows the same preview/create flow after the runtime writes a draft or issue set. Prefer `/prs create` plus `--draft-file` or `--issue-set-file` when operating from an existing Codex thread. |
 | `prs issue refine <number>` | Interactive existing-issue refinement flow. Fetches the current issue body plus comments, resumes the saved runtime session when that session is still tracked locally, otherwise asks whether to specify changes to the original requirements, defaults to no, only asks for change text when you answer yes, and starts a fresh refinement run, writes resumable state to `.prs/issues/<number>/refine-session.json` plus run artifacts to `.prs/runs/<timestamp>-issue-refine-<number>/`. The runtime may write one refined Markdown draft or a multi-issue set in `.prs/runs/<timestamp>-issue-refine-<number>/issue-set.json`. Single drafts keep the existing behavior: update a PRS-managed source issue or create one linked PRS-managed issue from a non-managed source. Multi-issue refinements are validated and reviewed as a set, then created as PRS-managed linked issues with sibling links and `Source issue: #<number>` entries; the source issue body is not overwritten. If GitHub authentication is unavailable, the refined draft or set is kept on disk instead of being applied. |
 | `prs issue plan <number> [--refresh]` | Secondary issue-execution support. By default it creates the managed implementation plan comment once and safely reuses the latest edited managed comment on later runs. Pass `--refresh` or `--update` to regenerate and update the managed comment when the issue context has changed. When `ai.issue.useCodexSuperpowers` is active, the selected runtime is Codex, and local Codex Superpowers is available, the command launches a plan-only Codex run and publishes the resulting `.prs/runs/<timestamp>-issue-plan-<number>/superpowers-plan.md` as the managed `<!-- prs:issue-plan -->` comment. If Superpowers is disabled, unavailable, or produces no plan artifact, `prs` falls back to the structured provider-generated plan. |
+| `prs issue estimate <number>` | Reads the issue's managed `<!-- prs:issue-plan -->` comment, scans bounded repository context from concrete likely files plus configured verification commands, compares configured AI profiles including the implementer profile, and prints estimated implementation token ranges, confidence, drivers, warnings, and a recommendation. It does not launch a runtime, call a text provider, modify files, or post to GitHub. If no managed plan exists, it asks you to run `prs issue plan <number>` first. |
 | `prs issue prepare <number>` | Preflights the configured forge, verification command, and `baseBranch`, creates a missing managed issue plan comment before writing the runtime snapshot, checks the plan's `### Likely files` against files changed by open pull requests, prompts in interactive terminals when overlap remains, prepares the issue branch from the selected base, and then prints machine-readable JSON describing the run. |
 | `prs issue prepare <number> --mode github-action` | Same preparation flow, including missing-plan creation, but writes prompt instructions tailored for non-interactive GitHub Actions runs. |
 | `prs issue finalize <number>` | Generates a deterministic local proposed commit message from the current repository diff, including included untracked files, lets you preview, edit, or skip it, and creates the commit only after confirmation. It never uses the configured text provider, so it does not require `OPENAI_API_KEY` just to finalize Codex-produced changes. It does not push or open a pull request. |
@@ -153,6 +157,7 @@ Important behavior:
 
 - `prs issue draft --draft-file <path>`, `prs issue draft --issue-set-file <path>`, `prs issue draft --runtime`, `prs issue plan <number> [--refresh]`, `prs issue prepare <number>`, `prs issue finalize <number>`, and full `prs issue <number>` runs print an advanced workflow notice before execution
 - `prs issue <number> <number> ...` and `prs issue batch ...` print a beta workflow notice before execution
+- `prs issue estimate <number>` is read-only and bounded; it estimates implementation effort from the managed plan rather than drafting/refinement effort
 - `prs issue` requires a clean working tree before it starts
 - `prs issue <number>` and `prs issue prepare <number>` fail before checkout if the configured verification command cannot run from the repository root
 - `prs issue <number>` and `prs issue prepare <number>` fail before checkout if the configured base branch is missing locally, missing on `origin`, or cannot be fast-forwarded cleanly
@@ -186,6 +191,7 @@ Important behavior:
 - declining the apply step, or running without usable GitHub authentication, keeps the refined draft on disk and records the refine session as completed without applying it remotely
 - after an approved Superpowers-backed draft or refinement, a non-empty `superpowers-plan.md` creates or updates the managed `<!-- prs:issue-plan -->` issue plan comment; missing or empty plan artifacts are logged and do not block issue creation or refinement
 - `prs issue plan <number> [--refresh]` requires issue access through the configured forge; creating or refreshing a managed plan comment also requires the configured provider plus GitHub authentication
+- `prs tool issue estimate <issue-number> --json` returns the same estimate as structured JSON for active Codex sessions and automation
 - `prs issue finalize <number>` requires local file changes and always uses deterministic local commit text
 - local full issue runs require an available interactive runtime CLI on `PATH`
 - local full issue runs never use the configured provider for commit or PR text during finalization

--- a/docs/codex-prs-workflows.md
+++ b/docs/codex-prs-workflows.md
@@ -76,6 +76,7 @@ When it is enabled and the selected runtime is Codex:
 - `prs issue draft --runtime` can use Codex Superpowers-specific instructions while keeping final drafts under `.prs/issues/` or the current draft run directory.
 - `prs issue refine <number>` can use Superpowers-specific instructions while keeping refined drafts and optional issue sets under `.prs/runs/<timestamp>-issue-refine-<number>/`.
 - `prs issue plan <number> [--refresh]` reserves `superpowers-spec.md` and `superpowers-plan.md` under `.prs/runs/<timestamp>-issue-plan-<number>/` and publishes a non-empty plan artifact to the managed `<!-- prs:issue-plan -->` issue comment.
+- `prs issue estimate <number>` reads the managed `<!-- prs:issue-plan -->` comment, scans bounded repository context, and estimates the implementation token budget for actually working through the plan across configured AI profiles. Use `prs tool issue estimate <number> --json` when an active Codex session needs the same estimate without prose formatting.
 
 Issue plans should include an explicit `.prs/config.json` `prReadiness.commands` update when the work introduces required local checkout setup for future PR testing, such as migrations, config import, generated assets, dependency updates, or cache rebuilds.
 

--- a/packages/cli/src/cli-command-surface.test.ts
+++ b/packages/cli/src/cli-command-surface.test.ts
@@ -83,6 +83,17 @@ describe("CLI command surface", () => {
     });
   });
 
+  it("parses issue estimate as a dedicated issue subcommand", async () => {
+    process.env.PRS_DISABLE_AUTO_RUN = "1";
+    const { parseIssueCommandArgs } = await loadCli();
+
+    expect(parseIssueCommandArgs(["issue", "estimate", "42"])).toEqual({
+      action: "estimate",
+      issueNumber: 42,
+      mode: "local",
+    });
+  });
+
   it("parses issue plan refresh aliases", async () => {
     process.env.PRS_DISABLE_AUTO_RUN = "1";
     const { parseIssueCommandArgs } = await loadCli();

--- a/packages/cli/src/cli-command-surface.test.ts
+++ b/packages/cli/src/cli-command-surface.test.ts
@@ -92,6 +92,9 @@ describe("CLI command surface", () => {
       issueNumber: 42,
       mode: "local",
     });
+    expect(() =>
+      parseIssueCommandArgs(["issue", "estimate", "42", "--refresh"])
+    ).toThrow('Unknown issue option "--refresh"');
   });
 
   it("parses issue plan refresh aliases", async () => {

--- a/packages/cli/src/commands/issue.ts
+++ b/packages/cli/src/commands/issue.ts
@@ -45,6 +45,11 @@ export type IssueCommandOptions =
       mode: "local";
       refresh: boolean;
     }
+  | {
+      action: "estimate";
+      issueNumber: number;
+      mode: "local";
+    }
   | ({
       action: "draft";
     } & IssueDraftCommandOptions)
@@ -63,6 +68,7 @@ const ISSUE_USAGE = [
   "  prs issue draft --runtime",
   "  prs issue refine <number>",
   "  prs issue plan <number> [--refresh]",
+  "  prs issue estimate <number>",
   "  prs issue prepare <number> [--mode <local|github-action>]",
   "  prs issue finalize <number>",
 ].join("\n");
@@ -410,6 +416,19 @@ export function parseIssueCommandArgs(args: string[]): IssueCommandOptions {
       issueNumber: parseIssueNumber(issueArgs[1]),
       mode: "local",
       refresh: parsedOptions.refresh,
+    };
+  }
+
+  if (subcommand === "estimate") {
+    const optionArgs = issueArgs.slice(2);
+    if (optionArgs.length > 0) {
+      throw new Error(`Unknown issue option "${optionArgs[0]}". ${ISSUE_USAGE}`);
+    }
+
+    return {
+      action: "estimate",
+      issueNumber: parseIssueNumber(issueArgs[1]),
+      mode: "local",
     };
   }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -46,6 +46,10 @@ import { publishAuditArtifact } from "./audit-artifacts";
 import { inspectManagedCodexSkills } from "./codex-skills";
 import { buildDoneStateInstructions } from "./done-state";
 import { listIssuesTool } from "./issue-list-tool";
+import {
+  estimateIssueTool,
+  renderIssueEstimate,
+} from "./issue-estimate-tool";
 import { readyIssueTool } from "./issue-ready-tool";
 import {
   formatLaunchStageNotice,
@@ -894,6 +898,8 @@ function resolveLaunchStageNoticeId(args: string[]): LaunchStageNoticeId | undef
         return "issue-draft";
       case "finalize":
         return "issue-finalize";
+      case "estimate":
+        return undefined;
       case "plan":
         return "issue-plan";
       case "prepare":
@@ -4411,6 +4417,17 @@ async function runToolCommand(): Promise<void> {
     return;
   }
 
+  if (toolCommand.kind === "issue-estimate") {
+    const result = await estimateIssueTool({
+      issueNumber: toolCommand.issueNumber,
+      repoRoot,
+      forge: getRepositoryForge(repoRoot),
+      repositoryConfig,
+    });
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return;
+  }
+
   if (toolCommand.kind === "issue-create") {
     const forge = getRepositoryForge(repoRoot);
 
@@ -7245,6 +7262,18 @@ async function runIssueCommand(): Promise<void> {
     await runIssuePlanCommand(issueCommand.issueNumber, {
       refresh: issueCommand.refresh,
     });
+    return;
+  }
+
+  if (issueCommand.action === "estimate") {
+    const repositoryConfig = getRepositoryConfig(repoRoot);
+    const result = await estimateIssueTool({
+      issueNumber: issueCommand.issueNumber,
+      repoRoot,
+      forge: getRepositoryForge(repoRoot),
+      repositoryConfig,
+    });
+    process.stdout.write(`${renderIssueEstimate(result)}\n`);
     return;
   }
 

--- a/packages/cli/src/issue-estimate-tool.test.ts
+++ b/packages/cli/src/issue-estimate-tool.test.ts
@@ -1,0 +1,48 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { resolveRepositoryConfig } from "@prs/core";
+import { estimateIssueTool } from "./issue-estimate-tool";
+
+describe("issue estimate tool", () => {
+  it("uses default comparison profiles when repository config has no explicit profiles", async () => {
+    const repoRoot = mkdtempSync(resolve(tmpdir(), "prs-issue-estimate-"));
+    writeFileSync(resolve(repoRoot, "README.md"), "# Test repository\n", "utf8");
+    const forge = {
+      fetchIssuePlanComment: vi.fn().mockResolvedValue({
+        id: 1,
+        url: "https://github.com/DevwareUK/prs/issues/267#issuecomment-1",
+        updatedAt: "2026-06-11T08:47:44Z",
+        body: [
+          "<!-- prs:issue-plan -->",
+          "## Likely files",
+          "",
+          "- `README.md`",
+          "",
+          "## Steps",
+          "",
+          "1. Update docs.",
+        ].join("\n"),
+      }),
+    };
+
+    const result = await estimateIssueTool({
+      issueNumber: 267,
+      repoRoot,
+      forge,
+      repositoryConfig: resolveRepositoryConfig(),
+    });
+
+    expect(result.status).toBe("estimated");
+    if (result.status === "estimated") {
+      expect(result.profiles.map((profile) => profile.name)).toEqual([
+        "premium",
+        "standard",
+      ]);
+      expect(result.profiles.find((profile) => profile.name === "standard")?.notes).toContain(
+        "Configured implementer profile."
+      );
+    }
+  });
+});

--- a/packages/cli/src/issue-estimate-tool.test.ts
+++ b/packages/cli/src/issue-estimate-tool.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { resolveRepositoryConfig } from "@prs/core";
-import { estimateIssueTool } from "./issue-estimate-tool";
+import { estimateIssueTool, renderIssueEstimate } from "./issue-estimate-tool";
 
 describe("issue estimate tool", () => {
   it("uses default comparison profiles when repository config has no explicit profiles", async () => {
@@ -42,6 +42,79 @@ describe("issue estimate tool", () => {
       ]);
       expect(result.profiles.find((profile) => profile.name === "standard")?.notes).toContain(
         "Configured implementer profile."
+      );
+    }
+  });
+
+  it("returns a blocked JSON-safe result when the issue has no managed plan comment", async () => {
+    const forge = {
+      fetchIssuePlanComment: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const result = await estimateIssueTool({
+      issueNumber: 268,
+      repoRoot: mkdtempSync(resolve(tmpdir(), "prs-issue-estimate-")),
+      forge,
+      repositoryConfig: resolveRepositoryConfig(),
+    });
+
+    expect(result).toEqual({
+      status: "blocked",
+      issueNumber: 268,
+      message:
+        "Issue implementation token estimates require a managed issue plan comment. Run `prs issue plan <number>` first.",
+      nextAction: "create-issue-plan",
+    });
+    expect(renderIssueEstimate(result)).toContain(
+      "Issue #268 implementation estimate is blocked."
+    );
+  });
+
+  it("renders missing-file warnings and exhausted scan budgets for human output", async () => {
+    const repoRoot = mkdtempSync(resolve(tmpdir(), "prs-issue-estimate-"));
+    const forge = {
+      fetchIssuePlanComment: vi.fn().mockResolvedValue({
+        id: 2,
+        url: "https://github.com/DevwareUK/prs/issues/267#issuecomment-2",
+        updatedAt: "2026-06-11T08:47:44Z",
+        body: [
+          "<!-- prs:issue-plan -->",
+          "## Likely files",
+          "",
+          "- `packages/cli/src/missing-01.ts`",
+          "- `packages/cli/src/missing-02.ts`",
+          "- `packages/cli/src/missing-03.ts`",
+          "- `packages/cli/src/missing-04.ts`",
+          "- `packages/cli/src/missing-05.ts`",
+          "- `packages/cli/src/missing-06.ts`",
+          "- `packages/cli/src/missing-07.ts`",
+          "- `packages/cli/src/missing-08.ts`",
+          "- `packages/cli/src/missing-09.ts`",
+          "- `packages/cli/src/missing-10.ts`",
+          "- `packages/cli/src/missing-11.ts`",
+          "- `packages/cli/src/missing-12.ts`",
+          "- `packages/cli/src/missing-13.ts`",
+          "",
+          "## Steps",
+          "",
+          "1. Estimate the work.",
+        ].join("\n"),
+      }),
+    };
+
+    const result = await estimateIssueTool({
+      issueNumber: 267,
+      repoRoot,
+      forge,
+      repositoryConfig: resolveRepositoryConfig(),
+    });
+
+    expect(result.status).toBe("estimated");
+    if (result.status === "estimated") {
+      expect(result.scanBudget.status).toBe("exhausted");
+      expect(result.warnings).toContain("12 likely files were not found locally.");
+      expect(renderIssueEstimate(result)).toContain(
+        "Scan budget: exhausted (0/13 files scanned, max 12)"
       );
     }
   });

--- a/packages/cli/src/issue-estimate-tool.ts
+++ b/packages/cli/src/issue-estimate-tool.ts
@@ -1,0 +1,241 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  estimateIssueImplementationTokens,
+  extractIssueImplementationPlanFiles,
+  filterRepositoryPaths,
+  type IssueEstimateFileContext,
+  type IssueImplementationTokenEstimate,
+} from "@prs/core";
+import type { ResolvedRepositoryConfigType } from "@prs/contracts";
+import type { IssuePlanComment, RepositoryForge } from "./forge";
+
+export type IssueEstimateToolResult =
+  | {
+      status: "blocked";
+      issueNumber: number;
+      message: string;
+      nextAction: "create-issue-plan";
+    }
+  | ({
+      status: "estimated";
+      issueNumber: number;
+      planSource: {
+        type: "managed-comment";
+        url: string;
+        updatedAt: string;
+      };
+    } & IssueImplementationTokenEstimate);
+
+type EstimateIssueToolOptions = {
+  issueNumber: number;
+  repoRoot: string;
+  forge: Pick<RepositoryForge, "fetchIssuePlanComment">;
+  repositoryConfig: ResolvedRepositoryConfigType;
+};
+
+const MAX_CONTEXT_FILES = 12;
+const DEFAULT_ESTIMATE_PROFILES = {
+  premium: {
+    model: "gpt-5.5",
+    thinking: "high" as const,
+  },
+  standard: {
+    model: "gpt-5.4-mini",
+    thinking: "medium" as const,
+  },
+};
+const DEFAULT_ESTIMATE_ROLES = {
+  planner: "premium",
+  implementer: "standard",
+  reviewer: "premium",
+  tester: "standard",
+};
+
+function rolesByProfileName(
+  roles: ResolvedRepositoryConfigType["ai"]["roles"] | undefined
+): Map<string, string[]> {
+  const result = new Map<string, string[]>();
+  for (const [role, profileName] of Object.entries(roles ?? {})) {
+    if (!profileName) {
+      continue;
+    }
+    result.set(profileName, [...(result.get(profileName) ?? []), role]);
+  }
+  return result;
+}
+
+function createEstimateProfiles(config: ResolvedRepositoryConfigType) {
+  const aiConfig = config.ai as ResolvedRepositoryConfigType["ai"] & {
+    profiles?: typeof DEFAULT_ESTIMATE_PROFILES;
+    roles?: typeof DEFAULT_ESTIMATE_ROLES;
+  };
+  const profiles =
+    aiConfig.profiles && Object.keys(aiConfig.profiles).length > 0
+      ? aiConfig.profiles
+      : DEFAULT_ESTIMATE_PROFILES;
+  const roleMap = rolesByProfileName(aiConfig.roles ?? DEFAULT_ESTIMATE_ROLES);
+  return Object.entries(profiles).map(([name, profile]) => ({
+    name,
+    role: roleMap.get(name)?.join(", "),
+    model: profile.model,
+    thinking: profile.thinking,
+  }));
+}
+
+function countLinesWithinBudget(filePath: string): number {
+  const stats = statSync(filePath);
+  if (!stats.isFile()) {
+    return 0;
+  }
+  const contents = readFileSync(filePath, "utf8");
+  return contents.length === 0 ? 0 : contents.split(/\r?\n/).length;
+}
+
+function collectLikelyFileContext(
+  repoRoot: string,
+  planBody: string,
+  excludePaths: readonly string[]
+): {
+  files: IssueEstimateFileContext[];
+  scanBudget: {
+    filesConsidered: number;
+    filesScanned: number;
+    maxFiles: number;
+    exhausted: boolean;
+  };
+} {
+  const likelyFiles = filterRepositoryPaths(
+    extractIssueImplementationPlanFiles(planBody),
+    excludePaths
+  );
+  const selectedFiles = likelyFiles.slice(0, MAX_CONTEXT_FILES);
+  const files = selectedFiles.map((path) => {
+    const absolutePath = resolve(repoRoot, path);
+    const exists = existsSync(absolutePath);
+    return {
+      path,
+      exists,
+      lineCount: exists ? countLinesWithinBudget(absolutePath) : 0,
+    };
+  });
+
+  return {
+    files,
+    scanBudget: {
+      filesConsidered: likelyFiles.length,
+      filesScanned: files.filter((file) => file.exists).length,
+      maxFiles: MAX_CONTEXT_FILES,
+      exhausted: likelyFiles.length > MAX_CONTEXT_FILES,
+    },
+  };
+}
+
+function createVerificationCommands(config: ResolvedRepositoryConfigType): string[][] {
+  return [
+    config.buildCommand,
+    ...config.prReadiness.commands.map((command) => command.command),
+  ];
+}
+
+function createBlockedResult(issueNumber: number): IssueEstimateToolResult {
+  return {
+    status: "blocked",
+    issueNumber,
+    message:
+      "Issue implementation token estimates require a managed issue plan comment. Run `prs issue plan <number>` first.",
+    nextAction: "create-issue-plan",
+  };
+}
+
+function createEstimateResult(
+  issueNumber: number,
+  planComment: IssuePlanComment,
+  config: ResolvedRepositoryConfigType,
+  repoRoot: string
+): IssueEstimateToolResult {
+  const context = collectLikelyFileContext(
+    repoRoot,
+    planComment.body,
+    config.aiContext.excludePaths
+  );
+  const estimate = estimateIssueImplementationTokens({
+    planBody: planComment.body,
+    profiles: createEstimateProfiles(config),
+    implementerProfileName:
+      ((config.ai as { roles?: { implementer?: string } }).roles ??
+        DEFAULT_ESTIMATE_ROLES).implementer,
+    context: {
+      likelyFiles: context.files,
+      verificationCommands: createVerificationCommands(config),
+      scanBudget: context.scanBudget,
+    },
+  });
+
+  return {
+    ...estimate,
+    status: "estimated",
+    issueNumber,
+    planSource: {
+      type: "managed-comment",
+      url: planComment.url,
+      updatedAt: planComment.updatedAt,
+    },
+  };
+}
+
+export async function estimateIssueTool(
+  options: EstimateIssueToolOptions
+): Promise<IssueEstimateToolResult> {
+  const planComment = await options.forge.fetchIssuePlanComment(options.issueNumber);
+  if (!planComment) {
+    return createBlockedResult(options.issueNumber);
+  }
+
+  return createEstimateResult(
+    options.issueNumber,
+    planComment,
+    options.repositoryConfig,
+    options.repoRoot
+  );
+}
+
+function formatRange(range: { low: number; high: number }): string {
+  return `${range.low.toLocaleString()}-${range.high.toLocaleString()} tokens`;
+}
+
+export function renderIssueEstimate(result: IssueEstimateToolResult): string {
+  if (result.status === "blocked") {
+    return [
+      `Issue #${result.issueNumber} implementation estimate is blocked.`,
+      "",
+      result.message,
+    ].join("\n");
+  }
+
+  return [
+    `Implementation token estimate for issue #${result.issueNumber}`,
+    "",
+    `Plan source: ${result.planSource.url}`,
+    `Confidence: ${result.confidence}`,
+    "",
+    "Model/profile estimates:",
+    ...result.profiles.map(
+      (profile) =>
+        `- ${profile.name} (${profile.model}, ${profile.thinking} thinking): ${formatRange(
+          profile.range
+        )} [${profile.confidence}]`
+    ),
+    "",
+    "Recommendation:",
+    result.recommendation,
+    "",
+    "Drivers:",
+    ...result.drivers.map((driver) => `- ${driver}`),
+    ...(result.warnings.length > 0
+      ? ["", "Warnings:", ...result.warnings.map((warning) => `- ${warning}`)]
+      : []),
+    "",
+    `Scan budget: ${result.scanBudget.status} (${result.scanBudget.filesScanned}/${result.scanBudget.filesConsidered} files scanned, max ${result.scanBudget.maxFiles})`,
+  ].join("\n");
+}

--- a/packages/cli/src/prs-tool-command.test.ts
+++ b/packages/cli/src/prs-tool-command.test.ts
@@ -37,6 +37,14 @@ describe("prs tool command parser", () => {
     });
   });
 
+  it("parses issue estimate JSON command", () => {
+    expect(parsePrsToolCommandArgs(["issue", "estimate", "151", "--json"])).toEqual({
+      kind: "issue-estimate",
+      issueNumber: 151,
+      json: true,
+    });
+  });
+
   it("rejects removed --all issue readiness shorthand", () => {
     expect(() =>
       parsePrsToolCommandArgs(["issue", "ready", "151", "--all", "--json"])

--- a/packages/cli/src/prs-tool-command.test.ts
+++ b/packages/cli/src/prs-tool-command.test.ts
@@ -43,6 +43,9 @@ describe("prs tool command parser", () => {
       issueNumber: 151,
       json: true,
     });
+    expect(() =>
+      parsePrsToolCommandArgs(["issue", "estimate", "151"])
+    ).toThrow("Usage:");
   });
 
   it("rejects removed --all issue readiness shorthand", () => {

--- a/packages/cli/src/prs-tool-command.ts
+++ b/packages/cli/src/prs-tool-command.ts
@@ -1,6 +1,7 @@
 export type PrsToolCommand =
   | { kind: "issue-list"; actionable: boolean; json: boolean }
   | { kind: "issue-ready"; issueNumber: number; unattended: boolean; json: boolean }
+  | { kind: "issue-estimate"; issueNumber: number; json: boolean }
   | {
       kind: "issue-create";
       draftFilePath?: string;
@@ -37,6 +38,7 @@ export function renderPrsToolCommandHelp(): string {
     "Usage:",
     "  prs tool issue list [--actionable] --json",
     "  prs tool issue ready <issue-number> [--unattended|--auto|--jdi] --json",
+    "  prs tool issue estimate <issue-number> --json",
     "  prs tool issue create (--draft-file <path>|--issue-set <path>) --json",
     "                        [--run-dir <path>] [--plan-file <path>] [--media-manifest <path>]",
     "                        [--label <name>] [--labels <a,b>]",
@@ -117,6 +119,21 @@ export function parsePrsToolCommandArgs(args: string[]): PrsToolCommand {
       }
       if (isUnattendedAlias(fourth) && rest[0] === "--json" && rest.length === 1) {
         return { kind: "issue-ready", issueNumber, unattended: true, json: true };
+      }
+      if (fourth === "--all") {
+        throw new Error(`Unknown tool option "--all". ${renderPrsToolCommandHelp()}`);
+      }
+      throw new Error(renderPrsToolCommandHelp());
+    }
+
+    if (command === "estimate") {
+      if (!third || third === "--json" || third === "--all") {
+        throw new Error(renderPrsToolCommandHelp());
+      }
+
+      const issueNumber = parseToolNumber(third, "issue");
+      if (fourth === "--json" && rest.length === 0) {
+        return { kind: "issue-estimate", issueNumber, json: true };
       }
       if (fourth === "--all") {
         throw new Error(`Unknown tool option "--all". ${renderPrsToolCommandHelp()}`);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export * from "./diff-summary";
 export * from "./feature-backlog";
 export * from "./issue-draft";
 export * from "./issue-resolution-plan";
+export * from "./issue-token-estimate";
 export * from "./path-filter";
 export * from "./pr-assistant";
 export * from "./pr-assistant-body";

--- a/packages/core/src/issue-token-estimate.test.ts
+++ b/packages/core/src/issue-token-estimate.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  estimateIssueImplementationTokens,
+  extractIssueImplementationPlanFiles,
+} from "./issue-token-estimate";
+
+describe("issue implementation token estimates", () => {
+  it("extracts likely files from Superpowers plan comments", () => {
+    const plan = [
+      "<!-- prs:issue-plan -->",
+      "# Implementation Plan",
+      "",
+      "## Likely Files",
+      "",
+      "- `packages/cli/src/index.ts`",
+      "- ./packages/core/src/issue-token-estimate.ts",
+      "- Command parser changes",
+      "- `packages/cli/src/index.ts`",
+      "",
+      "## Steps",
+      "- Add the estimator.",
+    ].join("\n");
+
+    expect(extractIssueImplementationPlanFiles(plan)).toEqual([
+      "packages/cli/src/index.ts",
+      "packages/core/src/issue-token-estimate.ts",
+    ]);
+  });
+
+  it("estimates larger token ranges for mini implementer profiles and reports drivers", () => {
+    const estimate = estimateIssueImplementationTokens({
+      planBody: [
+        "# Implementation Plan",
+        "",
+        "## Likely Files",
+        "",
+        "- `packages/cli/src/commands/issue.ts`",
+        "- `packages/cli/src/index.ts`",
+        "- `packages/core/src/issue-token-estimate.ts`",
+        "- `README.md`",
+        "",
+        "## Steps",
+        "",
+        "1. Add parser support.",
+        "2. Add bounded repository scanning.",
+        "3. Add JSON output.",
+        "4. Update docs.",
+        "",
+        "## Risks",
+        "",
+        "- Command-surface changes and verification output can be noisy.",
+      ].join("\n"),
+      profiles: [
+        {
+          name: "premium",
+          role: "planner",
+          model: "gpt-5.5",
+          thinking: "high",
+        },
+        {
+          name: "standard",
+          role: "implementer",
+          model: "gpt-5.4-mini",
+          thinking: "medium",
+        },
+      ],
+      implementerProfileName: "standard",
+      context: {
+        likelyFiles: [
+          { path: "packages/cli/src/index.ts", exists: true, lineCount: 7600 },
+          {
+            path: "packages/core/src/issue-token-estimate.ts",
+            exists: false,
+            lineCount: 0,
+          },
+        ],
+        verificationCommands: [["pnpm", "build"]],
+      },
+    });
+
+    expect(estimate.status).toBe("estimated");
+    expect(estimate.profiles).toHaveLength(2);
+    expect(estimate.profiles[1].range.high).toBeGreaterThan(
+      estimate.profiles[0].range.high
+    );
+    expect(estimate.recommendation).toContain("standard");
+    expect(estimate.drivers.join("\n")).toContain("4 implementation steps");
+    expect(estimate.scanBudget.status).toBe("complete");
+  });
+});

--- a/packages/core/src/issue-token-estimate.test.ts
+++ b/packages/core/src/issue-token-estimate.test.ts
@@ -87,4 +87,84 @@ describe("issue implementation token estimates", () => {
     expect(estimate.drivers.join("\n")).toContain("4 implementation steps");
     expect(estimate.scanBudget.status).toBe("complete");
   });
+
+  it("marks plans without likely files or implementation steps as low confidence", () => {
+    const estimate = estimateIssueImplementationTokens({
+      planBody: [
+        "<!-- prs:issue-plan -->",
+        "# Implementation Plan",
+        "",
+        "## Summary",
+        "",
+        "Investigate whether this issue is actionable.",
+      ].join("\n"),
+      profiles: [
+        {
+          name: "standard",
+          model: "gpt-5.4-mini",
+          thinking: "medium",
+        },
+      ],
+    });
+
+    expect(estimate.confidence).toBe("low");
+    expect(estimate.profiles[0].confidence).toBe("low");
+    expect(estimate.drivers).toContain("No explicit implementation steps detected.");
+    expect(estimate.drivers).toContain("0 likely files detected.");
+    expect(estimate.warnings).toContain(
+      "Estimate confidence is low; refine or split the plan before relying on the range."
+    );
+  });
+
+  it("warns when likely files are missing or the repository scan budget is exhausted", () => {
+    const estimate = estimateIssueImplementationTokens({
+      planBody: [
+        "## Likely Files",
+        "",
+        "- `packages/cli/src/index.ts`",
+        "- `packages/cli/src/missing-a.ts`",
+        "- `packages/cli/src/missing-b.ts`",
+        "- `packages/cli/src/missing-c.ts`",
+        "- `packages/cli/src/missing-d.ts`",
+        "",
+        "## Steps",
+        "",
+        "1. Add bounded scanning.",
+      ].join("\n"),
+      profiles: [
+        {
+          name: "premium",
+          model: "gpt-5.5",
+          thinking: "high",
+        },
+      ],
+      context: {
+        likelyFiles: [
+          { path: "packages/cli/src/index.ts", exists: true, lineCount: 100 },
+          { path: "packages/cli/src/missing-a.ts", exists: false, lineCount: 0 },
+          { path: "packages/cli/src/missing-b.ts", exists: false, lineCount: 0 },
+          { path: "packages/cli/src/missing-c.ts", exists: false, lineCount: 0 },
+          { path: "packages/cli/src/missing-d.ts", exists: false, lineCount: 0 },
+        ],
+        scanBudget: {
+          filesConsidered: 20,
+          filesScanned: 1,
+          maxFiles: 12,
+          exhausted: true,
+        },
+      },
+    });
+
+    expect(estimate.confidence).toBe("low");
+    expect(estimate.scanBudget).toEqual({
+      status: "exhausted",
+      filesConsidered: 20,
+      filesScanned: 1,
+      maxFiles: 12,
+    });
+    expect(estimate.warnings).toContain("4 likely files were not found locally.");
+    expect(estimate.warnings).toContain(
+      "Repository context scan budget was exhausted; estimate confidence is reduced."
+    );
+  });
 });

--- a/packages/core/src/issue-token-estimate.ts
+++ b/packages/core/src/issue-token-estimate.ts
@@ -1,0 +1,309 @@
+export type IssueEstimateThinkingLevel =
+  | "none"
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh";
+
+export type IssueEstimateProfile = {
+  name: string;
+  role?: string;
+  model: string;
+  thinking: IssueEstimateThinkingLevel;
+};
+
+export type IssueEstimateFileContext = {
+  path: string;
+  exists: boolean;
+  lineCount: number;
+};
+
+export type IssueEstimateInput = {
+  planBody: string;
+  profiles: IssueEstimateProfile[];
+  implementerProfileName?: string;
+  context?: {
+    likelyFiles?: IssueEstimateFileContext[];
+    verificationCommands?: string[][];
+    scanBudget?: {
+      filesConsidered: number;
+      filesScanned: number;
+      maxFiles: number;
+      exhausted: boolean;
+    };
+  };
+};
+
+export type IssueTokenRange = {
+  low: number;
+  high: number;
+};
+
+export type IssueProfileTokenEstimate = IssueEstimateProfile & {
+  range: IssueTokenRange;
+  confidence: "high" | "medium" | "low";
+  notes: string[];
+};
+
+export type IssueImplementationTokenEstimate = {
+  status: "estimated";
+  profiles: IssueProfileTokenEstimate[];
+  drivers: string[];
+  warnings: string[];
+  recommendation: string;
+  confidence: "high" | "medium" | "low";
+  scanBudget: {
+    status: "complete" | "exhausted";
+    filesConsidered: number;
+    filesScanned: number;
+    maxFiles: number;
+  };
+};
+
+const MANAGED_MARKER_PATTERN = /^<!--\s*prs:issue-plan\s*-->\s*$/i;
+const RISK_TERMS = [
+  "auth",
+  "cache",
+  "command",
+  "concurrency",
+  "contract",
+  "generated",
+  "migration",
+  "network",
+  "runtime",
+  "schema",
+  "workflow",
+];
+
+function normalizePlanPath(value: string): string | undefined {
+  const trimmed = value
+    .trim()
+    .replace(/^`|`$/g, "")
+    .replace(/^\.\//, "");
+  if (!trimmed || trimmed.includes("\n")) {
+    return undefined;
+  }
+  if (!/[/\\]/.test(trimmed) && !/\.[a-z0-9]+$/i.test(trimmed)) {
+    return undefined;
+  }
+  return trimmed.replace(/\\/g, "/");
+}
+
+function stripManagedMarker(planBody: string): string {
+  return planBody
+    .split(/\r?\n/)
+    .filter((line) => !MANAGED_MARKER_PATTERN.test(line.trim()))
+    .join("\n")
+    .trim();
+}
+
+export function extractIssueImplementationPlanFiles(planBody: string): string[] {
+  const lines = stripManagedMarker(planBody).split(/\r?\n/);
+  const start = lines.findIndex((line) =>
+    /^#{2,3}\s+Likely files\s*$/i.test(line.trim())
+  );
+  if (start === -1) {
+    return [];
+  }
+
+  const files: string[] = [];
+  for (const line of lines.slice(start + 1)) {
+    if (/^#{2,3}\s+/.test(line.trim())) {
+      break;
+    }
+
+    const match = line.match(/^\s*[-*]\s+(.+?)\s*$/);
+    if (!match) {
+      continue;
+    }
+
+    const path = normalizePlanPath(match[1] ?? "");
+    if (path) {
+      files.push(path);
+    }
+  }
+
+  return [...new Set(files)];
+}
+
+function countImplementationSteps(planBody: string): number {
+  const lines = stripManagedMarker(planBody).split(/\r?\n/);
+  const numberedSteps = lines.filter((line) => /^\s*\d+\.\s+\S/.test(line)).length;
+  if (numberedSteps > 0) {
+    return numberedSteps;
+  }
+
+  const stepsStart = lines.findIndex((line) =>
+    /^#{2,3}\s+(Steps|Implementation steps|Plan)\s*$/i.test(line.trim())
+  );
+  if (stepsStart === -1) {
+    return 0;
+  }
+
+  return lines
+    .slice(stepsStart + 1)
+    .filter((line) => /^\s*[-*]\s+\S/.test(line)).length;
+}
+
+function countRiskTerms(planBody: string): number {
+  const normalized = planBody.toLowerCase();
+  return RISK_TERMS.filter((term) => normalized.includes(term)).length;
+}
+
+function roundToThousand(value: number): number {
+  return Math.max(1000, Math.round(value / 1000) * 1000);
+}
+
+function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function profileMultiplier(profile: IssueEstimateProfile): number {
+  const model = profile.model.toLowerCase();
+  let multiplier = 1;
+  if (model.includes("mini")) {
+    multiplier += 0.35;
+  }
+  if (model.includes("spark")) {
+    multiplier += 0.45;
+  }
+  if (profile.thinking === "none" || profile.thinking === "minimal") {
+    multiplier -= 0.08;
+  }
+  if (profile.thinking === "high" || profile.thinking === "xhigh") {
+    multiplier += 0.08;
+  }
+  return Math.max(0.8, multiplier);
+}
+
+function confidenceFor(input: {
+  likelyFiles: string[];
+  missingFiles: number;
+  stepCount: number;
+  riskTermCount: number;
+  scanExhausted: boolean;
+}): "high" | "medium" | "low" {
+  if (
+    input.scanExhausted ||
+    input.stepCount === 0 ||
+    input.likelyFiles.length === 0 ||
+    input.missingFiles > 3
+  ) {
+    return "low";
+  }
+  if (input.riskTermCount > 4 || input.missingFiles > 0) {
+    return "medium";
+  }
+  return "high";
+}
+
+export function estimateIssueImplementationTokens(
+  input: IssueEstimateInput
+): IssueImplementationTokenEstimate {
+  const planBody = stripManagedMarker(input.planBody);
+  const likelyFilesFromPlan = extractIssueImplementationPlanFiles(input.planBody);
+  const fileContext = input.context?.likelyFiles ?? [];
+  const likelyFiles =
+    fileContext.length > 0 ? fileContext.map((file) => file.path) : likelyFilesFromPlan;
+  const stepCount = countImplementationSteps(planBody);
+  const riskTermCount = countRiskTerms(planBody);
+  const missingFiles = fileContext.filter((file) => !file.exists).length;
+  const largeFiles = fileContext.filter((file) => file.lineCount > 1000).length;
+  const verificationCommandCount = input.context?.verificationCommands?.length ?? 0;
+  const scanBudget = input.context?.scanBudget ?? {
+    filesConsidered: likelyFiles.length,
+    filesScanned: fileContext.filter((file) => file.exists).length,
+    maxFiles: Math.max(likelyFiles.length, fileContext.length),
+    exhausted: false,
+  };
+  const confidence = confidenceFor({
+    likelyFiles,
+    missingFiles,
+    stepCount,
+    riskTermCount,
+    scanExhausted: scanBudget.exhausted,
+  });
+
+  const planTokens = Math.ceil(planBody.length / 4);
+  const baseTokens =
+    planTokens +
+    Math.max(stepCount, 1) * 2500 +
+    Math.max(likelyFiles.length, 1) * 900 +
+    largeFiles * 2500 +
+    missingFiles * 700 +
+    riskTermCount * 1200 +
+    Math.max(verificationCommandCount, 1) * 1800;
+
+  const profiles = input.profiles.map((profile) => {
+    const multiplier = profileMultiplier(profile);
+    const range = {
+      low: roundToThousand(baseTokens * multiplier * 0.75),
+      high: roundToThousand(baseTokens * multiplier * (confidence === "low" ? 1.75 : 1.35)),
+    };
+    const notes = [
+      profile.name === input.implementerProfileName
+        ? "Configured implementer profile."
+        : "Comparison profile.",
+      profile.model.toLowerCase().includes("mini")
+        ? "Mini-class models may spend more turns on implementation/debug loops."
+        : "Premium-class model estimate assumes fewer implementation/debug loops.",
+    ];
+
+    return {
+      ...profile,
+      range,
+      confidence,
+      notes,
+    };
+  });
+
+  const implementerProfile = profiles.find(
+    (profile) => profile.name === input.implementerProfileName
+  );
+  const recommendation = implementerProfile
+    ? `Start with ${implementerProfile.name} (${implementerProfile.model}) unless the estimate drivers point to high-risk runtime, workflow, or command-surface work.`
+    : "Use the configured implementer profile unless the estimate drivers point to high-risk runtime, workflow, or command-surface work.";
+
+  const drivers = [
+    `${stepCount || "No explicit"} implementation steps detected.`,
+    `${likelyFiles.length} likely files detected.`,
+    `${verificationCommandCount || 1} verification command group${
+      (verificationCommandCount || 1) === 1 ? "" : "s"
+    } considered.`,
+    ...(largeFiles > 0 ? [`${pluralize(largeFiles, "large likely file")}.`] : []),
+    ...(riskTermCount > 0
+      ? [`${pluralize(riskTermCount, "risk signal")} in the plan.`]
+      : []),
+  ];
+  const warnings = [
+    ...(missingFiles > 0
+      ? [
+          `${pluralize(missingFiles, "likely file")} ${
+            missingFiles === 1 ? "was" : "were"
+          } not found locally.`,
+        ]
+      : []),
+    ...(scanBudget.exhausted
+      ? ["Repository context scan budget was exhausted; estimate confidence is reduced."]
+      : []),
+    ...(confidence === "low"
+      ? ["Estimate confidence is low; refine or split the plan before relying on the range."]
+      : []),
+  ];
+
+  return {
+    status: "estimated",
+    profiles,
+    drivers,
+    warnings,
+    recommendation,
+    confidence,
+    scanBudget: {
+      status: scanBudget.exhausted ? "exhausted" : "complete",
+      filesConsidered: scanBudget.filesConsidered,
+      filesScanned: scanBudget.filesScanned,
+      maxFiles: scanBudget.maxFiles,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Add `prs issue estimate <number>` for human-readable implementation token estimates from managed issue plans.
- Add `prs tool issue estimate <issue-number> --json` for Codex skills and automation.
- Estimate from bounded plan context: likely files, configured verification commands, configured/fallback AI profiles, confidence, drivers, warnings, and recommendation.
- Update README and CLI docs for the new command surface.

Closes #267

## Verification

- `pnpm build`
- `pnpm lint`
- `pnpm exec vitest run --coverage --testTimeout=60000` (`76` files, `552` tests)
- `node packages/cli/dist/index.js issue estimate 267`
- `node packages/cli/dist/index.js tool issue estimate 267 --json`

Note: local `pnpm test` uses Vitest's default 20s per-test timeout and repeatedly hit timing failures in pre-existing long issue workflow integration tests on this machine. The same covered suite passed with `--testTimeout=60000`, and the failing default-timeout cases reached their expected mocked workflow summaries.

<!-- prs:pr-assistant:start -->
## PR Assistant

### Summary
This pull request introduces a new command to estimate implementation token usage for issues based on their managed plans. The command `prs issue estimate <number>` provides a human-readable estimate, while `prs tool issue estimate <issue-number> --json` offers a structured JSON output for automation. The estimation considers likely files, verification commands, AI profiles, and various confidence metrics.

### Impact Profile
Risk level: none

#### Affected areas
- CLI command surface
- Issue estimation functionality
- Documentation updates

### Files changed
- README.md
- actions/pr-assistant/dist/index.js
- actions/pr-review/dist/index.js
- actions/test-suggestions/dist/index.js
- docs/cli-reference.md
- docs/codex-prs-workflows.md
- packages/cli/src/cli-command-surface.test.ts
- packages/cli/src/commands/issue.ts
- packages/cli/src/index.ts
- packages/cli/src/issue-estimate-tool.test.ts
- packages/cli/src/issue-estimate-tool.ts
- packages/cli/src/prs-tool-command.test.ts
- packages/cli/src/prs-tool-command.ts
- packages/core/src/index.ts
- packages/core/src/issue-token-estimate.test.ts
- packages/core/src/issue-token-estimate.ts

### Testing notes
- Tests cover edge cases for issue estimation, including scenarios with missing files and exhausted scan budgets.
- Local testing confirmed that the estimation command functions as expected without modifying any files or posting to GitHub.

### Reviewer checklist
- Verify that the new commands are correctly documented in the README and CLI reference.
- Check that the implementation correctly estimates tokens based on the provided issue plans.
- Ensure that tests cover various scenarios, including edge cases for missing files and confidence levels.
<!-- prs:pr-assistant:end -->